### PR TITLE
feat: show group total when BOM group is collapsed

### DIFF
--- a/frontend/src/components/configurator/BomPanel.tsx
+++ b/frontend/src/components/configurator/BomPanel.tsx
@@ -238,6 +238,18 @@ export function BomPanel({ floorplanId, placementsVersion = 0, className = '' }:
                 </div>
               </div>
               
+              {/* Collapsed Summary - Show only when collapsed and has children */}
+              {hasChildren && !isExpanded && (
+                <div className="mt-2 flex items-center justify-between">
+                  <span className="text-xs text-gray-500 ml-6">
+                    + {group.children.length} Add-On{group.children.length !== 1 ? 's' : ''}
+                  </span>
+                  <span className="text-sm font-semibold text-gray-700">
+                    = ${group.totalPrice.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                  </span>
+                </div>
+              )}
+              
               {/* Children (Addons) */}
               {isExpanded && hasChildren && (
                 <div className="mt-3 pl-6 border-l-2 border-gray-200 space-y-3">


### PR DESCRIPTION
## Summary

Adds a summary line when BOM groups are collapsed to show the complete group total including add-ons.

## Changes

When a group has add-ons but is collapsed, the summary now shows:
- + N Add-Ons (with proper pluralization)
- = $X,XXX.XX (complete group total including main item + add-ons)

## Example

**Before (collapsed):**
- Only showed main item price (e.g., $7.00)
- User couldn't see total cost or number of add-ons

**After (collapsed):**
- Shows: + 2 Add-Ons = $10.00
- User can immediately see complete cost

## Testing

- [ ] Open BOM panel with items that have add-ons
- [ ] Verify collapsed groups show summary line
- [ ] Verify pluralization works (1 Add-On vs 2 Add-Ons)
- [ ] Verify total matches expanded group total