### PR TITLE
fix(floorplan): improve edit UX and fix image caching

### DIFF
--- a/frontend/src/components/configurator/ConfiguratorCanvas.tsx
+++ b/frontend/src/components/configurator/ConfiguratorCanvas.tsx
@@ -1,7 +1,7 @@
 import { useRef, useCallback, useState, useEffect } from 'react';
 import { useDroppable, useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
-import { Pencil, X } from 'lucide-react';
+import { Pencil, X, Loader2 } from 'lucide-react';
 import type { Floorplan } from '@/services/floorplan';
 import type { Placement } from '@/services/placement';
 import type { Item } from '@/services/item';
@@ -19,7 +19,6 @@ import { itemService, type ItemVariant } from '@/services/item';
 import { variantAddonService } from '@/services/variant-addon';
 import { bomService } from '@/services/bom';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Loader2 } from 'lucide-react';
 
 // CSS keyframes for fade-in animation (50ms for snappy feel)
 const fadeInKeyframes = `
@@ -562,9 +561,17 @@ export function ConfiguratorCanvas({
   const imageRef = useRef<HTMLImageElement>(null);
   const [selectedPlacementId, setSelectedPlacementId] = useState<number | null>(null);
   const [editingPlacement, setEditingPlacement] = useState<Placement | null>(null);
+  const [imageCacheBuster, setImageCacheBuster] = useState(Date.now());
+  const [isImageLoading, setIsImageLoading] = useState(true);
   const { setNodeRef, isOver } = useDroppable({
     id: `canvas-${floorplan.id}`,
   });
+
+  // Update cache buster when floorplan changes to force image reload
+  useEffect(() => {
+    setImageCacheBuster(Date.now());
+    setIsImageLoading(true);
+  }, [floorplan.id, floorplan.image_path]);
   
   // Track new placements for fade-in animation
   const newPlacementIdsRef = useRef<Set<number>>(new Set());
@@ -613,6 +620,8 @@ export function ConfiguratorCanvas({
         width: naturalWidth * fittedScale,
         height: naturalHeight * fittedScale,
       });
+      
+      setIsImageLoading(false);
     }
   }, []);
 
@@ -648,11 +657,18 @@ export function ConfiguratorCanvas({
     onPlacementUpdate(placementId, { x, y, width, height });
   };
 
-  const imageUrl = `/uploads/${floorplan.image_path}`;
-  const imageWrapperStyle = {
-    width: `${imageDisplaySize.width}px`,
-    height: `${imageDisplaySize.height}px`,
-  };
+  const imageUrl = `/uploads/${floorplan.image_path}?v=${imageCacheBuster}`;
+  const imageWrapperStyle = imageDisplaySize.width > 0 && imageDisplaySize.height > 0
+    ? {
+        width: `${imageDisplaySize.width}px`,
+        height: `${imageDisplaySize.height}px`,
+      }
+    : {
+        width: 'auto',
+        height: 'auto',
+        maxWidth: '100%',
+        maxHeight: '100%',
+      };
 
   return (
     <>
@@ -674,13 +690,23 @@ export function ConfiguratorCanvas({
         {floorplan.image_path ? (
           <div className="flex h-full w-full items-center justify-center">
             <div className="relative" style={imageWrapperStyle}>
+              {isImageLoading && (
+                <div className="absolute inset-0 flex items-center justify-center bg-background/50 z-10">
+                  <Loader2 className="h-8 w-8 animate-spin text-primary" />
+                </div>
+              )}
               <img
+                key={`floorplan-${floorplan.id}-${imageCacheBuster}`}
                 ref={imageRef}
                 src={imageUrl}
                 alt={floorplan.name}
                 data-floorplan-image="true"
                 className="block h-full w-full object-contain cursor-crosshair select-none"
                 onLoad={updateImageSize}
+                onError={() => {
+                  console.error('Failed to load floorplan image:', imageUrl);
+                  setIsImageLoading(false);
+                }}
                 draggable={false}
                 onDragStart={(e) => e.preventDefault()}
               />

--- a/frontend/src/components/floorplans/FloorplanFormModal.tsx
+++ b/frontend/src/components/floorplans/FloorplanFormModal.tsx
@@ -229,7 +229,7 @@ export function FloorplanFormModal({ floorplan, projectId, isOpen, onClose, onSu
                 onChange={handleFileChange}
               />
               
-              {previewUrl ? (
+                  {previewUrl ? (
                 <div className="relative">
                   <img
                     src={previewUrl}
@@ -237,18 +237,20 @@ export function FloorplanFormModal({ floorplan, projectId, isOpen, onClose, onSu
                     className="max-h-48 mx-auto rounded shadow"
                   />
                   <div className="mt-2 flex justify-center gap-2">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        clearFile();
-                      }}
-                    >
-                      <X className="mr-1 h-4 w-4" />
-                      Remove
-                    </Button>
+                    {!isEdit && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          clearFile();
+                        }}
+                      >
+                        <X className="mr-1 h-4 w-4" />
+                        Remove
+                      </Button>
+                    )}
                     <Button
                       type="button"
                       variant="outline"

--- a/frontend/src/pages/projects/ProjectDashboard.tsx
+++ b/frontend/src/pages/projects/ProjectDashboard.tsx
@@ -80,8 +80,16 @@ const ProjectDashboard = () => {
       setFloorplans(floorplansData);
       setItems(itemsResult.items);
       
-      if (floorplansData.length > 0 && !activeFloorplan) {
-        setActiveFloorplan(floorplansData[0]);
+      if (floorplansData.length > 0) {
+        if (!activeFloorplan) {
+          setActiveFloorplan(floorplansData[0]);
+        } else {
+          // Update active floorplan with fresh data from API
+          const updatedFloorplan = floorplansData.find(fp => fp.id === activeFloorplan.id);
+          if (updatedFloorplan) {
+            setActiveFloorplan(updatedFloorplan);
+          }
+        }
       }
 
       setError('');
@@ -593,6 +601,7 @@ const ProjectDashboard = () => {
                   <div className="flex-1 overflow-hidden">
                     <div className="h-full">
                       <ConfiguratorCanvas
+                        key={`canvas-${activeFloorplan.id}-${activeFloorplan.image_path}`}
                         floorplan={activeFloorplan}
                         placements={placements}
                         items={items}


### PR DESCRIPTION
## Summary
Fixes UX issues when editing floorplans in the Project Configurator.

## Changes Made

### 1. Remove Button in Edit Mode
- **Issue**: The "Remove" button appeared when editing an existing floorplan but served no useful purpose
- **Fix**: Now only shows in create mode when uploading a new floorplan

### 2. Floorplan Image Not Updating
- **Issue**: After editing a floorplan with a new image, the canvas showed the old image until F5 refresh
- **Fix**: 
  - `activeFloorplan` state now updates with fresh data from API after save
  - Added cache-busting query parameter to force browser reload
  - Added loading spinner during image load
  - Added error handler for failed image loads

### 3. Canvas Remount on Update
- Added unique `key` prop to force ConfiguratorCanvas remount when floorplan's `image_path` changes
- Prevents stale state and ensures fresh render

## Testing
- [x] Edit floorplan with new image - updates immediately
- [x] Switch between floorplan tabs - displays correctly
- [x] Remove button only shows in create mode
- [x] Old floorplan image deleted from server (backend already handles this)

Closes #18