### PR TITLE
Fix: Add cachebuster to DragOverlay images

### DIFF
--- a/frontend/src/pages/projects/ProjectDashboard.tsx
+++ b/frontend/src/pages/projects/ProjectDashboard.tsx
@@ -898,7 +898,7 @@ const ProjectDashboard = () => {
               >
                 {activeDragItem.preview_image ? (
                   <img
-                    src={`/uploads/${activeDragItem.preview_image}`}
+                    src={itemService.getImageUrl(activeDragItem.preview_image)}
                     alt={activeDragItem.name}
                     className="w-full h-full object-fill bg-muted"
                   />


### PR DESCRIPTION
Fixes image caching issue when dragging items from the palette.

**Problem:** The DragOverlay was using a hardcoded URL without the cachebuster parameter, causing stale images to display during drag operations.

**Solution:** Now uses itemService.getImageUrl() which includes the timestamp parameter when available, ensuring images are properly cache-busted after Excel syncs.

**Changed:**
- frontend/src/pages/projects/ProjectDashboard.tsx:901