### PR TITLE
Fix drag overlay zoom scaling

### DIFF
--- a/frontend/src/pages/projects/ProjectDashboard.tsx
+++ b/frontend/src/pages/projects/ProjectDashboard.tsx
@@ -880,11 +880,9 @@ const ProjectDashboard = () => {
             placementWidth = Math.max(5, Math.min(500, placementWidth));
             placementHeight = Math.max(5, Math.min(500, placementHeight));
             
-            // Calculate scale factors to match what will be shown on the floorplan
+            // Scale the overlay to match the visual size on canvas
+            // canvasScaleRef already includes zoom factor from ConfiguratorCanvas
             const { scaleX, scaleY } = canvasScaleRef.current;
-            const zoom = canvasZoomRef.current.zoom;
-            const scaleTransformX = scaleX * zoom;
-            const scaleTransformY = scaleY * zoom;
             
             return (
               <div 
@@ -892,8 +890,8 @@ const ProjectDashboard = () => {
                 style={{ 
                   width: `${placementWidth}px`, 
                   height: `${placementHeight}px`,
-                  transform: `scale(${scaleTransformX}, ${scaleTransformY})`,
-                  transformOrigin: 'center center'
+                  transform: `scale(${scaleX}, ${scaleY})`,
+                  transformOrigin: 'top left'
                 }}
               >
                 {activeDragItem.preview_image ? (


### PR DESCRIPTION
Fixes the drag overlay to correctly scale with zoom level.

## Changes
- Use canvasScaleRef which already includes zoom factor (no double zoom)
- Change transformOrigin from 'center center' to 'top left' for proper anchoring
- Dragged items now display at correct visual size regardless of zoom level