### PR TITLE
Fix: Exclude test files from TypeScript build

### DIFF
--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -29,5 +29,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/tests/**", "**/__tests__/**"]
 }


### PR DESCRIPTION
Added exclude pattern to tsconfig.app.json to prevent test files from being compiled during production builds.\n\nThis fixes the CI build failure caused by TypeScript errors in test files.