### PR TITLE
fix: only use active variant images for item preview

### DIFF
--- a/backend/src/repositories/item.ts
+++ b/backend/src/repositories/item.ts
@@ -73,7 +73,7 @@ export class ItemRepository {
         i.created_at, 
         i.is_active,
         (SELECT iv.image_path FROM item_variants iv 
-         WHERE iv.item_id = i.id
+         WHERE iv.item_id = i.id AND iv.is_active = true
          ORDER BY iv.sort_order ASC, iv.id ASC 
          LIMIT 1) as preview_image
       FROM items i


### PR DESCRIPTION
## Bug Description
When an item's first style/variant is deactivated, the backend was still returning that inactive variant's image as the `preview_image`. This caused inactive variant images to appear in:
- **Item Management** - Items table showed inactive variant images
- **Configurator** - Item palette and placement fallbacks used inactive variant images

## Root Cause
In `backend/src/repositories/item.ts`, the SQL subquery for `preview_image` didn't filter for active variants:

```sql
(SELECT iv.image_path FROM item_variants iv 
 WHERE iv.item_id = i.id  -- Missing: AND iv.is_active = true
 ORDER BY iv.sort_order ASC, iv.id ASC 
 LIMIT 1) as preview_image
```

## Fix
Added `AND iv.is_active = true` to the WHERE clause of the subquery.

## Testing
- All 161 backend tests pass
- Items with only inactive variants now show "No Image" placeholder
- Items with both active and inactive variants show the first *active* variant's image

## Files Changed
- `backend/src/repositories/item.ts`: 1 line changed