### PR TITLE
feat: Add floorplan export as PNG image

### DIFF
--- a/frontend/src/components/configurator/ConfiguratorCanvas.tsx
+++ b/frontend/src/components/configurator/ConfiguratorCanvas.tsx
@@ -1,7 +1,7 @@
 import { useRef, useCallback, useState, useEffect } from 'react';
 import { useDroppable, useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
-import { Pencil, X, Loader2, AlertCircle, ZoomIn, ZoomOut, RotateCcw, RotateCw, Save, Trash2 } from 'lucide-react';
+import { Pencil, X, Loader2, AlertCircle, ZoomIn, ZoomOut, RotateCcw, RotateCw, Save, Trash2, Download } from 'lucide-react';
 import type { Floorplan } from '@/services/floorplan';
 import type { Placement } from '@/services/placement';
 import type { Item } from '@/services/item';
@@ -18,6 +18,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { itemService, type ItemVariant } from '@/services/item';
 import { variantAddonService } from '@/services/variant-addon';
 import { bomService } from '@/services/bom';
+import { exportFloorplanImage } from '@/services/floorplan-export';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
 // CSS keyframes for fade-in animation (50ms for snappy feel)
@@ -1294,6 +1295,15 @@ export function ConfiguratorCanvas({
     setPan({ x: 0, y: 0 });
   };
 
+  const handleExportImage = async () => {
+    try {
+      await exportFloorplanImage(floorplan, placements, items);
+    } catch (err) {
+      console.error('Failed to export floorplan:', err);
+      // Could add toast notification here
+    }
+  };
+
   // Pan functions - only pan with Ctrl/Cmd + mouse movement
   const startPan = (e: React.MouseEvent) => {
     // Only pan when holding Ctrl or Cmd key
@@ -1516,6 +1526,16 @@ export function ConfiguratorCanvas({
             >
               <RotateCcw className="h-4 w-4" />
             </Button>
+            <div className="h-px bg-border my-1" />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={handleExportImage}
+              title="Export floorplan image"
+            >
+              <Download className="h-4 w-4" />
+            </Button>
           </div>
           <div className="bg-background/90 border rounded-lg shadow-lg px-2 py-1 text-center">
             <span className="text-xs font-medium">{Math.round(zoom * 100)}%</span>
@@ -1524,7 +1544,7 @@ export function ConfiguratorCanvas({
 
         {/* Help text */}
         <div className="absolute bottom-2 left-2 text-xs text-muted-foreground bg-background/75 px-2 py-1 rounded">
-          Click item to select • Drag corners to resize (Shift to stretch, Ctrl for 5px snap) • Drag ↻ to rotate (Ctrl for 15° snap) • Click 🗑 to delete • Click ✎ to edit • Ctrl+wheel to zoom • Ctrl+drag to pan • Ctrl+drag item to duplicate
+          Click item to select • Drag corners to resize (Shift to stretch, Ctrl for 5px snap) • Drag ↻ to rotate (Ctrl for 15° snap) • Click 🗑 to delete • Click ✎ to edit • Ctrl+wheel to zoom • Ctrl+drag to pan • Ctrl+drag item to duplicate • Click ⬇ to export image
         </div>
 
         <PlacementEditModal

--- a/frontend/src/services/__tests__/floorplan-export.test.ts
+++ b/frontend/src/services/__tests__/floorplan-export.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { exportFloorplanImage } from '../floorplan-export';
+import type { Floorplan } from '../floorplan';
+import type { Placement } from '../placement';
+import type { Item } from '../item';
+import { itemService } from '../item';
+
+// Mock the item service
+vi.mock('../item', () => ({
+  itemService: {
+    getImageUrl: vi.fn((path: string) => `/uploads/${path}`),
+  },
+}));
+
+describe('exportFloorplanImage', () => {
+  let mockCanvas: HTMLCanvasElement;
+  let mockCtx: CanvasRenderingContext2D;
+  let mockLink: HTMLAnchorElement;
+  let createdElements: HTMLElement[] = [];
+
+  beforeEach(() => {
+    // Mock canvas and context
+    mockCtx = {
+      drawImage: vi.fn(),
+      fillRect: vi.fn(),
+      strokeRect: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      translate: vi.fn(),
+      rotate: vi.fn(),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      quadraticCurveTo: vi.fn(),
+      closePath: vi.fn(),
+      stroke: vi.fn(),
+      fill: vi.fn(),
+    } as unknown as CanvasRenderingContext2D;
+
+    mockCanvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => mockCtx),
+      toDataURL: vi.fn(() => 'data:image/png;base64,test'),
+    } as unknown as HTMLCanvasElement;
+
+    // Mock Image constructor
+    global.Image = class MockImage {
+      crossOrigin: string = '';
+      src: string = '';
+      naturalWidth: number = 1000;
+      naturalHeight: number = 800;
+      
+      constructor() {
+        setTimeout(() => {
+          if (this.onload) this.onload();
+        }, 0);
+      }
+      
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+    } as unknown as typeof Image;
+
+    // Mock document.createElement
+    createdElements = [];
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'canvas') {
+        return mockCanvas;
+      }
+      if (tagName === 'a') {
+        mockLink = {
+          href: '',
+          download: '',
+          click: vi.fn(),
+        } as unknown as HTMLAnchorElement;
+        return mockLink;
+      }
+      const el = document.createElement(tagName);
+      createdElements.push(el);
+      return el;
+    });
+
+    // Mock document.body.appendChild and removeChild
+    vi.spyOn(document.body, 'appendChild').mockImplementation((child) => child);
+    vi.spyOn(document.body, 'removeChild').mockImplementation((child) => child);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockFloorplan: Floorplan = {
+    id: 1,
+    project_id: 1,
+    name: 'Test Floorplan',
+    image_path: 'floorplans/test.jpg',
+    sort_order: 0,
+  };
+
+  const mockPlacement: Placement = {
+    id: 1,
+    bom_id: 1,
+    floorplan_id: 1,
+    item_id: 1,
+    item_variant_id: 1,
+    item_variant_image_path: 'items/test.png',
+    x: 100,
+    y: 100,
+    width: 50,
+    height: 50,
+    rotation: 0,
+    created_at: '2024-01-01',
+  };
+
+  const mockItem: Item = {
+    id: 1,
+    name: 'Test Item',
+    category_id: 1,
+    category_name: 'Test Category',
+    is_active: true,
+    created_at: '2024-01-01',
+    variants: [
+      {
+        id: 1,
+        item_id: 1,
+        name: 'Default',
+        price: 100,
+        image_path: 'items/test.png',
+        is_active: true,
+        created_at: '2024-01-01',
+      },
+    ],
+  };
+
+  it('should create canvas with floorplan dimensions', async () => {
+    await exportFloorplanImage(mockFloorplan, [mockPlacement], [mockItem]);
+
+    expect(mockCanvas.width).toBe(1000);
+    expect(mockCanvas.height).toBe(800);
+  });
+
+  it('should draw floorplan image on canvas', async () => {
+    await exportFloorplanImage(mockFloorplan, [mockPlacement], [mockItem]);
+
+    expect(mockCtx.drawImage).toHaveBeenCalledWith(
+      expect.any(Object),
+      0,
+      0,
+      1000,
+      800
+    );
+  });
+
+  it('should draw placement with correct position and rotation', async () => {
+    const placementWithRotation: Placement = {
+      ...mockPlacement,
+      rotation: 45,
+    };
+
+    await exportFloorplanImage(mockFloorplan, [placementWithRotation], [mockItem]);
+
+    expect(mockCtx.save).toHaveBeenCalled();
+    expect(mockCtx.translate).toHaveBeenCalledWith(125, 125); // x + width/2, y + height/2
+    expect(mockCtx.rotate).toHaveBeenCalledWith((45 * Math.PI) / 180);
+    expect(mockCtx.restore).toHaveBeenCalled();
+  });
+
+  it('should draw placement border with rounded corners', async () => {
+    await exportFloorplanImage(mockFloorplan, [mockPlacement], [mockItem]);
+
+    expect(mockCtx.strokeStyle).toBe('#8C00AA');
+    expect(mockCtx.lineWidth).toBe(2);
+    expect(mockCtx.beginPath).toHaveBeenCalled();
+    expect(mockCtx.stroke).toHaveBeenCalled();
+  });
+
+  it('should use item preview image when no variant image exists', async () => {
+    const itemWithPreview: Item = {
+      ...mockItem,
+      preview_image: 'items/preview.png',
+      variants: [
+        {
+          ...mockItem.variants![0],
+          image_path: undefined as any,
+        },
+      ],
+    };
+
+    const placementWithoutImagePath: Placement = {
+      ...mockPlacement,
+      item_variant_image_path: undefined,
+    };
+
+    await exportFloorplanImage(mockFloorplan, [placementWithoutImagePath], [itemWithPreview]);
+
+    expect(itemService.getImageUrl).toHaveBeenCalledWith('items/preview.png');
+  });
+
+  it('should draw placeholder for placements without images', async () => {
+    const itemWithoutImages: Item = {
+      ...mockItem,
+      preview_image: undefined,
+      variants: [],
+    };
+
+    const placementWithoutImage: Placement = {
+      ...mockPlacement,
+      item_variant_image_path: undefined,
+    };
+
+    await exportFloorplanImage(mockFloorplan, [placementWithoutImage], [itemWithoutImages]);
+
+    expect(mockCtx.fillStyle).toBe('#f3f4f6');
+    expect(mockCtx.fill).toHaveBeenCalled();
+  });
+
+  it('should handle multiple placements', async () => {
+    const placements: Placement[] = [
+      mockPlacement,
+      {
+        ...mockPlacement,
+        id: 2,
+        x: 200,
+        y: 200,
+      },
+    ];
+
+    await exportFloorplanImage(mockFloorplan, placements, [mockItem]);
+
+    // Should draw both placements (2 floorplan draws + 2 placement draws)
+    const drawImageCalls = (mockCtx.drawImage as any).mock.calls;
+    expect(drawImageCalls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('should export as PNG and trigger download', async () => {
+    await exportFloorplanImage(mockFloorplan, [mockPlacement], [mockItem]);
+
+    expect(mockCanvas.toDataURL).toHaveBeenCalledWith('image/png', 0.92);
+    expect(mockLink.download).toBe('Test_Floorplan_floorplan.png');
+    expect(mockLink.href).toBe('data:image/png;base64,test');
+    expect(mockLink.click).toHaveBeenCalled();
+  });
+
+  it('should sanitize floorplan name in filename', async () => {
+    const floorplanWithSpecialChars: Floorplan = {
+      ...mockFloorplan,
+      name: 'Floor Plan @ Home!',
+    };
+
+    await exportFloorplanImage(floorplanWithSpecialChars, [mockPlacement], [mockItem]);
+
+    expect(mockLink.download).toBe('Floor_Plan___Home__floorplan.png');
+  });
+
+  it('should apply background color when specified', async () => {
+    await exportFloorplanImage(mockFloorplan, [mockPlacement], [mockItem], {
+      backgroundColor: '#ffffff',
+    });
+
+    expect(mockCtx.fillStyle).toBe('#ffffff');
+    expect(mockCtx.fillRect).toHaveBeenCalledWith(0, 0, 1000, 800);
+  });
+
+  it('should continue drawing other placements when one fails', async () => {
+    // Track which images are created and make the 3rd one fail (2nd placement)
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    
+    let imageIndex = 0;
+    global.Image = class MockImage {
+      crossOrigin: string = '';
+      src: string = '';
+      naturalWidth: number = 1000;
+      naturalHeight: number = 800;
+      
+      constructor() {
+        const currentIndex = ++imageIndex;
+        setTimeout(() => {
+          // Image loads: 1=floorplan, 2=placement1, 3=placement2 (should fail)
+          if (currentIndex === 3) {
+            if (this.onerror) this.onerror();
+          } else {
+            if (this.onload) this.onload();
+          }
+        }, 0);
+      }
+      
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+    } as unknown as typeof Image;
+
+    const failingPlacement: Placement = {
+      ...mockPlacement,
+      id: 2,
+      x: 200,
+      y: 200,
+      item_variant_image_path: 'invalid/image.png',
+    };
+
+    await exportFloorplanImage(mockFloorplan, [mockPlacement, failingPlacement], [mockItem]);
+
+    // Should have warned about the failing placement
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    const warningCall = consoleWarnSpy.mock.calls.find(call => 
+      typeof call[0] === 'string' && call[0].includes('Failed to draw placement')
+    );
+    expect(warningCall).toBeDefined();
+    expect(warningCall![0]).toContain('Failed to draw placement');
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should use custom quality when specified', async () => {
+    await exportFloorplanImage(mockFloorplan, [mockPlacement], [mockItem], {
+      quality: 1.0,
+    });
+
+    expect(mockCanvas.toDataURL).toHaveBeenCalledWith('image/png', 1.0);
+  });
+});

--- a/frontend/src/services/floorplan-export.ts
+++ b/frontend/src/services/floorplan-export.ts
@@ -1,0 +1,169 @@
+import type { Floorplan } from './floorplan';
+import type { Placement } from './placement';
+import type { Item } from './item';
+import { itemService } from './item';
+
+interface ExportOptions {
+  quality?: number;
+  backgroundColor?: string;
+}
+
+export async function exportFloorplanImage(
+  floorplan: Floorplan,
+  placements: Placement[],
+  items: Item[],
+  options: ExportOptions = {}
+): Promise<void> {
+  const { quality = 0.92, backgroundColor } = options;
+
+  const floorplanImage = await loadImage(`/uploads/${floorplan.image_path}`);
+  const canvasWidth = floorplanImage.naturalWidth;
+  const canvasHeight = floorplanImage.naturalHeight;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = canvasWidth;
+  canvas.height = canvasHeight;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Failed to get canvas context');
+  }
+
+  if (backgroundColor) {
+    ctx.fillStyle = backgroundColor;
+    ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+  }
+
+  ctx.drawImage(floorplanImage, 0, 0, canvasWidth, canvasHeight);
+
+  for (const placement of placements) {
+    try {
+      await drawPlacement(ctx, placement, items);
+    } catch (err) {
+      console.warn(`Failed to draw placement ${placement.id}:`, err);
+    }
+  }
+
+  const dataUrl = canvas.toDataURL('image/png', quality);
+
+  const link = document.createElement('a');
+  link.download = `${floorplan.name.replace(/[^a-zA-Z0-9-_]/g, '_')}_floorplan.png`;
+  link.href = dataUrl;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+async function drawPlacement(
+  ctx: CanvasRenderingContext2D,
+  placement: Placement,
+  items: Item[]
+): Promise<void> {
+  const item = items.find((i) => i.id === placement.item_id);
+  const variant = item?.variants?.find((v) => v.id === placement.item_variant_id);
+
+  let imagePath: string | null = null;
+  if (placement.item_variant_image_path) {
+    imagePath = placement.item_variant_image_path;
+  } else if (variant?.image_path) {
+    imagePath = variant.image_path;
+  } else if (item?.preview_image) {
+    imagePath = item.preview_image;
+  }
+
+  if (!imagePath) {
+    drawPlaceholder(ctx, placement);
+    return;
+  }
+
+  const imageUrl = itemService.getImageUrl(imagePath);
+  const image = await loadImage(imageUrl);
+
+  const centerX = placement.x + placement.width / 2;
+  const centerY = placement.y + placement.height / 2;
+
+  ctx.save();
+  ctx.translate(centerX, centerY);
+  ctx.rotate((placement.rotation * Math.PI) / 180);
+
+  ctx.drawImage(
+    image,
+    -placement.width / 2,
+    -placement.height / 2,
+    placement.width,
+    placement.height
+  );
+
+  // Draw border with rounded corners (matching UI: border-2 border-primary rounded)
+  ctx.strokeStyle = '#8C00AA'; // Primary purple color
+  ctx.lineWidth = 2;
+  const x = -placement.width / 2;
+  const y = -placement.height / 2;
+  const w = placement.width;
+  const h = placement.height;
+  const r = 4; // border-radius: 4px (matching rounded class)
+  
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+  ctx.stroke();
+
+  ctx.restore();
+}
+
+function drawPlaceholder(
+  ctx: CanvasRenderingContext2D,
+  placement: Placement
+): void {
+  const centerX = placement.x + placement.width / 2;
+  const centerY = placement.y + placement.height / 2;
+
+  ctx.save();
+  ctx.translate(centerX, centerY);
+  ctx.rotate((placement.rotation * Math.PI) / 180);
+
+  const x = -placement.width / 2;
+  const y = -placement.height / 2;
+  const w = placement.width;
+  const h = placement.height;
+  const r = 4; // border-radius: 4px
+
+  // Draw rounded rectangle fill
+  ctx.fillStyle = '#f3f4f6';
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+  ctx.fill();
+
+  // Draw rounded border
+  ctx.strokeStyle = '#9ca3af';
+  ctx.lineWidth = 2;
+  ctx.stroke();
+
+  ctx.restore();
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`Failed to load image: ${src}`));
+    img.src = src;
+  });
+}


### PR DESCRIPTION
## Summary

Add ability to export floorplans with all placements as a PNG image at the floorplan's natural (100%) resolution.

## Features

- Export button in zoom controls (bottom-right of canvas)
- Floorplan exported at natural dimensions (not zoomed view)
- All placements drawn with proper positions and rotation
- Purple rounded borders matching the UI (#8C00AA, 4px radius)
- Image fallback chain: placement image → variant image → item preview
- Placeholder rectangle for placements without images
- Graceful error handling for failed image loads

## Technical Changes

- **New file:** `frontend/src/services/floorplan-export.ts` - Canvas-based export service
- **Modified:** `frontend/src/components/configurator/ConfiguratorCanvas.tsx` - Added export button and handler
- **New tests:** `frontend/src/services/__tests__/floorplan-export.test.ts` - 12 comprehensive unit tests

## How to Test

1. Open a project with a floorplan and placements
2. Click the download button (⬇) in the zoom controls
3. Verify the exported PNG:
   - Matches floorplan's native resolution
   - Shows all placements with correct positions
   - Has purple rounded borders around placements
   - Filename: `{floorplan_name}_floorplan.png`

## Screenshots

N/A - Can provide if needed