### PR TITLE
Fix: Preserve item memory on placement delete and fix auth reload loop

### DIFF
--- a/frontend/src/components/invoice/__tests__/InvoiceSettingsModal.test.tsx
+++ b/frontend/src/components/invoice/__tests__/InvoiceSettingsModal.test.tsx
@@ -31,7 +31,7 @@ const mockInitialSettings: InvoiceSettings = {
 };
 
 describe('InvoiceSettingsModal', () => {
-  it('renders with initial settings', () => {
+  it('renders with initial settings', async () => {
     render(
       <InvoiceSettingsModal
         projectId={1}
@@ -43,7 +43,10 @@ describe('InvoiceSettingsModal', () => {
       />
     );
 
-    expect(screen.getByText('Configure Invoice')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Configure Invoice')).toBeInTheDocument();
+    }, { timeout: 10000 });
+    
     expect(screen.getAllByLabelText('Percentage (%)')[0]).toHaveValue(10);
     expect(screen.getAllByLabelText('Amount (USD)')[0]).toHaveValue(100);
   });

--- a/frontend/src/context/SyncContext.tsx
+++ b/frontend/src/context/SyncContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
 import { getLastSyncTimestamp } from '../services/settings';
 import { setGlobalSyncTimestamp } from '../services/item';
+import { authService } from '../services/auth';
 
 interface SyncContextType {
   lastSyncTimestamp: number;
@@ -22,9 +23,12 @@ export function SyncProvider({ children }: { children: ReactNode }) {
     }
   };
 
-  // Load timestamp on mount
+  // Load timestamp on mount (only if authenticated)
   useEffect(() => {
-    refreshTimestamp();
+    const token = authService.getAccessToken();
+    if (token) {
+      refreshTimestamp();
+    }
   }, []);
 
   return (

--- a/frontend/src/pages/projects/ProjectDashboard.tsx
+++ b/frontend/src/pages/projects/ProjectDashboard.tsx
@@ -386,15 +386,6 @@ const ProjectDashboard = () => {
   };
 
   const handlePlacementDelete = async (id: number) => {
-    // Find the placement being deleted to clear its memory
-    const placementToDelete = placements.find(p => p.id === id);
-    if (placementToDelete) {
-      itemSizeMemory.current.delete(placementToDelete.item_id);
-      itemVariantMemory.current.delete(placementToDelete.item_id);
-      persistSizeMemory();
-      persistVariantMemory();
-    }
-
     // Clean up placement-specific addon tracking
     placementAddons.current.delete(id);
 

--- a/frontend/tests/ItemFormModal.test.tsx
+++ b/frontend/tests/ItemFormModal.test.tsx
@@ -42,7 +42,7 @@ describe('ItemFormModal', () => {
     // Dialog renders in a portal, so check document.body
     await waitFor(() => {
       expect(document.body.textContent).toContain('Create Product');
-    });
+    }, { timeout: 10000 });
   });
 
   it('renders edit item modal with pre-filled data', async () => {

--- a/frontend/tests/ItemManagement.test.tsx
+++ b/frontend/tests/ItemManagement.test.tsx
@@ -105,7 +105,7 @@ describe('ItemManagement', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Product Management')).toBeInTheDocument();
-    });
+    }, { timeout: 10000 });
 
     expect(screen.getByText('Manage products and their details')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /add product/i })).toBeInTheDocument();
@@ -137,7 +137,7 @@ describe('ItemManagement', () => {
     // Wait for the page to load
     await waitFor(() => {
       expect(screen.getByText('Product Management')).toBeInTheDocument();
-    });
+    }, { timeout: 10000 });
 
     // Find and click the Add Product button
     const addButton = screen.getByRole('button', { name: /add product/i });
@@ -146,7 +146,7 @@ describe('ItemManagement', () => {
     // Modal should open - check for any modal content
     await waitFor(() => {
       expect(document.querySelector('[role="dialog"]')).toBeInTheDocument();
-    });
+    }, { timeout: 10000 });
   });
 
   it('shows empty state when no items', async () => {

--- a/frontend/tests/UserManagement.test.tsx
+++ b/frontend/tests/UserManagement.test.tsx
@@ -67,7 +67,7 @@ describe('UserManagement', () => {
 
     await waitFor(() => {
       expect(screen.getByText('User Management')).toBeInTheDocument();
-    });
+    }, { timeout: 10000 });
 
     expect(screen.getByText('Manage system users and permissions')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /add user/i })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

This PR fixes two bugs:

### Bug 1: Item memory cleared on placement delete
**Problem:** When deleting a placement, the item size and variant memory was being cleared, causing the next dragged item to lose the previous configuration.

**Fix:** Removed the code that cleared `itemSizeMemory` and `itemVariantMemory` in `handlePlacementDelete` in `ProjectDashboard.tsx`.

### Bug 2: Auth reload loop when tokens cleared
**Problem:** After manually clearing browser storage and tokens, refreshing the page caused an infinite reload loop in the auth dialog.

**Root cause:** `SyncContext` was making authenticated API calls unconditionally on mount, which 401'd and triggered a hard redirect.

**Fix:** Modified `SyncContext.tsx` to check for an access token before making API calls.

### Test fixes
Also fixed 5 flaky UI tests by increasing `waitFor` timeout from default 1000ms to 10000ms.

## Testing
- All backend tests pass
- All frontend tests pass (194 tests)