### PR TITLE
Fix project total calculation when floorplan is deleted (#46)

### DIFF
--- a/frontend/src/components/invoice/SummaryTab.tsx
+++ b/frontend/src/components/invoice/SummaryTab.tsx
@@ -1,34 +1,21 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { Settings, FileDown, Receipt, Loader2 } from 'lucide-react';
-import type { FloorplanBom } from '@/services/bom';
 import { generateInvoiceDOCX } from '@/services/invoice-docx';
 import type { InvoiceSettings } from '@/services/invoice-settings';
 import type { Floorplan } from '@/services/floorplan';
-
-interface FloorplanItem {
-  name: string;
-  quantity: number;
-  unitPrice: number;
-  total: number;
-}
+import type { FloorplanTotal } from '@/services/bom';
 
 interface SummaryTabProps {
   projectName: string;
   projectNumber: string;
   customerName: string;
   floorplans: Floorplan[];
-  floorplanBoms: Map<number, FloorplanBom>;
+  floorplanTotals: FloorplanTotal[];
+  projectTotal: number;
   invoiceSettings: InvoiceSettings | null;
   onConfigureInvoice: () => void;
-}
-
-interface FloorplanTotal {
-  floorplan: Floorplan;
-  total: number;
-  items: FloorplanItem[];
-  isLoading: boolean;
 }
 
 export function SummaryTab({
@@ -36,115 +23,12 @@ export function SummaryTab({
   projectNumber,
   customerName,
   floorplans,
-  floorplanBoms,
+  floorplanTotals,
+  projectTotal,
   invoiceSettings,
   onConfigureInvoice,
 }: SummaryTabProps) {
-  const [floorplanTotals, setFloorplanTotals] = useState<FloorplanTotal[]>([]);
-  const [projectTotal, setProjectTotal] = useState<number>(0);
-  const [isLoading, setIsLoading] = useState(true);
-  const lastBomVersionRef = useRef<string>('');
-
-  // Calculate totals from BOM data when it changes
-  useEffect(() => {
-    // If no floorplans, nothing to calculate - show empty state immediately
-    if (floorplans.length === 0) {
-      setFloorplanTotals([]);
-      setProjectTotal(0);
-      setIsLoading(false);
-      lastBomVersionRef.current = '';
-      return;
-    }
-
-    // Create a version string from all BOM data to detect changes
-    const bomVersion = floorplans
-      .map(fp => {
-        const bom = floorplanBoms.get(fp.id);
-        return bom ? `${fp.id}:${bom.totalPrice}` : `${fp.id}:null`;
-      })
-      .join('|');
-
-    // Skip if BOM data hasn't changed
-    if (bomVersion === lastBomVersionRef.current) return;
-    lastBomVersionRef.current = bomVersion;
-
-    setIsLoading(true);
-
-    // Calculate totals from BOM data
-    const totals: FloorplanTotal[] = floorplans.map((floorplan) => {
-      const bom = floorplanBoms.get(floorplan.id);
-
-      if (!bom) {
-        return {
-          floorplan,
-          total: 0,
-          items: [],
-          isLoading: false,
-        };
-      }
-
-      const items: FloorplanItem[] = [];
-      const itemTotals = new Map<string, { quantity: number; unitPrice: number; total: number }>();
-
-      bom.groups.forEach((group) => {
-        // Add main entry (aggregate if same item appears in multiple groups)
-        const mainName = `${group.mainEntry.item_name}${group.mainEntry.style_name ? ` (${group.mainEntry.style_name})` : ''}`;
-        const existingMain = itemTotals.get(mainName);
-        const mainTotal = group.mainEntry.unit_price * group.quantity;
-        if (existingMain) {
-          existingMain.quantity += group.quantity;
-          existingMain.total += mainTotal;
-        } else {
-          itemTotals.set(mainName, {
-            quantity: group.quantity,
-            unitPrice: group.mainEntry.unit_price,
-            total: mainTotal,
-          });
-        }
-
-        // Add children (add-ons) as separate line items (also aggregate)
-        group.children.forEach((child) => {
-          const childName = `${child.item_name}${child.style_name ? ` (${child.style_name})` : ''}`;
-          const existingChild = itemTotals.get(childName);
-          const childTotal = child.unit_price * group.quantity;
-          if (existingChild) {
-            existingChild.quantity += group.quantity;
-            existingChild.total += childTotal;
-          } else {
-            itemTotals.set(childName, {
-              quantity: group.quantity,
-              unitPrice: child.unit_price,
-              total: childTotal,
-            });
-          }
-        });
-      });
-
-      // Convert map to array
-      itemTotals.forEach((totals, name) => {
-        items.push({
-          name,
-          quantity: totals.quantity,
-          unitPrice: totals.unitPrice,
-          total: totals.total,
-        });
-      });
-
-      return {
-        floorplan,
-        total: bom.totalPrice,
-        items,
-        isLoading: false,
-      };
-    });
-
-    setFloorplanTotals(totals);
-
-    // Calculate project total
-    const total = totals.reduce((sum, item) => sum + item.total, 0);
-    setProjectTotal(total);
-    setIsLoading(false);
-  }, [floorplans, floorplanBoms]);
+  const [isGenerating, setIsGenerating] = useState(false);
 
   const formatCurrency = (amount: number, decimals = 2) => {
     return amount.toLocaleString('en-US', {
@@ -169,19 +53,23 @@ export function SummaryTab({
   );
 
   const handleGenerateInvoice = async () => {
-    await generateInvoiceDOCX({
-      projectName,
-      projectNumber,
-      customerName,
-      floorplanTotals: floorplanTotals.map(ft => ({
-        floorplan: ft.floorplan,
-        total: ft.total,
-        items: ft.items,
-      })),
-      projectTotal,
-      invoiceSettings,
-    });
+    setIsGenerating(true);
+    try {
+      await generateInvoiceDOCX({
+        projectName,
+        projectNumber,
+        customerName,
+        floorplanTotals,
+        projectTotal,
+        invoiceSettings,
+      });
+    } finally {
+      setIsGenerating(false);
+    }
   };
+
+  // Show loading if we have floorplans but no BOM data yet
+  const isLoading = floorplans.length > 0 && floorplanTotals.length === 0;
 
   if (isLoading) {
     return (
@@ -316,10 +204,14 @@ export function SummaryTab({
               variant="outline"
               size="sm"
               className="w-full"
-              disabled={!hasInvoiceSettings}
+              disabled={isGenerating}
               onClick={handleGenerateInvoice}
             >
-              <Receipt className="mr-2 h-4 w-4" />
+              {isGenerating ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Receipt className="mr-2 h-4 w-4" />
+              )}
               Create Invoice (DOCX)
             </Button>
           </>

--- a/frontend/src/components/invoice/__tests__/SummaryTab.test.tsx
+++ b/frontend/src/components/invoice/__tests__/SummaryTab.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { SummaryTab } from '../SummaryTab';
 import type { InvoiceSettings } from '@/services/invoice-settings';
 import type { Floorplan } from '@/services/floorplan';
-import type { FloorplanBom } from '@/services/bom';
+import type { FloorplanTotal } from '@/services/bom';
 
 // Mock services
 vi.mock('@/services/invoice-docx', () => ({
@@ -11,74 +11,36 @@ vi.mock('@/services/invoice-docx', () => ({
 }));
 
 const mockFloorplans: Floorplan[] = [
-  { id: 1, name: 'Basement', project_id: 1, created_at: '2024-01-01' },
-  { id: 2, name: 'Ground Floor', project_id: 1, created_at: '2024-01-01' },
+  { id: 1, name: 'Basement', project_id: 1, image_path: 'test.jpg', sort_order: 1 },
+  { id: 2, name: 'Ground Floor', project_id: 1, image_path: 'test.jpg', sort_order: 2 },
 ];
 
-const mockFloorplanBoms = new Map<number, FloorplanBom>([
-  [
-    1,
-    {
-      floorplanId: 1,
-      totalPrice: 500,
-      groups: [
-        {
-          mainEntry: {
-            id: 1,
-            project_id: 1,
-            floorplan_id: 1,
-            item_id: 1,
-            variant_id: 1,
-            parent_bom_id: null,
-            item_name: 'Test Item',
-            style_name: 'Black',
-            model_number: 'TEST-001',
-            unit_price: 100,
-            picture_path: null,
-            created_at: '2024-01-01',
-            updated_at: '2024-01-01',
-          },
-          children: [],
-          quantity: 5,
-          totalPrice: 500,
-          isAvailable: true,
-          bomEntryIds: [1],
-        },
-      ],
-    },
-  ],
-  [
-    2,
-    {
-      floorplanId: 2,
-      totalPrice: 500,
-      groups: [
-        {
-          mainEntry: {
-            id: 2,
-            project_id: 1,
-            floorplan_id: 2,
-            item_id: 2,
-            variant_id: 2,
-            parent_bom_id: null,
-            item_name: 'Another Item',
-            style_name: null,
-            model_number: 'TEST-002',
-            unit_price: 250,
-            picture_path: null,
-            created_at: '2024-01-01',
-            updated_at: '2024-01-01',
-          },
-          children: [],
-          quantity: 2,
-          totalPrice: 500,
-          isAvailable: true,
-          bomEntryIds: [2],
-        },
-      ],
-    },
-  ],
-]);
+const mockFloorplanTotals: FloorplanTotal[] = [
+  {
+    floorplan: mockFloorplans[0],
+    total: 500,
+    items: [
+      {
+        name: 'Test Item (Black)',
+        quantity: 5,
+        unitPrice: 100,
+        total: 500,
+      },
+    ],
+  },
+  {
+    floorplan: mockFloorplans[1],
+    total: 500,
+    items: [
+      {
+        name: 'Another Item',
+        quantity: 2,
+        unitPrice: 250,
+        total: 500,
+      },
+    ],
+  },
+];
 
 const mockInvoiceSettings: InvoiceSettings = {
   discount_percentage: 10,
@@ -90,20 +52,21 @@ const mockInvoiceSettings: InvoiceSettings = {
 };
 
 describe('SummaryTab', () => {
-  it('renders and shows content when BOM data is provided', async () => {
+  it('renders and shows content when totals are provided', async () => {
     render(
       <SummaryTab
         projectName="Test Project"
         projectNumber="PRJ-001"
         customerName="Test Customer"
         floorplans={mockFloorplans}
-        floorplanBoms={mockFloorplanBoms}
+        floorplanTotals={mockFloorplanTotals}
+        projectTotal={1000}
         invoiceSettings={null}
         onConfigureInvoice={vi.fn()}
       />
     );
 
-    // Should eventually show floorplan breakdown
+    // Should show floorplan breakdown
     await waitFor(() => {
       expect(screen.getByText('Floorplan Breakdown')).toBeInTheDocument();
     });
@@ -116,7 +79,8 @@ describe('SummaryTab', () => {
         projectNumber="PRJ-001"
         customerName="Test Customer"
         floorplans={[]} // No floorplans - should show empty state immediately
-        floorplanBoms={new Map()}
+        floorplanTotals={[]}
+        projectTotal={0}
         invoiceSettings={null}
         onConfigureInvoice={vi.fn()}
       />
@@ -126,22 +90,37 @@ describe('SummaryTab', () => {
     expect(screen.getByText('No floorplans yet. Create a floorplan to see breakdown.')).toBeInTheDocument();
   });
 
-  it('displays floorplan breakdown after loading', async () => {
+  it('shows loading when floorplans exist but totals are empty', () => {
     render(
       <SummaryTab
         projectName="Test Project"
         projectNumber="PRJ-001"
         customerName="Test Customer"
         floorplans={mockFloorplans}
-        floorplanBoms={mockFloorplanBoms}
+        floorplanTotals={[]} // Empty totals - should show loading
+        projectTotal={0}
         invoiceSettings={null}
         onConfigureInvoice={vi.fn()}
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Floorplan Breakdown')).toBeInTheDocument();
-    });
+    // Should show loading spinner
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+  });
+
+  it('displays floorplan breakdown', async () => {
+    render(
+      <SummaryTab
+        projectName="Test Project"
+        projectNumber="PRJ-001"
+        customerName="Test Customer"
+        floorplans={mockFloorplans}
+        floorplanTotals={mockFloorplanTotals}
+        projectTotal={1000}
+        invoiceSettings={null}
+        onConfigureInvoice={vi.fn()}
+      />
+    );
 
     expect(screen.getByText('Basement')).toBeInTheDocument();
     expect(screen.getByText('Ground Floor')).toBeInTheDocument();
@@ -155,7 +134,8 @@ describe('SummaryTab', () => {
         projectNumber="PRJ-001"
         customerName="Test Customer"
         floorplans={mockFloorplans}
-        floorplanBoms={mockFloorplanBoms}
+        floorplanTotals={mockFloorplanTotals}
+        projectTotal={1000}
         invoiceSettings={mockInvoiceSettings}
         onConfigureInvoice={vi.fn()}
       />
@@ -178,7 +158,8 @@ describe('SummaryTab', () => {
         projectNumber="PRJ-001"
         customerName="Test Customer"
         floorplans={mockFloorplans}
-        floorplanBoms={mockFloorplanBoms}
+        floorplanTotals={mockFloorplanTotals}
+        projectTotal={1000}
         invoiceSettings={null}
         onConfigureInvoice={vi.fn()}
       />
@@ -198,7 +179,8 @@ describe('SummaryTab', () => {
         projectNumber="PRJ-001"
         customerName="Test Customer"
         floorplans={mockFloorplans}
-        floorplanBoms={mockFloorplanBoms}
+        floorplanTotals={mockFloorplanTotals}
+        projectTotal={1000}
         invoiceSettings={null}
         onConfigureInvoice={mockOnConfigure}
       />
@@ -221,7 +203,8 @@ describe('SummaryTab', () => {
         projectNumber="PRJ-001"
         customerName="Test Customer"
         floorplans={mockFloorplans}
-        floorplanBoms={mockFloorplanBoms}
+        floorplanTotals={mockFloorplanTotals}
+        projectTotal={1000}
         invoiceSettings={mockInvoiceSettings}
         onConfigureInvoice={vi.fn()}
       />
@@ -233,24 +216,6 @@ describe('SummaryTab', () => {
     });
   });
 
-  it('shows empty state when no floorplans exist', async () => {
-    render(
-      <SummaryTab
-        projectName="Test Project"
-        projectNumber="PRJ-001"
-        customerName="Test Customer"
-        floorplans={[]}
-        floorplanBoms={new Map()}
-        invoiceSettings={null}
-        onConfigureInvoice={vi.fn()}
-      />
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText('No floorplans yet. Create a floorplan to see breakdown.')).toBeInTheDocument();
-    });
-  });
-
   it('formats currency correctly', async () => {
     render(
       <SummaryTab
@@ -258,7 +223,8 @@ describe('SummaryTab', () => {
         projectNumber="PRJ-001"
         customerName="Test Customer"
         floorplans={mockFloorplans}
-        floorplanBoms={mockFloorplanBoms}
+        floorplanTotals={mockFloorplanTotals}
+        projectTotal={1000}
         invoiceSettings={mockInvoiceSettings}
         onConfigureInvoice={vi.fn()}
       />
@@ -271,14 +237,15 @@ describe('SummaryTab', () => {
     });
   });
 
-  it('recalculates totals when floorplanBoms changes', async () => {
+  it('recalculates totals when floorplanTotals changes', async () => {
     const { rerender } = render(
       <SummaryTab
         projectName="Test Project"
         projectNumber="PRJ-001"
         customerName="Test Customer"
         floorplans={mockFloorplans}
-        floorplanBoms={mockFloorplanBoms}
+        floorplanTotals={mockFloorplanTotals}
+        projectTotal={1000}
         invoiceSettings={mockInvoiceSettings}
         onConfigureInvoice={vi.fn()}
       />
@@ -288,18 +255,20 @@ describe('SummaryTab', () => {
       expect(screen.getByText('Floorplan Breakdown')).toBeInTheDocument();
     });
 
-    // Rerender with updated BOM data
-    const updatedBoms = new Map(mockFloorplanBoms);
-    updatedBoms.set(1, {
-      ...mockFloorplanBoms.get(1)!,
-      totalPrice: 750,
-      groups: [
-        {
-          ...mockFloorplanBoms.get(1)!.groups[0],
-          totalPrice: 750,
-        },
-      ],
-    });
+    // Rerender with updated totals
+    const updatedTotals = [
+      {
+        ...mockFloorplanTotals[0],
+        total: 750,
+        items: [
+          {
+            ...mockFloorplanTotals[0].items[0],
+            total: 750,
+          },
+        ],
+      },
+      mockFloorplanTotals[1],
+    ];
 
     rerender(
       <SummaryTab
@@ -307,7 +276,8 @@ describe('SummaryTab', () => {
         projectNumber="PRJ-001"
         customerName="Test Customer"
         floorplans={mockFloorplans}
-        floorplanBoms={updatedBoms}
+        floorplanTotals={updatedTotals}
+        projectTotal={1250}
         invoiceSettings={mockInvoiceSettings}
         onConfigureInvoice={vi.fn()}
       />

--- a/frontend/src/pages/projects/ProjectDashboard.tsx
+++ b/frontend/src/pages/projects/ProjectDashboard.tsx
@@ -1,12 +1,13 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { projectService, type Project } from '@/services/project';
 import { floorplanService, type Floorplan, type CreateFloorplanDTO } from '@/services/floorplan';
 import { placementService, type Placement, type CreatePlacementDTO } from '@/services/placement';
 import { itemService, type Item } from '@/services/item';
 import { variantAddonService } from '@/services/variant-addon';
-import { bomService, type FloorplanBom } from '@/services/bom';
+import { bomService } from '@/services/bom';
 import type { InvoiceSettings } from '@/services/invoice-settings';
+import type { FloorplanBom, BomGroup } from '@/services/bom';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
@@ -65,10 +66,88 @@ const ProjectDashboard = () => {
   const [isDuplicating, setIsDuplicating] = useState(false);
   const [isCtrlDraggingItem, setIsCtrlDraggingItem] = useState(false);
   const [placementsVersion, setPlacementsVersion] = useState(0);
-  const [projectTotal, setProjectTotal] = useState<number>(0);
   const [isDropping, setIsDropping] = useState(false);
+  
+  // BOM state - Map of floorplanId to BOM data
   const [floorplanBoms, setFloorplanBoms] = useState<Map<number, FloorplanBom>>(new Map());
   
+  // Update BOM for a specific floorplan
+  const setFloorplanBom = useCallback((floorplanId: number, bom: FloorplanBom) => {
+    setFloorplanBoms((prev) => new Map(prev).set(floorplanId, bom));
+  }, []);
+
+  // Aggregate items from BOM groups, combining duplicate entries
+  const aggregateItems = useCallback((groups: BomGroup[]) => {
+    const itemTotals = new Map<string, { quantity: number; unitPrice: number; total: number }>();
+
+    groups.forEach((group) => {
+      // Aggregate main entries
+      const mainName = `${group.mainEntry.item_name}${group.mainEntry.style_name ? ` (${group.mainEntry.style_name})` : ''}`;
+      const mainTotal = group.mainEntry.unit_price * group.quantity;
+      const existingMain = itemTotals.get(mainName);
+
+      if (existingMain) {
+        existingMain.quantity += group.quantity;
+        existingMain.total += mainTotal;
+      } else {
+        itemTotals.set(mainName, {
+          quantity: group.quantity,
+          unitPrice: group.mainEntry.unit_price,
+          total: mainTotal,
+        });
+      }
+
+      // Aggregate addon entries
+      group.children.forEach((child) => {
+        const childName = `${child.item_name}${child.style_name ? ` (${child.style_name})` : ''}`;
+        const childTotal = child.unit_price * group.quantity;
+        const existingChild = itemTotals.get(childName);
+
+        if (existingChild) {
+          existingChild.quantity += group.quantity;
+          existingChild.total += childTotal;
+        } else {
+          itemTotals.set(childName, {
+            quantity: group.quantity,
+            unitPrice: child.unit_price,
+            total: childTotal,
+          });
+        }
+      });
+    });
+
+    return Array.from(itemTotals.entries()).map(([name, data]) => ({
+      name,
+      ...data,
+    }));
+  }, []);
+
+  // Calculate floorplan totals by iterating over floorplans array (not the Map)
+  const floorplanTotals = useMemo(() => {
+    return floorplans.map((floorplan) => {
+      const bom = floorplanBoms.get(floorplan.id);
+
+      if (!bom || bom.groups.length === 0) {
+        return {
+          floorplan,
+          total: 0,
+          items: [] as { name: string; quantity: number; unitPrice: number; total: number }[],
+        };
+      }
+
+      return {
+        floorplan,
+        total: bom.totalPrice,
+        items: aggregateItems(bom.groups),
+      };
+    });
+  }, [floorplans, floorplanBoms, aggregateItems]);
+
+  // Calculate project total - sum of floorplan totals
+  const projectTotal = useMemo(() => {
+    return floorplanTotals.reduce((sum, ft) => sum + ft.total, 0);
+  }, [floorplanTotals]);
+
   // Floorplan modal state
   const [showFloorplanModal, setShowFloorplanModal] = useState(false);
   const [floorplanToEdit, setFloorplanToEdit] = useState<Floorplan | null>(null);
@@ -228,7 +307,7 @@ const ProjectDashboard = () => {
   const fetchFloorplanBom = async (floorplanId: number, signal?: AbortSignal) => {
     try {
       const bomData = await bomService.getBomForFloorplan(floorplanId, signal);
-      setFloorplanBoms(prev => new Map(prev).set(floorplanId, bomData));
+      setFloorplanBom(floorplanId, bomData);
     } catch (err: any) {
       if (err.name !== 'AbortError') {
         console.error('Failed to load BOM:', err);
@@ -239,6 +318,9 @@ const ProjectDashboard = () => {
   // Fetch BOM for all floorplans when placements change (debounced)
   const bomFetchTimeoutRef = useRef<number | null>(null);
   useEffect(() => {
+    // Skip initial render - only run when placementsVersion changes from user actions
+    if (placementsVersion === 0) return;
+    
     // Clear any pending fetch
     if (bomFetchTimeoutRef.current) {
       clearTimeout(bomFetchTimeoutRef.current);
@@ -257,13 +339,25 @@ const ProjectDashboard = () => {
         clearTimeout(bomFetchTimeoutRef.current);
       }
     };
-  }, [placementsVersion, floorplans]);
+  }, [placementsVersion]);
+
+  // Initial BOM fetch when floorplans load (runs once)
+  const initialBomFetchRef = useRef(false);
+  useEffect(() => {
+    if (floorplans.length > 0 && !initialBomFetchRef.current) {
+      initialBomFetchRef.current = true;
+      const controller = new AbortController();
+      floorplans.forEach(fp => {
+        fetchFloorplanBom(fp.id, controller.signal);
+      });
+      return () => controller.abort();
+    }
+  }, [floorplans]);
 
   useEffect(() => {
     if (activeFloorplan) {
       const controller = new AbortController();
       fetchPlacements(activeFloorplan.id, controller.signal);
-      fetchFloorplanBom(activeFloorplan.id, controller.signal);
       return () => controller.abort();
     }
   }, [activeFloorplan?.id]);
@@ -273,15 +367,6 @@ const ProjectDashboard = () => {
     fetchProjectData(controller.signal);
     return () => controller.abort();
   }, [projectId]);
-
-  // Calculate project total from BOM data instead of fetching separately
-  useEffect(() => {
-    let total = 0;
-    floorplanBoms.forEach((bom) => {
-      total += bom.totalPrice;
-    });
-    setProjectTotal(total);
-  }, [floorplanBoms]);
 
   const handlePlacementCreate = async (placement: { x: number; y: number; width?: number; height?: number; item_id: number; item_variant_id: number; addon_ids?: number[]; ignoreDefaults?: boolean }) => {
     if (!activeFloorplan) return;
@@ -743,7 +828,12 @@ const ProjectDashboard = () => {
       setActiveFloorplan(null);
       setShowDeleteFloorplanModal(false);
       setFloorplanToDelete(null);
-      setPlacementsVersion(prev => prev + 1);
+      // Clear BOM data for deleted floorplan to prevent stale data
+      setFloorplanBoms(prev => {
+        const next = new Map(prev);
+        next.delete(floorplanToDelete.id);
+        return next;
+      });
       await fetchProjectData();
     } catch (err: any) {
       setError(err.response?.data?.error || 'Failed to delete floorplan');
@@ -1022,7 +1112,8 @@ const ProjectDashboard = () => {
                   projectNumber={generateProjectNumber(project)}
                   customerName={project?.customer_name || ''}
                   floorplans={floorplans}
-                  floorplanBoms={floorplanBoms}
+                  floorplanTotals={floorplanTotals}
+                  projectTotal={projectTotal}
                   invoiceSettings={invoiceSettings}
                   onConfigureInvoice={() => setShowInvoiceModal(true)}
                 />

--- a/frontend/src/services/bom.ts
+++ b/frontend/src/services/bom.ts
@@ -1,4 +1,5 @@
 import api from './api';
+import type { Floorplan } from './floorplan';
 
 export interface BomEntry {
   id: number;
@@ -32,6 +33,19 @@ export interface FloorplanBom {
   floorplanId: number;
   groups: BomGroup[];
   totalPrice: number;
+}
+
+export interface FloorplanItem {
+  name: string;
+  quantity: number;
+  unitPrice: number;
+  total: number;
+}
+
+export interface FloorplanTotal {
+  floorplan: Floorplan;
+  total: number;
+  items: FloorplanItem[];
 }
 
 export interface ChangeReport {
@@ -76,11 +90,6 @@ export const bomService = {
 
   async updateFromCatalog(floorplanId: number, signal?: AbortSignal): Promise<ChangeReport> {
     const response = await api.post(`/floorplans/${floorplanId}/bom/update-from-catalog`, {}, { signal });
-    return response.data.data;
-  },
-
-  async getProjectTotal(projectId: number, signal?: AbortSignal): Promise<{ totalPrice: number }> {
-    const response = await api.get(`/projects/${projectId}/total`, { signal });
     return response.data.data;
   },
 };


### PR DESCRIPTION
Fix project total calculation when floorplan is deleted

Centralize BOM calculations in ProjectDashboard to prevent stale data
from deleted floorplans contributing to project totals.

Changes:
- Calculate floorplanTotals and projectTotal by iterating over floorplans
  array instead of floorplanBoms Map entries
- Remove duplicate BOM fetches on initial load and active floorplan change
- Clean up BOM data for deleted floorplan immediately after deletion
- Update SummaryTab to receive calculated totals as props
- Remove unused getProjectTotal from bomService
- Update FloorplanTotal type to use proper Floorplan type
- Update tests to use new props interface

Fixes #46
