### PR TITLE
feat: multi-tenancy with tenant isolation and role system

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -18,6 +18,7 @@ import placementRoutes from './routes/placements.ts';
 import currencyRoutes from './routes/currency.ts';
 import settingsRoutes from './routes/settings.ts';
 import areaRoutes from './routes/areas.ts';
+import tenantRoutes from './routes/tenants.ts';
 
 const app: Hono = new Hono();
 
@@ -102,6 +103,9 @@ api.route('/settings', settingsRoutes);
 
 // Area routes at /api/areas/*
 api.route('/areas', areaRoutes);
+
+  // Tenant management routes at /api/tenants/*
+  api.route('/tenants', tenantRoutes);
 
 // Mount API router
 app.route('/api', api);

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -3,10 +3,11 @@ import { verifyToken } from '../services/jwt.ts';
 
 /**
  * Auth middleware - verifies JWT token from Authorization header
+ * Sets userId, userEmail, userRole, tenantId on Hono context
  */
 export async function authMiddleware(c: Context, next: Next): Promise<Response | void> {
   const authHeader = c.req.header('Authorization');
-  
+
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return c.json({ error: 'Unauthorized - No token provided' }, 401);
   }
@@ -15,16 +16,30 @@ export async function authMiddleware(c: Context, next: Next): Promise<Response |
 
   try {
     const payload = await verifyToken(token);
-    
-    // Add user info to context for use in routes
+
     c.set('userId', parseInt(payload.sub));
     c.set('userEmail', payload.email);
     c.set('userRole', payload.role);
-    
+    c.set('tenantId', payload.tenantId);
+
     await next();
   } catch (_error) {
     return c.json({ error: 'Unauthorized - Invalid token' }, 401);
   }
+}
+
+/**
+ * Tenant admin middleware - checks if user has tenant_admin or admin role
+ * Must be used after authMiddleware
+ */
+export async function tenantAdminMiddleware(c: Context, next: Next): Promise<Response | void> {
+  const userRole = c.get('userRole');
+
+  if (userRole !== 'tenant_admin' && userRole !== 'admin') {
+    return c.json({ error: 'Forbidden - Admin access required' }, 403);
+  }
+
+  await next();
 }
 
 /**
@@ -33,10 +48,10 @@ export async function authMiddleware(c: Context, next: Next): Promise<Response |
  */
 export async function adminMiddleware(c: Context, next: Next): Promise<Response | void> {
   const userRole = c.get('userRole');
-  
+
   if (userRole !== 'admin') {
     return c.json({ error: 'Forbidden - Admin access required' }, 403);
   }
-  
+
   await next();
 }

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -2,13 +2,38 @@
  * Database models and types
  */
 
+// === Roles ===
+export type UserRole = 'admin' | 'tenant_admin' | 'user';
+
+// === Tenants ===
+export interface Tenant {
+  id: number;
+  name: string;
+  is_distributor: number; // SQLite boolean: 0 or 1
+  is_active: number;      // SQLite boolean: 0 or 1
+  created_at: string;
+}
+
+export interface CreateTenantDTO {
+  name: string;
+  is_distributor?: number;
+}
+
+export interface UpdateTenantDTO {
+  name?: string;
+  is_active?: number;
+  is_distributor?: number;
+}
+
 // User
 export interface User {
   id: number;
   email: string;
   full_name: string | null;
   password_hash: string;
-  role: 'admin' | 'user';
+  role: UserRole;
+  tenant_id: number;
+  is_active: number;
   created_at: string;
 }
 
@@ -17,7 +42,8 @@ export interface CreateUserDTO {
   full_name?: string | undefined;
   password?: string;
   password_hash?: string;
-  role?: 'admin' | 'user';
+  role?: UserRole;
+  tenant_id: number;
 }
 
 export interface UpdateUserDTO {
@@ -25,7 +51,9 @@ export interface UpdateUserDTO {
   full_name?: string;
   password?: string;
   password_hash?: string;
-  role?: 'admin' | 'user';
+  role?: UserRole;
+  tenant_id?: number;
+  is_active?: number;
 }
 
 // Category
@@ -151,6 +179,7 @@ export interface Project {
   customer_email: string | null;
   customer_phone: string | null;
   customer_address: string | null;
+  tenant_id: number;
   created_at: string;
   // Invoice settings
   discount_percentage: number;
@@ -168,6 +197,7 @@ export interface CreateProjectDTO {
   customer_email?: string;
   customer_phone?: string;
   customer_address?: string;
+  tenant_id: number;
 }
 
 export interface UpdateProjectDTO {
@@ -177,6 +207,7 @@ export interface UpdateProjectDTO {
   customer_email?: string;
   customer_phone?: string;
   customer_address?: string;
+  tenant_id?: number;
 }
 
 export interface UpdateInvoiceSettingsDTO {

--- a/backend/src/repositories/project.ts
+++ b/backend/src/repositories/project.ts
@@ -1,82 +1,104 @@
 import { getDb } from '../config/database.ts';
 import type { Project, CreateProjectDTO, UpdateProjectDTO, UpdateInvoiceSettingsDTO } from '../models/index.ts';
+import type { TenantContext } from './user.ts';
+
+const PROJECT_COLUMNS = `id, name, status, customer_name, customer_email, customer_phone, customer_address, created_at,
+             discount_percentage, discount_usd, services_percentage, services_usd, local_currency_code,
+             exchange_rate, tenant_id`;
 
 /**
  * Project Repository
  * Handles all database operations for projects
  */
 export class ProjectRepository {
-  findAll(search?: string): Promise<Project[]> {
-    let sql = `
-      SELECT id, name, status, customer_name, customer_email, customer_phone, customer_address, created_at,
-             discount_percentage, discount_usd, services_percentage, services_usd, local_currency_code,
-             exchange_rate
-      FROM projects 
-    `;
+  findAll(search?: string, ctx?: TenantContext): Promise<Project[]> {
+    let sql = `SELECT ${PROJECT_COLUMNS} FROM projects`;
+    const conditions: string[] = [];
     const params: (string | number)[] = [];
-    
+
+    if (ctx && ctx.role !== 'admin') {
+      conditions.push('tenant_id = ?');
+      params.push(ctx.tenantId);
+    } else if (ctx && ctx.role === 'admin' && ctx.tenantId !== undefined) {
+      // Distributor filtering by specific tenant (via ?tenantId query param)
+      // Only apply if tenantId was explicitly set for filtering
+    }
+
     if (search) {
-      sql += ` WHERE name LIKE ? OR customer_name LIKE ?`;
+      conditions.push('(name LIKE ? OR customer_name LIKE ?)');
       const searchPattern = `%${search}%`;
       params.push(searchPattern, searchPattern);
     }
-    
+
+    if (conditions.length > 0) {
+      sql += ` WHERE ${conditions.join(' AND ')}`;
+    }
+
     sql += ` ORDER BY created_at DESC`;
-    
+
     const result = getDb().queryEntries(sql, params);
     return Promise.resolve(result as unknown as Project[]);
   }
 
-  findById(id: number): Promise<Project | null> {
-    const result = getDb().queryEntries(`
-      SELECT id, name, status, customer_name, customer_email, customer_phone, customer_address, created_at,
-             discount_percentage, discount_usd, services_percentage, services_usd, local_currency_code,
-             exchange_rate
-      FROM projects 
-      WHERE id = ?
-    `, [id]);
-    return Promise.resolve(result.length > 0 ? (result[0] as unknown as Project) : null);
+  findAllByTenant(tenantId: number, search?: string): Promise<Project[]> {
+    let sql = `SELECT ${PROJECT_COLUMNS} FROM projects WHERE tenant_id = ?`;
+    const params: (string | number)[] = [tenantId];
+
+    if (search) {
+      sql += ` AND (name LIKE ? OR customer_name LIKE ?)`;
+      const searchPattern = `%${search}%`;
+      params.push(searchPattern, searchPattern);
+    }
+
+    sql += ` ORDER BY created_at DESC`;
+    const result = getDb().queryEntries(sql, params);
+    return Promise.resolve(result as unknown as Project[]);
   }
 
-  findByNameAndCustomer(name: string, customerName: string, excludeId?: number): Promise<Project | null> {
-    let sql = `
-      SELECT id, name, status, customer_name, customer_email, customer_phone, customer_address, created_at,
-             discount_percentage, discount_usd, services_percentage, services_usd, local_currency_code,
-             exchange_rate
-      FROM projects 
-      WHERE name = ? AND customer_name = ?
-    `;
-    const params: (string | number)[] = [name, customerName];
-    
-    if (excludeId) {
-      sql += ' AND id != ?';
-      params.push(excludeId);
+  findById(id: number, ctx?: TenantContext): Promise<Project | null> {
+    let sql = `SELECT ${PROJECT_COLUMNS} FROM projects WHERE id = ?`;
+    const params: (string | number)[] = [id];
+
+    if (ctx && ctx.role !== 'admin') {
+      sql += ` AND tenant_id = ?`;
+      params.push(ctx.tenantId);
     }
-    
+
     const result = getDb().queryEntries(sql, params);
     return Promise.resolve(result.length > 0 ? (result[0] as unknown as Project) : null);
   }
 
-  create(data: CreateProjectDTO): Promise<Project> {
+  findByNameAndCustomer(name: string, customerName: string, tenantId: number, excludeId?: number): Promise<Project | null> {
+    let sql = `SELECT ${PROJECT_COLUMNS} FROM projects WHERE name = ? AND customer_name = ? AND tenant_id = ?`;
+    const params: (string | number)[] = [name, customerName, tenantId];
+
+    if (excludeId) {
+      sql += ' AND id != ?';
+      params.push(excludeId);
+    }
+
+    const result = getDb().queryEntries(sql, params);
+    return Promise.resolve(result.length > 0 ? (result[0] as unknown as Project) : null);
+  }
+
+  create(data: CreateProjectDTO & { tenant_id: number }): Promise<Project> {
     try {
       const result = getDb().queryEntries(`
-        INSERT INTO projects (name, status, customer_name, customer_email, customer_phone, customer_address) 
-        VALUES (?, ?, ?, ?, ?, ?)
-        RETURNING id, name, status, customer_name, customer_email, customer_phone, customer_address, created_at,
-                  discount_percentage, discount_usd, services_percentage, services_usd, local_currency_code,
-                  exchange_rate
+        INSERT INTO projects (name, status, customer_name, customer_email, customer_phone, customer_address, tenant_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        RETURNING ${PROJECT_COLUMNS}
       `, [
-        data.name, 
+        data.name,
         data.status || 'active',
         data.customer_name,
         data.customer_email || null,
         data.customer_phone || null,
-        data.customer_address || null
+        data.customer_address || null,
+        data.tenant_id
       ]);
-      
+
       return Promise.resolve(result[0] as unknown as Project);
     } catch (error: unknown) {
-      // Check for unique constraint violation
       const message = error instanceof Error ? error.message : 'Unknown error';
       if (message.includes('UNIQUE constraint failed') ||
           message.includes('idx_projects_unique_name_customer')) {
@@ -86,19 +108,17 @@ export class ProjectRepository {
     }
   }
 
-  async update(id: number, data: UpdateProjectDTO): Promise<Project | null> {
-    // Get current project to check for duplicates
-    const currentProject = await this.findById(id);
+  async update(id: number, data: UpdateProjectDTO, ctx?: TenantContext): Promise<Project | null> {
+    const currentProject = await this.findById(id, ctx);
     if (!currentProject) {
       return null;
     }
 
-    // Check for duplicate if name or customer_name is being changed
     const newName = data.name !== undefined ? data.name : currentProject.name;
     const newCustomerName = data.customer_name !== undefined ? data.customer_name : currentProject.customer_name;
-    
+
     if ((data.name !== undefined || data.customer_name !== undefined)) {
-      const existing = await this.findByNameAndCustomer(newName, newCustomerName, id);
+      const existing = await this.findByNameAndCustomer(newName, newCustomerName, currentProject.tenant_id, id);
       if (existing) {
         throw new Error(`A project with the name "${newName}" already exists for customer "${newCustomerName}"`);
       }
@@ -131,6 +151,10 @@ export class ProjectRepository {
       sets.push('customer_address = ?');
       values.push(data.customer_address);
     }
+    if (data.tenant_id !== undefined) {
+      sets.push('tenant_id = ?');
+      values.push(data.tenant_id);
+    }
 
     if (sets.length === 0) {
       return currentProject;
@@ -139,18 +163,15 @@ export class ProjectRepository {
     values.push(id);
 
     try {
-      const result = getDb().queryEntries(`
-        UPDATE projects 
-        SET ${sets.join(', ')} 
-        WHERE id = ?
-        RETURNING id, name, status, customer_name, customer_email, customer_phone, customer_address, created_at,
-                  discount_percentage, discount_usd, services_percentage, services_usd, local_currency_code,
-                  exchange_rate
-      `, values);
+      let sql = `UPDATE projects SET ${sets.join(', ')} WHERE id = ?`;
+      if (ctx && ctx.role !== 'admin') {
+        sql = `UPDATE projects SET ${sets.join(', ')} WHERE id = ? AND tenant_id = ${ctx.tenantId}`;
+      }
+      sql += ` RETURNING ${PROJECT_COLUMNS}`;
 
+      const result = getDb().queryEntries(sql, values);
       return result.length > 0 ? (result[0] as unknown as Project) : null;
     } catch (error: unknown) {
-      // Check for unique constraint violation
       const message = error instanceof Error ? error.message : 'Unknown error';
       if (message.includes('UNIQUE constraint failed') ||
           message.includes('idx_projects_unique_name_customer')) {
@@ -160,8 +181,12 @@ export class ProjectRepository {
     }
   }
 
-  delete(id: number): Promise<void> {
-    getDb().query(`DELETE FROM projects WHERE id = ?`, [id]);
+  delete(id: number, ctx?: TenantContext): Promise<void> {
+    if (ctx && ctx.role !== 'admin') {
+      getDb().query(`DELETE FROM projects WHERE id = ? AND tenant_id = ?`, [id, ctx.tenantId]);
+    } else {
+      getDb().query(`DELETE FROM projects WHERE id = ?`, [id]);
+    }
     return Promise.resolve();
   }
 
@@ -201,12 +226,10 @@ export class ProjectRepository {
     values.push(id);
 
     const result = getDb().queryEntries(`
-      UPDATE projects 
-      SET ${sets.join(', ')} 
+      UPDATE projects
+      SET ${sets.join(', ')}
       WHERE id = ?
-      RETURNING id, name, status, customer_name, customer_email, customer_phone, customer_address, created_at,
-                discount_percentage, discount_usd, services_percentage, services_usd, local_currency_code,
-                exchange_rate
+      RETURNING ${PROJECT_COLUMNS}
     `, values);
 
     return Promise.resolve(result.length > 0 ? (result[0] as unknown as Project) : null);

--- a/backend/src/repositories/tenant.ts
+++ b/backend/src/repositories/tenant.ts
@@ -1,0 +1,68 @@
+import { getDb } from '../config/database.ts';
+import type { Tenant, CreateTenantDTO, UpdateTenantDTO } from '../models/index.ts';
+
+export class TenantRepository {
+  findAll(): Promise<Tenant[]> {
+    const result = getDb().queryEntries('SELECT * FROM tenants ORDER BY name');
+    return Promise.resolve(result as unknown as Tenant[]);
+  }
+
+  findById(id: number): Promise<Tenant | null> {
+    const result = getDb().queryEntries('SELECT * FROM tenants WHERE id = ?', [id]);
+    return Promise.resolve(result.length > 0 ? (result[0] as unknown as Tenant) : null);
+  }
+
+  findByName(name: string): Promise<Tenant | null> {
+    const result = getDb().queryEntries('SELECT * FROM tenants WHERE name = ?', [name]);
+    return Promise.resolve(result.length > 0 ? (result[0] as unknown as Tenant) : null);
+  }
+
+  findDistributor(): Promise<Tenant | null> {
+    const result = getDb().queryEntries('SELECT * FROM tenants WHERE is_distributor = 1');
+    return Promise.resolve(result.length > 0 ? (result[0] as unknown as Tenant) : null);
+  }
+
+  create(data: CreateTenantDTO): Promise<Tenant> {
+    const result = getDb().queryEntries(
+      'INSERT INTO tenants (name, is_distributor) VALUES (?, ?) RETURNING *',
+      [data.name, data.is_distributor ?? 0]
+    );
+    return Promise.resolve(result[0] as unknown as Tenant);
+  }
+
+  update(id: number, data: UpdateTenantDTO): Promise<Tenant> {
+    const fields: string[] = [];
+    const values: (string | number | boolean)[] = [];
+
+    if (data.name !== undefined) {
+      fields.push('name = ?');
+      values.push(data.name);
+    }
+    if (data.is_active !== undefined) {
+      fields.push('is_active = ?');
+      values.push(data.is_active);
+    }
+    if (data.is_distributor !== undefined) {
+      fields.push('is_distributor = ?');
+      values.push(data.is_distributor);
+    }
+
+    if (fields.length > 0) {
+      values.push(id);
+      getDb().query(
+        `UPDATE tenants SET ${fields.join(', ')} WHERE id = ?`,
+        values
+      );
+    }
+
+    const result = getDb().queryEntries('SELECT * FROM tenants WHERE id = ?', [id]);
+    return Promise.resolve(result[0] as unknown as Tenant);
+  }
+
+  delete(id: number): Promise<void> {
+    getDb().query('DELETE FROM tenants WHERE id = ?', [id]);
+    return Promise.resolve();
+  }
+}
+
+export const tenantRepository = new TenantRepository();

--- a/backend/src/repositories/user.ts
+++ b/backend/src/repositories/user.ts
@@ -1,24 +1,42 @@
 import { getDb } from '../config/database.ts';
-import type { User, CreateUserDTO, UpdateUserDTO } from '../models/index.ts';
+import type { User, CreateUserDTO, UpdateUserDTO, UserRole } from '../models/index.ts';
+
+export interface TenantContext {
+  tenantId: number;
+  role: UserRole;
+}
 
 /**
  * User Repository
  * Handles all database operations for users
  */
 export class UserRepository {
-  findAll(): Promise<User[]> {
+  findAll(ctx?: TenantContext): Promise<User[]> {
+    let sql = `SELECT id, email, full_name, role, tenant_id, is_active, created_at FROM users`;
+    const params: (string | number)[] = [];
+
+    if (ctx && ctx.role !== 'admin') {
+      sql += ` WHERE tenant_id = ?`;
+      params.push(ctx.tenantId);
+    }
+
+    sql += ` ORDER BY created_at DESC`;
+    const result = getDb().queryEntries(sql, params);
+    return Promise.resolve(result as unknown as User[]);
+  }
+
+  findAllByTenant(tenantId: number): Promise<User[]> {
     const result = getDb().queryEntries(`
-      SELECT id, email, full_name, role, created_at 
-      FROM users 
-      ORDER BY created_at DESC
-    `);
+      SELECT id, email, full_name, role, tenant_id, is_active, created_at
+      FROM users WHERE tenant_id = ? ORDER BY created_at DESC
+    `, [tenantId]);
     return Promise.resolve(result as unknown as User[]);
   }
 
   findById(id: number): Promise<User | null> {
     const result = getDb().queryEntries(`
-      SELECT id, email, full_name, role, created_at 
-      FROM users 
+      SELECT id, email, full_name, role, tenant_id, is_active, created_at
+      FROM users
       WHERE id = ?
     `, [id]);
     return Promise.resolve(result.length > 0 ? (result[0] as unknown as User) : null);
@@ -37,17 +55,17 @@ export class UserRepository {
 
   create(data: CreateUserDTO & { password_hash: string }): Promise<User> {
     const result = getDb().queryEntries(`
-      INSERT INTO users (email, full_name, password_hash, role) 
-      VALUES (?, ?, ?, ?)
-      RETURNING id, email, full_name, role, created_at
-    `, [data.email, data.full_name || null, data.password_hash, data.role || 'user']);
-    
+      INSERT INTO users (email, full_name, password_hash, role, tenant_id)
+      VALUES (?, ?, ?, ?, ?)
+      RETURNING id, email, full_name, role, tenant_id, is_active, created_at
+    `, [data.email, data.full_name || null, data.password_hash, data.role || 'user', data.tenant_id]);
+
     return Promise.resolve(result[0] as unknown as User);
   }
 
   update(id: number, data: UpdateUserDTO): Promise<User | null> {
     const sets: string[] = [];
-    const values: (string | undefined | null)[] = [];
+    const values: (string | number | undefined | null)[] = [];
 
     if (data.email !== undefined) {
       sets.push('email = ?');
@@ -65,6 +83,14 @@ export class UserRepository {
       sets.push('role = ?');
       values.push(data.role);
     }
+    if (data.tenant_id !== undefined) {
+      sets.push('tenant_id = ?');
+      values.push(data.tenant_id);
+    }
+    if (data.is_active !== undefined) {
+      sets.push('is_active = ?');
+      values.push(data.is_active);
+    }
 
     if (sets.length === 0) {
       return this.findById(id);
@@ -73,10 +99,10 @@ export class UserRepository {
     values.push(id.toString());
 
     const result = getDb().queryEntries(`
-      UPDATE users 
-      SET ${sets.join(', ')} 
+      UPDATE users
+      SET ${sets.join(', ')}
       WHERE id = ?
-      RETURNING id, email, full_name, role, created_at
+      RETURNING id, email, full_name, role, tenant_id, is_active, created_at
     `, values);
 
     return Promise.resolve(result.length > 0 ? (result[0] as unknown as User) : null);

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -12,6 +12,9 @@ import {
 } from '../services/refresh-token.ts';
 import { authMiddleware } from '../middleware/auth.ts';
 import { loginRateLimit, refreshRateLimit } from '../middleware/rate-limit.ts';
+import { TenantRepository } from '../repositories/tenant.ts';
+
+const tenantRepo = new TenantRepository();
 
 const authRoutes = new Hono();
 
@@ -40,8 +43,19 @@ authRoutes.post('/login', loginRateLimit(), zValidator('json', loginSchema), asy
       return c.json({ error: 'Invalid email or password' }, 401);
     }
 
+    // Check user is active
+    if (!user.is_active) {
+      return c.json({ error: 'Account disabled - contact your administrator' }, 403);
+    }
+
+    // Check tenant is active
+    const tenant = await tenantRepo.findById(user.tenant_id);
+    if (!tenant || !tenant.is_active) {
+      return c.json({ error: 'Account disabled - contact your administrator' }, 403);
+    }
+
     // Generate access token (short-lived)
-    const accessToken = await generateToken(user.id, user.email, user.role);
+    const accessToken = await generateToken(user.id, user.email, user.role, user.tenant_id);
 
     // Generate refresh token (long-lived)
     const refreshToken = await createRefreshToken(user.id);
@@ -53,6 +67,8 @@ authRoutes.post('/login', loginRateLimit(), zValidator('json', loginSchema), asy
           email: user.email,
           full_name: user.full_name,
           role: user.role,
+          tenantId: user.tenant_id,
+          tenantName: tenant.name,
         },
         accessToken,
         refreshToken,
@@ -131,8 +147,19 @@ authRoutes.post('/refresh', refreshRateLimit(), zValidator('json', refreshSchema
       return c.json({ error: 'User not found' }, 404);
     }
 
+    // Check user is still active
+    if (!user.is_active) {
+      return c.json({ error: 'Account disabled - contact your administrator' }, 403);
+    }
+
+    // Check tenant is still active
+    const tenant = await tenantRepo.findById(user.tenant_id);
+    if (!tenant || !tenant.is_active) {
+      return c.json({ error: 'Account disabled - contact your administrator' }, 403);
+    }
+
     // Generate new access token
-    const newAccessToken = await generateToken(user.id, user.email, user.role);
+    const newAccessToken = await generateToken(user.id, user.email, user.role, user.tenant_id);
 
     // Generate new refresh token (rotation)
     const newRefreshToken = await createRefreshToken(user.id);
@@ -160,12 +187,17 @@ authRoutes.get('/me', authMiddleware, async (c) => {
       return c.json({ error: 'User not found' }, 404);
     }
 
+    const tenant = await tenantRepo.findById(user.tenant_id);
+
     return c.json({
       data: {
         id: user.id,
         email: user.email,
         full_name: user.full_name,
         role: user.role,
+        tenant_id: user.tenant_id,
+        tenantId: user.tenant_id,
+        tenantName: tenant?.name || 'Unknown',
         created_at: user.created_at,
       },
     });

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -8,6 +8,7 @@ import { bomService } from '../services/bom.ts';
 
 import { invoiceCalculationService } from '../services/invoice-calculation.ts';
 import type { CreateProjectDTO } from '../models/index.ts';
+import type { TenantContext } from '../repositories/user.ts';
 
 // Extend Hono context types
 declare module 'hono' {
@@ -15,7 +16,21 @@ declare module 'hono' {
     userId: number;
     userEmail: string;
     userRole: string;
+    tenantId: number;
   }
+}
+
+function getTenantCtx(c: { get: (key: string) => unknown; req: { query: (key: string) => string | undefined } }): TenantContext {
+  const role = c.get('userRole') as TenantContext['role'];
+  const tenantId = c.get('tenantId') as number;
+
+  // Admin can filter by specific tenant via query param
+  const queryTenantId = c.req.query('tenantId');
+  if (queryTenantId && role === 'admin') {
+    return { tenantId: parseInt(queryTenantId), role: 'tenant_admin' }; // Force filtering
+  }
+
+  return { tenantId, role };
 }
 
 const projectRoutes = new Hono();
@@ -38,6 +53,7 @@ const updateProjectSchema = z.object({
   customer_email: z.string().email().optional().or(z.literal('')),
   customer_phone: z.string().max(50).optional().or(z.literal('')),
   customer_address: z.string().max(500).optional().or(z.literal('')),
+  tenant_id: z.number().optional(),
 });
 
 // Validation schema for updating invoice settings
@@ -56,7 +72,8 @@ const updateInvoiceSettingsSchema = z.object({
 projectRoutes.get('/', authMiddleware, async (c) => {
   try {
     const search = c.req.query('search');
-    const projects = await projectRepository.findAll(search || undefined);
+    const ctx = getTenantCtx(c);
+    const projects = await projectRepository.findAll(search || undefined, ctx);
     return c.json({
       data: projects,
     });
@@ -74,11 +91,12 @@ projectRoutes.get('/:id/total', authMiddleware, async (c) => {
   }
 
   try {
-    const project = await projectRepository.findById(id);
+    const ctx = getTenantCtx(c);
+    const project = await projectRepository.findById(id, ctx);
     if (!project) {
       return c.json({ error: 'Project not found' }, 404);
     }
-    
+
     const total = await bomService.getProjectTotal(id);
     return c.json({ data: total });
   } catch (error) {
@@ -96,7 +114,8 @@ projectRoutes.get('/:id/invoice-calculation', authMiddleware, async (c) => {
 
   try {
     // Check if project exists
-    const project = await projectRepository.findById(id);
+    const ctx = getTenantCtx(c);
+    const project = await projectRepository.findById(id, ctx);
     if (!project) {
       return c.json({ error: 'Project not found' }, 404);
     }
@@ -131,11 +150,12 @@ projectRoutes.get('/:id', authMiddleware, async (c) => {
   }
 
   try {
-    const project = await projectRepository.findById(id);
+    const ctx = getTenantCtx(c);
+    const project = await projectRepository.findById(id, ctx);
     if (!project) {
       return c.json({ error: 'Project not found' }, 404);
     }
-    
+
     return c.json({
       data: project,
     });
@@ -151,16 +171,18 @@ projectRoutes.post('/', authMiddleware, zValidator('json', createProjectSchema),
 
   try {
     // Create project with customer info
-    const createData: CreateProjectDTO = { 
+    const tenantId = c.get('tenantId') as number;
+    const createData: CreateProjectDTO & { tenant_id: number } = {
       name,
       customer_name,
+      tenant_id: tenantId,
     };
-    
+
     if (status) createData.status = status;
     if (customer_email) createData.customer_email = customer_email;
     if (customer_phone) createData.customer_phone = customer_phone;
     if (customer_address) createData.customer_address = customer_address;
-    
+
     const project = await projectRepository.create(createData);
 
     return c.json({
@@ -188,7 +210,8 @@ projectRoutes.put('/:id/invoice-settings', authMiddleware, zValidator('json', up
 
   try {
     // Check if project exists
-    const project = await projectRepository.findById(id);
+    const ctx = getTenantCtx(c);
+    const project = await projectRepository.findById(id, ctx);
     if (!project) {
       return c.json({ error: 'Project not found' }, 404);
     }
@@ -211,32 +234,41 @@ projectRoutes.put('/:id', authMiddleware, zValidator('json', updateProjectSchema
   if (isNaN(id)) {
     return c.json({ error: 'Invalid ID' }, 400);
   }
-  const { name, status, customer_name, customer_email, customer_phone, customer_address } = c.req.valid('json');
+  const { name, status, customer_name, customer_email, customer_phone, customer_address, tenant_id } = c.req.valid('json');
+  const callerRole = c.get('userRole') as string;
 
   try {
     // Check if project exists
-    const existingProject = await projectRepository.findById(id);
+    const ctx = getTenantCtx(c);
+    const existingProject = await projectRepository.findById(id, ctx);
     if (!existingProject) {
       return c.json({ error: 'Project not found' }, 404);
     }
 
-    const updateData: { 
-      name?: string; 
+    // Users can only edit active projects
+    if (callerRole === 'user' && existingProject.status !== 'active') {
+      return c.json({ error: 'Only active projects can be edited' }, 403);
+    }
+
+    const updateData: {
+      name?: string;
       status?: 'active' | 'completed' | 'cancelled';
       customer_name?: string;
       customer_email?: string;
       customer_phone?: string;
       customer_address?: string;
+      tenant_id?: number;
     } = {};
-    
+
     if (name !== undefined) updateData.name = name;
     if (status !== undefined) updateData.status = status;
     if (customer_name !== undefined) updateData.customer_name = customer_name;
     if (customer_email !== undefined && customer_email !== '') updateData.customer_email = customer_email;
     if (customer_phone !== undefined && customer_phone !== '') updateData.customer_phone = customer_phone;
     if (customer_address !== undefined && customer_address !== '') updateData.customer_address = customer_address;
+    if (tenant_id !== undefined && callerRole === 'admin') updateData.tenant_id = tenant_id;
 
-    const project = await projectRepository.update(id, updateData);
+    const project = await projectRepository.update(id, updateData, ctx);
 
     return c.json({
       data: project,
@@ -253,15 +285,21 @@ projectRoutes.put('/:id', authMiddleware, zValidator('json', updateProjectSchema
   }
 });
 
-// DELETE /projects/:id - Delete project
+// DELETE /projects/:id - Delete project (admin/tenant_admin only)
 projectRoutes.delete('/:id', authMiddleware, async (c) => {
   const id = parseInt(c.req.param('id'));
   if (isNaN(id)) {
     return c.json({ error: 'Invalid ID' }, 400);
   }
 
+  const callerRole = c.get('userRole') as string;
+  if (callerRole === 'user') {
+    return c.json({ error: 'Forbidden - Users cannot delete projects' }, 403);
+  }
+
   try {
-    const project = await projectRepository.findById(id);
+    const ctx = getTenantCtx(c);
+    const project = await projectRepository.findById(id, ctx);
     if (!project) {
       return c.json({ error: 'Project not found' }, 404);
     }
@@ -269,12 +307,12 @@ projectRoutes.delete('/:id', authMiddleware, async (c) => {
     // Check if project has floorplans
     const floorplans = await floorplanRepository.findByProject(id);
     if (floorplans.length > 0) {
-      return c.json({ 
-        error: `Cannot delete project with ${floorplans.length} floorplan(s). Please delete all floorplans first.` 
+      return c.json({
+        error: `Cannot delete project with ${floorplans.length} floorplan(s). Please delete all floorplans first.`
       }, 400);
     }
 
-    await projectRepository.delete(id);
+    await projectRepository.delete(id, ctx);
     
     return c.json({
       message: 'Project deleted successfully',

--- a/backend/src/routes/tenants.ts
+++ b/backend/src/routes/tenants.ts
@@ -1,0 +1,101 @@
+import { Hono } from 'hono';
+import { authMiddleware, adminMiddleware } from '../middleware/auth.ts';
+import { TenantRepository } from '../repositories/tenant.ts';
+import { projectRepository } from '../repositories/project.ts';
+import { userRepository } from '../repositories/user.ts';
+
+const tenantRoutes = new Hono();
+const tenantRepo = new TenantRepository();
+
+// All tenant routes require admin role
+tenantRoutes.use('/*', authMiddleware, adminMiddleware);
+
+// GET /tenants - List all tenants
+tenantRoutes.get('/', async (c) => {
+  const tenants = await tenantRepo.findAll();
+  return c.json({ data: tenants });
+});
+
+// GET /tenants/:id - Get single tenant
+tenantRoutes.get('/:id', async (c) => {
+  const id = parseInt(c.req.param('id'));
+  const tenant = await tenantRepo.findById(id);
+
+  if (!tenant) {
+    return c.json({ error: 'Tenant not found' }, 404);
+  }
+
+  return c.json({ data: tenant });
+});
+
+// POST /tenants - Create a new partner tenant
+tenantRoutes.post('/', async (c) => {
+  const body = await c.req.json();
+
+  if (!body.name || typeof body.name !== 'string' || body.name.trim().length === 0) {
+    return c.json({ error: 'Tenant name is required' }, 400);
+  }
+
+  const existing = await tenantRepo.findByName(body.name.trim());
+  if (existing) {
+    return c.json({ error: 'A tenant with this name already exists' }, 409);
+  }
+
+  const tenant = await tenantRepo.create({
+    name: body.name.trim(),
+    is_distributor: body.is_distributor ? 1 : 0,
+  });
+  return c.json({ data: tenant }, 201);
+});
+
+// PUT /tenants/:id - Update a tenant
+tenantRoutes.put('/:id', async (c) => {
+  const id = parseInt(c.req.param('id'));
+  const tenant = await tenantRepo.findById(id);
+
+  if (!tenant) {
+    return c.json({ error: 'Tenant not found' }, 404);
+  }
+
+  const body = await c.req.json();
+  const updateData: { name?: string; is_active?: number; is_distributor?: number } = {};
+  if (body.name !== undefined) updateData.name = body.name.trim();
+  if (body.is_active !== undefined) updateData.is_active = body.is_active;
+  if (body.is_distributor !== undefined) updateData.is_distributor = body.is_distributor;
+
+  const updated = await tenantRepo.update(id, updateData);
+  return c.json({ data: updated });
+});
+
+// DELETE /tenants/:id - Delete tenant (hard delete if no projects, soft delete otherwise)
+tenantRoutes.delete('/:id', async (c) => {
+  const id = parseInt(c.req.param('id'));
+  const tenant = await tenantRepo.findById(id);
+
+  if (!tenant) {
+    return c.json({ error: 'Tenant not found' }, 404);
+  }
+
+  if (tenant.is_distributor) {
+    return c.json({ error: 'Cannot delete a distributor tenant' }, 403);
+  }
+
+  // Check if tenant has projects
+  const projects = await projectRepository.findAllByTenant(id);
+  if (projects.length > 0) {
+    return c.json({
+      error: `Cannot delete tenant with ${projects.length} project(s). Remove all projects first or deactivate the tenant instead.`,
+    }, 400);
+  }
+
+  // No projects — hard delete users and tenant
+  const users = await userRepository.findAllByTenant(id);
+  for (const user of users) {
+    await userRepository.delete(user.id);
+  }
+  await tenantRepo.delete(id);
+
+  return c.json({ message: 'Tenant deleted successfully' });
+});
+
+export default tenantRoutes;

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -3,7 +3,9 @@ import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { userRepository } from '../repositories/user.ts';
 import { hashPassword } from '../services/password.ts';
-import { authMiddleware, adminMiddleware } from '../middleware/auth.ts';
+import { authMiddleware, tenantAdminMiddleware } from '../middleware/auth.ts';
+import type { TenantContext } from '../repositories/user.ts';
+import type { UserRole } from '../models/index.ts';
 
 const userRoutes = new Hono();
 
@@ -12,12 +14,28 @@ const createUserSchema = z.object({
   email: z.string().email(),
   full_name: z.string().optional(),
   password: z.string().min(8),
-  role: z.enum(['admin', 'user']).optional(),
+  role: z.enum(['admin', 'tenant_admin', 'user']).optional(),
+  tenant_id: z.number().optional(),
 });
 
+function getUserTenantCtx(c: { get: (key: string) => unknown; req: { query: (key: string) => string | undefined } }): TenantContext {
+  const role = c.get('userRole') as TenantContext['role'];
+  const tenantId = c.get('tenantId') as number;
+
+  // Admin can filter by specific tenant via query param
+  const queryTenantId = c.req.query('tenantId');
+  if (queryTenantId && role === 'admin') {
+    return { tenantId: parseInt(queryTenantId), role: 'tenant_admin' }; // Force filtering
+  }
+
+  return { tenantId, role };
+}
+
 // POST /users - Create new user
-userRoutes.post('/', authMiddleware, adminMiddleware, zValidator('json', createUserSchema), async (c) => {
-  const { email, full_name, password, role } = c.req.valid('json');
+userRoutes.post('/', authMiddleware, tenantAdminMiddleware, zValidator('json', createUserSchema), async (c) => {
+  const { email, full_name, password, role, tenant_id } = c.req.valid('json');
+  const callerRole = c.get('userRole') as UserRole;
+  const callerTenantId = c.get('tenantId') as number;
 
   try {
     // Check if user already exists
@@ -26,15 +44,25 @@ userRoutes.post('/', authMiddleware, adminMiddleware, zValidator('json', createU
       return c.json({ error: 'User with this email already exists' }, 400);
     }
 
-    // Hash password
+    // Determine target tenant
+    let targetTenantId = callerTenantId;
+    if (tenant_id && callerRole === 'admin') {
+      targetTenantId = tenant_id;
+    }
+
+    // Prevent tenant admin from creating admin users
+    if (role === 'admin' && callerRole !== 'admin') {
+      return c.json({ error: 'Only admins can create admin users' }, 403);
+    }
+
     const passwordHash = hashPassword(password);
 
-    // Create user
     const user = await userRepository.create({
       email,
       full_name,
       password_hash: passwordHash,
       role: role || 'user',
+      tenant_id: targetTenantId,
     });
 
     return c.json({
@@ -47,10 +75,11 @@ userRoutes.post('/', authMiddleware, adminMiddleware, zValidator('json', createU
   }
 });
 
-// GET /users - List all users
-userRoutes.get('/', authMiddleware, adminMiddleware, async (c) => {
+// GET /users - List users (filtered by tenant)
+userRoutes.get('/', authMiddleware, tenantAdminMiddleware, async (c) => {
   try {
-    const users = await userRepository.findAll();
+    const ctx = getUserTenantCtx(c);
+    const users = await userRepository.findAll(ctx);
     return c.json({
       data: users,
     });
@@ -61,50 +90,70 @@ userRoutes.get('/', authMiddleware, adminMiddleware, async (c) => {
 });
 
 // PUT /users/:id - Update user (admin only)
-userRoutes.put('/:id', authMiddleware, adminMiddleware, async (c) => {
+userRoutes.put('/:id', authMiddleware, tenantAdminMiddleware, async (c) => {
   const id = parseInt(c.req.param('id'));
   if (isNaN(id)) {
     return c.json({ error: 'Invalid ID' }, 400);
   }
   const body = await c.req.json();
-  
+  const callerRole = c.get('userRole') as UserRole;
+  const callerTenantId = c.get('tenantId') as number;
+
   try {
-    // Check if user exists
     const existingUser = await userRepository.findById(id);
     if (!existingUser) {
       return c.json({ error: 'User not found' }, 404);
     }
-    
-    // Admin can update: full_name, email, password, role
-    const updateData: { full_name?: string; email?: string; password_hash?: string; role?: 'admin' | 'user' } = {};
-    
+
+    // Tenant admin can only edit users in their own tenant
+    if (callerRole !== 'admin' && existingUser.tenant_id !== callerTenantId) {
+      return c.json({ error: 'Forbidden - Cannot edit users from other tenants' }, 403);
+    }
+
+    const updateData: { full_name?: string; email?: string; password_hash?: string; role?: UserRole; tenant_id?: number; is_active?: number } = {};
+
     if (body.full_name !== undefined) {
       updateData.full_name = body.full_name;
     }
-    
+
     if (body.email) {
-      // Check if email is already taken by another user
       const userWithEmail = await userRepository.findByEmail(body.email);
       if (userWithEmail && userWithEmail.id !== id) {
         return c.json({ error: 'Email already in use' }, 400);
       }
       updateData.email = body.email;
     }
-    
+
     if (body.password) {
       updateData.password_hash = hashPassword(body.password);
     }
-    
-    if (body.role && ['admin', 'user'].includes(body.role)) {
+
+    if (body.role && ['admin', 'tenant_admin', 'user'].includes(body.role)) {
+      // Only admin can assign admin role
+      if (body.role === 'admin' && callerRole !== 'admin') {
+        return c.json({ error: 'Only admins can assign admin role' }, 403);
+      }
       updateData.role = body.role;
     }
-    
+
+    if (body.tenant_id && callerRole === 'admin') {
+      updateData.tenant_id = body.tenant_id;
+    }
+
+    if (body.is_active !== undefined) {
+      // Prevent deactivating admin users
+      if (!body.is_active && existingUser.role === 'admin') {
+        return c.json({ error: 'Cannot deactivate admin users' }, 403);
+      }
+      updateData.is_active = body.is_active;
+    }
+
     if (Object.keys(updateData).length === 0) {
       return c.json({ error: 'No fields to update' }, 400);
     }
-    
+
     const updatedUser = await userRepository.update(id, updateData);
-    
+
     return c.json({
       data: updatedUser,
       message: 'User updated successfully',
@@ -116,18 +165,30 @@ userRoutes.put('/:id', authMiddleware, adminMiddleware, async (c) => {
 });
 
 // DELETE /users/:id - Delete user
-userRoutes.delete('/:id', authMiddleware, adminMiddleware, async (c) => {
+userRoutes.delete('/:id', authMiddleware, tenantAdminMiddleware, async (c) => {
   const id = parseInt(c.req.param('id'));
   if (isNaN(id)) {
     return c.json({ error: 'Invalid ID' }, 400);
   }
   const currentUserId = c.get('userId');
+  const callerRole = c.get('userRole') as UserRole;
+  const callerTenantId = c.get('tenantId') as number;
 
   if (id === currentUserId) {
     return c.json({ error: 'Cannot delete your own account' }, 400);
   }
 
   try {
+    const user = await userRepository.findById(id);
+    if (!user) {
+      return c.json({ error: 'User not found' }, 404);
+    }
+
+    // Tenant admin can only delete users in their own tenant
+    if (callerRole !== 'admin' && user.tenant_id !== callerTenantId) {
+      return c.json({ error: 'Forbidden - Cannot delete users from other tenants' }, 403);
+    }
+
     await userRepository.delete(id);
     return c.json({
       message: 'User deleted successfully',

--- a/backend/src/scripts/migrate.ts
+++ b/backend/src/scripts/migrate.ts
@@ -31,21 +31,29 @@ export function getAppliedMigrations(): Promise<string[]> {
 export function applyMigration(name: string, sql: string): Promise<void> {
   try {
     const db = getDb();
-    
-    // For migration 025, we need to disable foreign keys temporarily
-    // because we're recreating tables with foreign key references
-    if (name === '025_remove_all_cascade_constraints') {
+
+    // For migrations that recreate tables, we need to disable foreign keys temporarily
+    const needsFkOff = name === '025_remove_all_cascade_constraints' || name === '031_multi_tenancy';
+    if (needsFkOff) {
       db.query('PRAGMA foreign_keys = OFF');
     }
-    
-    db.execute(sql);
-    db.query(`INSERT INTO migrations (name) VALUES (?)`, [name]);
-    
+
+    // Wrap in transaction so migration is all-or-nothing
+    db.query('BEGIN TRANSACTION');
+    try {
+      db.execute(sql);
+      db.query(`INSERT INTO migrations (name) VALUES (?)`, [name]);
+      db.query('COMMIT');
+    } catch (error) {
+      db.query('ROLLBACK');
+      throw error;
+    }
+
     // Re-enable foreign keys if we disabled them
-    if (name === '025_remove_all_cascade_constraints') {
+    if (needsFkOff) {
       db.query('PRAGMA foreign_keys = ON');
     }
-    
+
     console.log(`✅ Applied migration: ${name}`);
     return Promise.resolve();
   } catch (error) {
@@ -723,6 +731,55 @@ export async function runMigrations(): Promise<void> {
         CREATE INDEX idx_area_vertices_placement ON area_vertices(placement_id);
 
         PRAGMA foreign_keys = ON;
+      `
+    },
+    {
+      name: '031_multi_tenancy',
+      sql: `
+        -- 1. Create tenants table
+        CREATE TABLE tenants (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          name TEXT NOT NULL,
+          is_distributor INTEGER NOT NULL DEFAULT 0,
+          is_active INTEGER NOT NULL DEFAULT 1,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE UNIQUE INDEX idx_tenants_name ON tenants(name);
+
+        -- 2. Seed the distributor tenant
+        INSERT INTO tenants (id, name, is_distributor, is_active)
+        VALUES (1, 'Distributor', 1, 1);
+
+        -- 3. Recreate users table with new role constraint, tenant_id, and is_active
+        CREATE TABLE users_new (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          email TEXT UNIQUE NOT NULL,
+          password_hash TEXT NOT NULL,
+          role TEXT CHECK(role IN ('admin', 'tenant_admin', 'user')) NOT NULL DEFAULT 'user',
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          full_name TEXT,
+          tenant_id INTEGER NOT NULL DEFAULT 1,
+          is_active INTEGER NOT NULL DEFAULT 1
+        );
+
+        INSERT INTO users_new (id, email, password_hash, role, created_at, full_name, tenant_id, is_active)
+        SELECT id, email, password_hash,
+          role,
+          created_at, full_name, 1, 1
+        FROM users;
+
+        DROP TABLE users;
+        ALTER TABLE users_new RENAME TO users;
+        CREATE INDEX idx_users_email ON users(email);
+        CREATE INDEX idx_users_tenant ON users(tenant_id);
+
+        -- 4. Add tenant_id to projects
+        ALTER TABLE projects ADD COLUMN tenant_id INTEGER NOT NULL DEFAULT 1;
+        CREATE INDEX idx_projects_tenant ON projects(tenant_id);
+
+        -- 5. Recreate unique index to include tenant_id
+        DROP INDEX IF EXISTS idx_projects_unique_name_customer;
+        CREATE UNIQUE INDEX idx_projects_unique_name_customer ON projects(name, customer_name, tenant_id);
       `
     }
   ];

--- a/backend/src/services/jwt.ts
+++ b/backend/src/services/jwt.ts
@@ -1,5 +1,6 @@
 import { create, verify } from 'djwt';
 import { env } from '../config/env.ts';
+import type { UserRole } from '../models/index.ts';
 
 const JWT_SECRET = env.JWT_SECRET;
 // Access tokens expire in 15 minutes (900 seconds)
@@ -9,7 +10,8 @@ const ACCESS_TOKEN_EXPIRY = 60 * 15;
 export interface JWTPayload {
   sub: string;      // user id
   email: string;    // user email
-  role: 'admin' | 'user';
+  role: UserRole;
+  tenantId: number;
   exp: number;      // expiration time
   iat: number;      // issued at
 }
@@ -20,13 +22,15 @@ export interface JWTPayload {
 export async function generateToken(
   userId: number,
   email: string,
-  role: 'admin' | 'user'
+  role: UserRole,
+  tenantId: number
 ): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   const payload = {
     sub: userId.toString(),
     email,
     role,
+    tenantId,
     exp: now + ACCESS_TOKEN_EXPIRY,
     iat: now,
   };

--- a/backend/tests/repositories/bom-entry_test.ts
+++ b/backend/tests/repositories/bom-entry_test.ts
@@ -21,6 +21,7 @@ Deno.test('BomEntryRepository - findByPicturePath', async (t) => {
     customer_name: 'Test Customer',
     customer_address: '123 Test St',
     status: 'active',
+    tenant_id: 1,
   });
 
   const floorplan = await floorplanRepository.create({

--- a/backend/tests/repositories/user_test.ts
+++ b/backend/tests/repositories/user_test.ts
@@ -16,6 +16,7 @@ Deno.test('UserRepository - create user', async () => {
     email: 'test@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   assertExists(user.id);
@@ -34,6 +35,7 @@ Deno.test('UserRepository - create user with full_name', async () => {
     full_name: 'John Doe',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   assertExists(user.id);
@@ -51,6 +53,7 @@ Deno.test('UserRepository - findByEmail finds existing user', async () => {
     full_name: 'Jane Smith',
     password_hash: passwordHash,
     role: 'admin',
+    tenant_id: 1,
   });
 
   const found = await userRepository.findByEmail('find@example.com');
@@ -77,6 +80,7 @@ Deno.test('UserRepository - findById finds user by id', async () => {
     full_name: 'Test User',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const found = await userRepository.findById(created.id);
@@ -96,12 +100,14 @@ Deno.test('UserRepository - findAll returns all users', async () => {
     full_name: 'User One',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
   await userRepository.create({
     email: 'user2@example.com',
     full_name: 'User Two',
     password_hash: passwordHash,
     role: 'admin',
+    tenant_id: 1,
   });
 
   const users = await userRepository.findAll();
@@ -119,6 +125,7 @@ Deno.test('UserRepository - update user full_name', async () => {
     email: 'update@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const updated = await userRepository.update(created.id, {
@@ -137,6 +144,7 @@ Deno.test('UserRepository - update user email', async () => {
     email: 'old@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const updated = await userRepository.update(created.id, {
@@ -156,6 +164,7 @@ Deno.test('UserRepository - update user full_name to null', async () => {
     full_name: 'Original Name',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const updated = await userRepository.update(created.id, {
@@ -174,6 +183,7 @@ Deno.test('UserRepository - delete user', async () => {
     email: 'delete@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   await userRepository.delete(created.id);
@@ -190,6 +200,7 @@ Deno.test('UserRepository - user has password_hash field', async () => {
     email: 'haspassword@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const found = await userRepository.findByEmail('haspassword@example.com');

--- a/backend/tests/routes/auth-security_test.ts
+++ b/backend/tests/routes/auth-security_test.ts
@@ -14,6 +14,7 @@ Deno.test('Token rotation - refresh returns new refresh token', async () => {
     email: 'rotation@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   // Login to get initial tokens
@@ -47,6 +48,7 @@ Deno.test('Token rotation - old refresh token is rejected after rotation', async
     email: 'rotation2@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   // Login
@@ -78,7 +80,7 @@ Deno.test('Token rotation - old refresh token is rejected after rotation', async
 Deno.test('PUT /auth/me - accepts password change', async () => {
   clearDatabase();
   const passwordHash = hashPassword('oldpass1234');
-  await userRepository.create({ email: 'profile@example.com', password_hash: passwordHash, role: 'user' });
+  await userRepository.create({ email: 'profile@example.com', password_hash: passwordHash, role: 'user', tenant_id: 1 });
 
   const loginRes = await testRequest('/api/auth/login', {
     method: 'POST',
@@ -99,7 +101,7 @@ Deno.test('PUT /auth/me - accepts password change', async () => {
 Deno.test('PUT /auth/me - rejects short password', async () => {
   clearDatabase();
   const passwordHash = hashPassword('oldpass1234');
-  await userRepository.create({ email: 'profile2@example.com', password_hash: passwordHash, role: 'user' });
+  await userRepository.create({ email: 'profile2@example.com', password_hash: passwordHash, role: 'user', tenant_id: 1 });
 
   const loginRes = await testRequest('/api/auth/login', {
     method: 'POST',

--- a/backend/tests/routes/auth_tenant_test.ts
+++ b/backend/tests/routes/auth_tenant_test.ts
@@ -1,0 +1,246 @@
+import { assertEquals, assertExists } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { testRequest, parseJSON } from '../test-client.ts';
+import { getDb } from '../../src/config/database.ts';
+import { hashPassword } from '../../src/services/password.ts';
+
+// Setup test database before all tests
+await setupTestDatabase();
+
+/** Helper: create a partner tenant via direct SQL and return its id */
+function createTenant(name: string, isActive = 1): number {
+  const db = getDb();
+  db.query(
+    'INSERT INTO tenants (name, is_distributor, is_active) VALUES (?, 0, ?)',
+    [name, isActive],
+  );
+  const rows = db.queryEntries<{ id: number }>(
+    'SELECT id FROM tenants WHERE name = ?',
+    [name],
+  );
+  return rows[0].id;
+}
+
+/** Helper: create a user with a known password via direct SQL */
+function createUser(
+  email: string,
+  password: string,
+  tenantId: number,
+  role = 'user',
+): number {
+  const db = getDb();
+  const hash = hashPassword(password);
+  db.query(
+    'INSERT INTO users (email, password_hash, role, tenant_id) VALUES (?, ?, ?, ?)',
+    [email, hash, role, tenantId],
+  );
+  const rows = db.queryEntries<{ id: number }>(
+    'SELECT id FROM users WHERE email = ?',
+    [email],
+  );
+  return rows[0].id;
+}
+
+// ──────────────────────────────────────────────
+// Login with tenant checks
+// ──────────────────────────────────────────────
+
+Deno.test('Auth tenant - login succeeds for user in active tenant', async () => {
+  clearDatabase();
+  const tenantId = createTenant('Active Corp');
+  createUser('active@example.com', 'password123', tenantId);
+
+  const res = await testRequest('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'active@example.com',
+      password: 'password123',
+    }),
+  });
+
+  const data = await parseJSON(res);
+
+  assertEquals(res.status, 200);
+  assertExists(data.data.accessToken);
+  assertExists(data.data.refreshToken);
+  assertEquals(data.data.user.email, 'active@example.com');
+});
+
+Deno.test('Auth tenant - login blocked for user in inactive tenant (403)', async () => {
+  clearDatabase();
+  const tenantId = createTenant('Inactive Corp', 0);
+  createUser('blocked@example.com', 'password123', tenantId);
+
+  const res = await testRequest('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'blocked@example.com',
+      password: 'password123',
+    }),
+  });
+
+  const data = await parseJSON(res);
+
+  assertEquals(res.status, 403);
+  assertEquals(data.error, 'Account disabled - contact your administrator');
+});
+
+Deno.test('Auth tenant - token refresh blocked for user in inactive tenant (403)', async () => {
+  clearDatabase();
+  // Start with active tenant so we can log in and get a refresh token
+  const tenantId = createTenant('Soon Inactive', 1);
+  createUser('refresh@example.com', 'password123', tenantId);
+
+  // Login while tenant is still active
+  const loginRes = await testRequest('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'refresh@example.com',
+      password: 'password123',
+    }),
+  });
+
+  const loginData = await parseJSON(loginRes);
+  assertEquals(loginRes.status, 200);
+  const refreshToken = loginData.data.refreshToken;
+
+  // Now deactivate the tenant
+  const db = getDb();
+  db.query('UPDATE tenants SET is_active = 0 WHERE id = ?', [tenantId]);
+
+  // Attempt to refresh — should be blocked
+  const refreshRes = await testRequest('/api/auth/refresh', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refreshToken }),
+  });
+
+  const refreshData = await parseJSON(refreshRes);
+
+  assertEquals(refreshRes.status, 403);
+  assertEquals(refreshData.error, 'Account disabled - contact your administrator');
+});
+
+Deno.test('Auth tenant - login response includes tenantId and tenantName', async () => {
+  clearDatabase();
+  const tenantId = createTenant('Acme Homes');
+  createUser('acme@example.com', 'password123', tenantId);
+
+  const res = await testRequest('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'acme@example.com',
+      password: 'password123',
+    }),
+  });
+
+  const data = await parseJSON(res);
+
+  assertEquals(res.status, 200);
+  assertEquals(data.data.user.tenantId, tenantId);
+  assertEquals(data.data.user.tenantName, 'Acme Homes');
+});
+
+Deno.test('Auth tenant - /auth/me response includes tenantId and tenantName', async () => {
+  clearDatabase();
+  const tenantId = createTenant('Me Tenant');
+  createUser('metest@example.com', 'password123', tenantId);
+
+  // Login first to get access token
+  const loginRes = await testRequest('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'metest@example.com',
+      password: 'password123',
+    }),
+  });
+
+  const loginData = await parseJSON(loginRes);
+  assertEquals(loginRes.status, 200);
+  const accessToken = loginData.data.accessToken;
+
+  // Call /auth/me
+  const meRes = await testRequest('/api/auth/me', {
+    headers: { 'Authorization': `Bearer ${accessToken}` },
+  });
+
+  const meData = await parseJSON(meRes);
+
+  assertEquals(meRes.status, 200);
+  assertEquals(meData.data.tenantId, tenantId);
+  assertEquals(meData.data.tenantName, 'Me Tenant');
+  assertExists(meData.data.tenant_id);
+});
+
+// ──────────────────────────────────────────────
+// Login blocked for inactive user (is_active = 0)
+// ──────────────────────────────────────────────
+
+Deno.test('Auth tenant - login blocked for inactive user (403)', async () => {
+  clearDatabase();
+  const tenantId = createTenant('Active Tenant');
+  const userId = createUser('deactivated@example.com', 'password123', tenantId);
+
+  // Deactivate user directly via SQL
+  const db = getDb();
+  db.query('UPDATE users SET is_active = 0 WHERE id = ?', [userId]);
+
+  const res = await testRequest('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'deactivated@example.com',
+      password: 'password123',
+    }),
+  });
+
+  const data = await parseJSON(res);
+
+  assertEquals(res.status, 403);
+  assertEquals(data.error, 'Account disabled - contact your administrator');
+});
+
+// ──────────────────────────────────────────────
+// Token refresh blocked for inactive user
+// ──────────────────────────────────────────────
+
+Deno.test('Auth tenant - token refresh blocked for inactive user (403)', async () => {
+  clearDatabase();
+  const tenantId = createTenant('Refresh Tenant');
+  createUser('soon-inactive@example.com', 'password123', tenantId);
+
+  // Login while user is active
+  const loginRes = await testRequest('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'soon-inactive@example.com',
+      password: 'password123',
+    }),
+  });
+
+  const loginData = await parseJSON(loginRes);
+  assertEquals(loginRes.status, 200);
+  const refreshToken = loginData.data.refreshToken;
+
+  // Deactivate user via SQL
+  const db = getDb();
+  db.query("UPDATE users SET is_active = 0 WHERE email = 'soon-inactive@example.com'");
+
+  // Attempt to refresh — should be blocked
+  const refreshRes = await testRequest('/api/auth/refresh', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refreshToken }),
+  });
+
+  const refreshData = await parseJSON(refreshRes);
+
+  assertEquals(refreshRes.status, 403);
+  assertEquals(refreshData.error, 'Account disabled - contact your administrator');
+});

--- a/backend/tests/routes/auth_test.ts
+++ b/backend/tests/routes/auth_test.ts
@@ -18,6 +18,7 @@ Deno.test('Auth endpoints - login with valid credentials', async () => {
     email: 'logintest@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const response = await testRequest('/api/auth/login', {
@@ -66,6 +67,7 @@ Deno.test('Auth endpoints - login with invalid password', async () => {
     email: 'wrongpass@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const response = await testRequest('/api/auth/login', {
@@ -106,6 +108,7 @@ Deno.test('Auth endpoints - get current user with valid token', async () => {
     email: 'me@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const loginResponse = await testRequest('/api/auth/login', {
@@ -159,6 +162,7 @@ Deno.test('Auth endpoints - logout with valid token', async () => {
     email: 'logout@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const loginResponse = await testRequest('/api/auth/login', {
@@ -194,6 +198,7 @@ Deno.test('Auth endpoints - update profile with full_name', async () => {
     email: 'updateprofile@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const loginResponse = await testRequest('/api/auth/login', {
@@ -235,6 +240,7 @@ Deno.test('Auth endpoints - refresh token with valid refresh token', async () =>
     email: 'refreshtest@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const loginResponse = await testRequest('/api/auth/login', {
@@ -293,6 +299,7 @@ Deno.test('Auth endpoints - access protected endpoint with refreshed token', asy
     email: 'refreshthenaccess@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const loginResponse = await testRequest('/api/auth/login', {
@@ -339,6 +346,7 @@ Deno.test('Auth endpoints - update profile with email', async () => {
     email: 'updateemail@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const loginResponse = await testRequest('/api/auth/login', {
@@ -380,6 +388,7 @@ Deno.test('Auth endpoints - update profile with password', async () => {
     email: 'updatepass@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const loginResponse = await testRequest('/api/auth/login', {
@@ -431,6 +440,7 @@ Deno.test('Auth endpoints - update profile without changes fails', async () => {
     full_name: 'Test User',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const loginResponse = await testRequest('/api/auth/login', {

--- a/backend/tests/routes/bom_test.ts
+++ b/backend/tests/routes/bom_test.ts
@@ -25,6 +25,7 @@ async function getAuthToken(): Promise<string> {
     email: 'test@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   // Login
@@ -49,6 +50,7 @@ Deno.test('BOM - Create placement auto-creates BOM entry with required addons', 
     name: 'Test Project',
     customer_name: 'Test Customer',
     status: 'active',
+    tenant_id: 1,
   });
 
   // Create floorplan
@@ -149,6 +151,7 @@ Deno.test('BOM - Get BOM for floorplan returns hierarchical structure', async ()
     name: 'Test Project 2',
     customer_name: 'Test Customer',
     status: 'active',
+    tenant_id: 1,
   });
 
   // Create floorplan
@@ -224,6 +227,7 @@ Deno.test('BOM - Delete last placement removes BOM entry', async () => {
     name: 'Test Project 3',
     customer_name: 'Test Customer',
     status: 'active',
+    tenant_id: 1,
   });
 
   // Create floorplan
@@ -298,6 +302,7 @@ Deno.test('BOM - Get project total sums all floorplan totals', async () => {
     name: 'Test Project 4',
     customer_name: 'Test Customer',
     status: 'active',
+    tenant_id: 1,
   });
 
   // Create two floorplans

--- a/backend/tests/routes/categories_test.ts
+++ b/backend/tests/routes/categories_test.ts
@@ -21,6 +21,7 @@ async function getAdminToken(): Promise<string> {
     email: 'admin@example.com',
     password_hash: passwordHash,
     role: 'admin',
+    tenant_id: 1,
   });
 
   // Login as admin
@@ -46,6 +47,7 @@ async function getUserToken(): Promise<string> {
     email: 'user@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   // Login as user
@@ -267,6 +269,7 @@ Deno.test('PUT /categories/:id - should deactivate category and cascade to items
     email: 'admin@test.com',
     password_hash: passwordHash,
     role: 'admin',
+    tenant_id: 1,
   });
 
   // Login
@@ -349,6 +352,7 @@ Deno.test('PUT /categories/:id - should activate category without cascading to c
     email: 'admin@test.com',
     password_hash: passwordHash,
     role: 'admin',
+    tenant_id: 1,
   });
 
   // Login

--- a/backend/tests/routes/data-integrity_test.ts
+++ b/backend/tests/routes/data-integrity_test.ts
@@ -68,7 +68,7 @@ Deno.test('deleteByFloorplan - placements are cleaned up', async () => {
   clearDatabase();
 
   // Create project → floorplan → item → variant → BOM entry → placement
-  const project = await projectRepository.create({ name: 'Test Project', customer_name: 'Test Customer' });
+  const project = await projectRepository.create({ name: 'Test Project', customer_name: 'Test Customer', tenant_id: 1 });
   const floorplan = await floorplanRepository.create({ project_id: project.id, name: 'Floor 1', image_path: 'test.png' });
   const category = await categoryRepository.create({ name: 'Cat1' });
   const item = await itemRepository.create({ name: 'Item1', category_id: category.id });
@@ -98,7 +98,7 @@ Deno.test('Route ordering - POST /placements/bulk-update is reachable', async ()
   clearDatabase();
 
   const passwordHash = hashPassword('testpassword123');
-  await userRepository.create({ email: 'routetest@example.com', password_hash: passwordHash, role: 'admin' });
+  await userRepository.create({ email: 'routetest@example.com', password_hash: passwordHash, role: 'admin', tenant_id: 1 });
 
   const loginRes = await testRequest('/api/auth/login', {
     method: 'POST',
@@ -129,6 +129,7 @@ Deno.test('UserRepository.update - can update email with !== undefined check', a
     email: 'original@example.com',
     password_hash: hashPassword('testpassword123'),
     role: 'user',
+    tenant_id: 1,
   });
 
   const updated = await userRepository.update(user.id, { email: 'new@example.com' });
@@ -199,7 +200,7 @@ Deno.test('ItemRepository.delete - rolls back on error', async () => {
 Deno.test('BomEntry.delete - cleans up child placements', async () => {
   clearDatabase();
 
-  const project = await projectRepository.create({ name: 'BomDelProject', customer_name: 'Test' });
+  const project = await projectRepository.create({ name: 'BomDelProject', customer_name: 'Test', tenant_id: 1 });
   const floorplan = await floorplanRepository.create({ project_id: project.id, name: 'Floor', image_path: 'test.png' });
   const category = await categoryRepository.create({ name: 'Cat' });
   const item = await itemRepository.create({ name: 'Item', category_id: category.id });
@@ -246,7 +247,7 @@ Deno.test('CategoryRepository.reorder - updates all sort orders atomically', () 
 Deno.test('BomService.updateFromCatalog - totalAfter reflects updated prices', async () => {
   clearDatabase();
 
-  const project = await projectRepository.create({ name: 'TotalProject', customer_name: 'Test' });
+  const project = await projectRepository.create({ name: 'TotalProject', customer_name: 'Test', tenant_id: 1 });
   const floorplan = await floorplanRepository.create({ project_id: project.id, name: 'Floor', image_path: 'test.png' });
   const category = await categoryRepository.create({ name: 'Cat' });
   const item = await itemRepository.create({ name: 'Item', category_id: category.id });
@@ -272,7 +273,7 @@ Deno.test('BomService.updateFromCatalog - totalAfter reflects updated prices', a
 Deno.test('BomService.updateFromCatalog - updates snapshot including picture_path on price change', async () => {
   clearDatabase();
 
-  const project = await projectRepository.create({ name: 'ImgProject', customer_name: 'Test' });
+  const project = await projectRepository.create({ name: 'ImgProject', customer_name: 'Test', tenant_id: 1 });
   const floorplan = await floorplanRepository.create({ project_id: project.id, name: 'Floor', image_path: 'test.png' });
   const category = await categoryRepository.create({ name: 'Cat' });
   const item = await itemRepository.create({ name: 'Item', category_id: category.id });
@@ -309,7 +310,7 @@ Deno.test('Route ordering - POST /placements/bulk-update responds with correct h
   clearDatabase();
 
   const passwordHash = hashPassword('testpassword123');
-  await userRepository.create({ email: 'route2@example.com', password_hash: passwordHash, role: 'admin' });
+  await userRepository.create({ email: 'route2@example.com', password_hash: passwordHash, role: 'admin', tenant_id: 1 });
 
   const loginRes = await testRequest('/api/auth/login', {
     method: 'POST',

--- a/backend/tests/routes/floorplans_test.ts
+++ b/backend/tests/routes/floorplans_test.ts
@@ -18,6 +18,7 @@ async function getAuthToken(): Promise<string> {
     email: 'test@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const loginResponse = await testRequest('/api/auth/login', {
@@ -42,6 +43,7 @@ Deno.test('Floorplan - CRUD operations', async (t) => {
     customer_name: 'Test Customer',
     customer_address: '123 Test St',
     status: 'active',
+    tenant_id: 1,
   });
   const projectId = project.id;
 
@@ -146,6 +148,7 @@ Deno.test('Floorplan - validation and errors', async (t) => {
     customer_name: 'Test Customer',
     customer_address: '123 Test St',
     status: 'active',
+    tenant_id: 1,
   });
   const projectId = project.id;
 
@@ -212,6 +215,7 @@ Deno.test('Floorplan - reorder functionality', async (t) => {
     customer_name: 'Test Customer',
     customer_address: '123 Test St',
     status: 'active',
+    tenant_id: 1,
   });
   const projectId = project.id;
 
@@ -334,6 +338,7 @@ Deno.test('Floorplan - delete with image cleanup', async (t) => {
     customer_name: 'Test Customer',
     customer_address: '123 Test St',
     status: 'active',
+    tenant_id: 1,
   });
   const projectId = project.id;
 

--- a/backend/tests/routes/invoice-settings_test.ts
+++ b/backend/tests/routes/invoice-settings_test.ts
@@ -19,6 +19,7 @@ async function getAuthToken(): Promise<string> {
     email: 'test@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   // Login
@@ -42,6 +43,7 @@ Deno.test('PUT /projects/:id/invoice-settings - should update invoice settings',
   const project = await projectRepository.create({
     name: 'Test Project',
     customer_name: 'Test Customer',
+    tenant_id: 1,
   });
   
   try {
@@ -103,6 +105,7 @@ Deno.test('PUT /projects/:id/invoice-settings - should handle partial updates', 
   const project = await projectRepository.create({
     name: 'Test Project Partial',
     customer_name: 'Test Customer',
+    tenant_id: 1,
   });
   
   try {
@@ -149,6 +152,7 @@ Deno.test('GET /projects/:id/invoice-calculation - should return calculated invo
   const project = await projectRepository.create({
     name: 'Test Project Calc',
     customer_name: 'Test Customer',
+    tenant_id: 1,
   });
   
   // Update invoice settings

--- a/backend/tests/routes/items_test.ts
+++ b/backend/tests/routes/items_test.ts
@@ -20,6 +20,7 @@ async function getAdminToken(): Promise<string> {
     email: 'admin@example.com',
     password_hash: passwordHash,
     role: 'admin',
+    tenant_id: 1,
   });
 
   const loginResponse = await testRequest('/api/auth/login', {
@@ -170,6 +171,7 @@ Deno.test('POST /items - should require admin role', async () => {
     email: 'user@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   const loginResponse = await testRequest('/api/auth/login', {

--- a/backend/tests/routes/placements_test.ts
+++ b/backend/tests/routes/placements_test.ts
@@ -25,6 +25,7 @@ async function getAuthToken(): Promise<string> {
     email: 'test@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   // Login
@@ -50,6 +51,7 @@ Deno.test('Placement - CRUD operations', async (t) => {
     customer_name: 'Test Customer',
     customer_address: '123 Test St',
     status: 'active',
+    tenant_id: 1,
   });
   const projectId = project.id;
 
@@ -223,6 +225,7 @@ Deno.test('Placement - duplicate endpoint', async (t) => {
     customer_name: 'Test Customer',
     customer_address: '123 Test St',
     status: 'active',
+    tenant_id: 1,
   });
   const projectId = project.id;
 

--- a/backend/tests/routes/projects_tenant_test.ts
+++ b/backend/tests/routes/projects_tenant_test.ts
@@ -1,0 +1,515 @@
+import { assertEquals, assertExists } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { testRequest, parseJSON } from '../test-client.ts';
+import { getDb } from '../../src/config/database.ts';
+import { hashPassword } from '../../src/services/password.ts';
+
+// Setup test database before all tests
+await setupTestDatabase();
+
+/** Helper: create a partner tenant via direct SQL and return its id */
+function createTenant(name: string, isActive = 1): number {
+  const db = getDb();
+  db.query(
+    'INSERT INTO tenants (name, is_distributor, is_active) VALUES (?, 0, ?)',
+    [name, isActive],
+  );
+  const rows = db.queryEntries<{ id: number }>(
+    'SELECT id FROM tenants WHERE name = ?',
+    [name],
+  );
+  return rows[0].id;
+}
+
+/** Helper: create a user with a known password via direct SQL */
+function createUser(
+  email: string,
+  password: string,
+  tenantId: number,
+  role = 'user',
+): number {
+  const db = getDb();
+  const hash = hashPassword(password);
+  db.query(
+    'INSERT INTO users (email, password_hash, role, tenant_id) VALUES (?, ?, ?, ?)',
+    [email, hash, role, tenantId],
+  );
+  const rows = db.queryEntries<{ id: number }>(
+    'SELECT id FROM users WHERE email = ?',
+    [email],
+  );
+  return rows[0].id;
+}
+
+/** Helper: login and return the access token */
+async function login(email: string, password: string): Promise<string> {
+  const res = await testRequest('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  const data = await parseJSON(res);
+  return data.data.accessToken;
+}
+
+// ──────────────────────────────────────────────
+// Admin can change project tenant_id via PUT
+// ──────────────────────────────────────────────
+
+Deno.test('Projects tenant - admin can change project tenant_id via PUT', async () => {
+  clearDatabase();
+  const tenantA = createTenant('Tenant A');
+  const tenantB = createTenant('Tenant B');
+
+  // Create admin in distributor tenant (id=1)
+  createUser('admin@example.com', 'password123', 1, 'admin');
+  const adminToken = await login('admin@example.com', 'password123');
+
+  // Create a project in tenant A
+  const createRes = await testRequest('/api/projects', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${adminToken}`,
+    },
+    body: JSON.stringify({
+      name: 'Moveable Project',
+      customer_name: 'Customer X',
+    }),
+  });
+  const createData = await parseJSON(createRes);
+  assertEquals(createRes.status, 201);
+  const projectId = createData.data.id;
+
+  // Admin updates tenant_id of the project
+  // First update to tenantA so it has a known tenant
+  await testRequest(`/api/projects/${projectId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${adminToken}`,
+    },
+    body: JSON.stringify({ tenant_id: tenantA }),
+  });
+
+  // Now move from tenantA to tenantB
+  const res = await testRequest(`/api/projects/${projectId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${adminToken}`,
+    },
+    body: JSON.stringify({ tenant_id: tenantB }),
+  });
+
+  const data = await parseJSON(res);
+
+  assertEquals(res.status, 200);
+  assertEquals(data.data.tenant_id, tenantB);
+});
+
+// ──────────────────────────────────────────────
+// Tenant admin cannot change project tenant_id
+// ──────────────────────────────────────────────
+
+Deno.test('Projects tenant - tenant admin cannot change project tenant_id (ignored)', async () => {
+  clearDatabase();
+  const tenantId = createTenant('TA Tenant');
+  const otherTenant = createTenant('Other Tenant');
+
+  // Create tenant_admin
+  createUser('ta@example.com', 'password123', tenantId, 'tenant_admin');
+  const taToken = await login('ta@example.com', 'password123');
+
+  // Create a project as tenant_admin
+  const createRes = await testRequest('/api/projects', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${taToken}`,
+    },
+    body: JSON.stringify({
+      name: 'Locked Project',
+      customer_name: 'Customer Y',
+    }),
+  });
+  const createData = await parseJSON(createRes);
+  assertEquals(createRes.status, 201);
+  const projectId = createData.data.id;
+
+  // Attempt to change tenant_id — should be ignored
+  const res = await testRequest(`/api/projects/${projectId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${taToken}`,
+    },
+    body: JSON.stringify({ tenant_id: otherTenant, name: 'Renamed Project' }),
+  });
+
+  const data = await parseJSON(res);
+
+  assertEquals(res.status, 200);
+  // tenant_id should remain the original
+  assertEquals(data.data.tenant_id, tenantId);
+  // Name should still be updated
+  assertEquals(data.data.name, 'Renamed Project');
+});
+
+// ──────────────────────────────────────────────
+// New project gets caller's tenant_id
+// ──────────────────────────────────────────────
+
+Deno.test('Projects tenant - new project gets caller tenant_id', async () => {
+  clearDatabase();
+  const tenantId = createTenant('Project Tenant');
+  createUser('creator@example.com', 'password123', tenantId, 'user');
+  const userToken = await login('creator@example.com', 'password123');
+
+  const res = await testRequest('/api/projects', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${userToken}`,
+    },
+    body: JSON.stringify({
+      name: 'Tenant Project',
+      customer_name: 'My Customer',
+    }),
+  });
+
+  const data = await parseJSON(res);
+
+  assertEquals(res.status, 201);
+  assertEquals(data.data.tenant_id, tenantId);
+  assertExists(data.data.id);
+});
+
+// ──────────────────────────────────────────────
+// Tenant user only sees own tenant's projects
+// ──────────────────────────────────────────────
+
+Deno.test('Projects tenant - tenant user only sees own tenant projects', async () => {
+  clearDatabase();
+  const tenantA = createTenant('Tenant A');
+  const tenantB = createTenant('Tenant B');
+
+  // Create users in each tenant
+  createUser('userA@example.com', 'password123', tenantA, 'user');
+  createUser('userB@example.com', 'password123', tenantB, 'user');
+
+  const tokenA = await login('userA@example.com', 'password123');
+  const tokenB = await login('userB@example.com', 'password123');
+
+  // Create projects in each tenant
+  await testRequest('/api/projects', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${tokenA}`,
+    },
+    body: JSON.stringify({ name: 'Project A1', customer_name: 'Cust A1' }),
+  });
+  await testRequest('/api/projects', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${tokenA}`,
+    },
+    body: JSON.stringify({ name: 'Project A2', customer_name: 'Cust A2' }),
+  });
+  await testRequest('/api/projects', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${tokenB}`,
+    },
+    body: JSON.stringify({ name: 'Project B1', customer_name: 'Cust B1' }),
+  });
+
+  // User A should only see their 2 projects
+  const resA = await testRequest('/api/projects', {
+    headers: { 'Authorization': `Bearer ${tokenA}` },
+  });
+  const dataA = await parseJSON(resA);
+  assertEquals(resA.status, 200);
+  assertEquals(dataA.data.length, 2);
+  for (const project of dataA.data) {
+    assertEquals(project.tenant_id, tenantA);
+  }
+
+  // User B should only see their 1 project
+  const resB = await testRequest('/api/projects', {
+    headers: { 'Authorization': `Bearer ${tokenB}` },
+  });
+  const dataB = await parseJSON(resB);
+  assertEquals(resB.status, 200);
+  assertEquals(dataB.data.length, 1);
+  assertEquals(dataB.data[0].tenant_id, tenantB);
+});
+
+// ──────────────────────────────────────────────
+// Admin sees all projects
+// ──────────────────────────────────────────────
+
+Deno.test('Projects tenant - admin sees all projects across tenants', async () => {
+  clearDatabase();
+  const tenantA = createTenant('Tenant A');
+  const tenantB = createTenant('Tenant B');
+
+  // Create users
+  createUser('userA@example.com', 'password123', tenantA, 'user');
+  createUser('userB@example.com', 'password123', tenantB, 'user');
+  createUser('admin@example.com', 'password123', 1, 'admin');
+
+  const tokenA = await login('userA@example.com', 'password123');
+  const tokenB = await login('userB@example.com', 'password123');
+  const adminToken = await login('admin@example.com', 'password123');
+
+  // Create projects in different tenants
+  await testRequest('/api/projects', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${tokenA}`,
+    },
+    body: JSON.stringify({ name: 'Proj A', customer_name: 'Cust A' }),
+  });
+  await testRequest('/api/projects', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${tokenB}`,
+    },
+    body: JSON.stringify({ name: 'Proj B', customer_name: 'Cust B' }),
+  });
+
+  // Admin should see all projects
+  const res = await testRequest('/api/projects', {
+    headers: { 'Authorization': `Bearer ${adminToken}` },
+  });
+  const data = await parseJSON(res);
+
+  assertEquals(res.status, 200);
+  assertEquals(data.data.length >= 2, true);
+
+  // Verify projects from both tenants are present
+  const tenantIds = data.data.map((p: { tenant_id: number }) => p.tenant_id);
+  assertEquals(tenantIds.includes(tenantA), true);
+  assertEquals(tenantIds.includes(tenantB), true);
+});
+
+// ──────────────────────────────────────────────
+// User cannot delete projects (403)
+// ──────────────────────────────────────────────
+
+Deno.test('Projects tenant - user cannot delete projects (403)', async () => {
+  clearDatabase();
+  const tenantId = createTenant('Delete Tenant');
+  createUser('user@example.com', 'password123', tenantId, 'user');
+  const userToken = await login('user@example.com', 'password123');
+
+  // Create a project
+  const createRes = await testRequest('/api/projects', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${userToken}`,
+    },
+    body: JSON.stringify({ name: 'User Project', customer_name: 'Cust' }),
+  });
+  const createData = await parseJSON(createRes);
+  assertEquals(createRes.status, 201);
+  const projectId = createData.data.id;
+
+  // Attempt to delete — should be forbidden
+  const res = await testRequest(`/api/projects/${projectId}`, {
+    method: 'DELETE',
+    headers: { 'Authorization': `Bearer ${userToken}` },
+  });
+
+  assertEquals(res.status, 403);
+});
+
+// ──────────────────────────────────────────────
+// Tenant admin can delete projects
+// ──────────────────────────────────────────────
+
+Deno.test('Projects tenant - tenant admin can delete projects', async () => {
+  clearDatabase();
+  const tenantId = createTenant('TA Delete Tenant');
+  createUser('ta@example.com', 'password123', tenantId, 'tenant_admin');
+  const taToken = await login('ta@example.com', 'password123');
+
+  // Create a project
+  const createRes = await testRequest('/api/projects', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${taToken}`,
+    },
+    body: JSON.stringify({ name: 'TA Project', customer_name: 'Cust' }),
+  });
+  const createData = await parseJSON(createRes);
+  assertEquals(createRes.status, 201);
+  const projectId = createData.data.id;
+
+  // Delete — should succeed
+  const res = await testRequest(`/api/projects/${projectId}`, {
+    method: 'DELETE',
+    headers: { 'Authorization': `Bearer ${taToken}` },
+  });
+
+  assertEquals(res.status, 200);
+});
+
+// ──────────────────────────────────────────────
+// Admin can delete projects
+// ──────────────────────────────────────────────
+
+Deno.test('Projects tenant - admin can delete projects', async () => {
+  clearDatabase();
+  createUser('admin@example.com', 'password123', 1, 'admin');
+  const adminToken = await login('admin@example.com', 'password123');
+
+  // Create a project
+  const createRes = await testRequest('/api/projects', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${adminToken}`,
+    },
+    body: JSON.stringify({ name: 'Admin Project', customer_name: 'Cust' }),
+  });
+  const createData = await parseJSON(createRes);
+  assertEquals(createRes.status, 201);
+  const projectId = createData.data.id;
+
+  // Delete — should succeed
+  const res = await testRequest(`/api/projects/${projectId}`, {
+    method: 'DELETE',
+    headers: { 'Authorization': `Bearer ${adminToken}` },
+  });
+
+  assertEquals(res.status, 200);
+});
+
+// ──────────────────────────────────────────────
+// User cannot edit non-active projects (403)
+// ──────────────────────────────────────────────
+
+Deno.test('Projects tenant - user cannot edit non-active projects (403)', async () => {
+  clearDatabase();
+  const tenantId = createTenant('Status Tenant');
+  createUser('user@example.com', 'password123', tenantId, 'user');
+  const userToken = await login('user@example.com', 'password123');
+
+  // Create a project
+  const createRes = await testRequest('/api/projects', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${userToken}`,
+    },
+    body: JSON.stringify({ name: 'Soon Completed', customer_name: 'Cust' }),
+  });
+  const createData = await parseJSON(createRes);
+  assertEquals(createRes.status, 201);
+  const projectId = createData.data.id;
+
+  // Set status to 'completed' via direct SQL
+  const db = getDb();
+  db.query('UPDATE projects SET status = ? WHERE id = ?', ['completed', projectId]);
+
+  // Attempt to edit — should be forbidden
+  const res = await testRequest(`/api/projects/${projectId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${userToken}`,
+    },
+    body: JSON.stringify({ name: 'Renamed' }),
+  });
+
+  assertEquals(res.status, 403);
+});
+
+// ──────────────────────────────────────────────
+// User can edit active projects
+// ──────────────────────────────────────────────
+
+Deno.test('Projects tenant - user can edit active projects', async () => {
+  clearDatabase();
+  const tenantId = createTenant('Active Tenant');
+  createUser('user@example.com', 'password123', tenantId, 'user');
+  const userToken = await login('user@example.com', 'password123');
+
+  // Create a project (default status is 'active')
+  const createRes = await testRequest('/api/projects', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${userToken}`,
+    },
+    body: JSON.stringify({ name: 'Active Project', customer_name: 'Cust' }),
+  });
+  const createData = await parseJSON(createRes);
+  assertEquals(createRes.status, 201);
+  const projectId = createData.data.id;
+
+  // Edit — should succeed
+  const res = await testRequest(`/api/projects/${projectId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${userToken}`,
+    },
+    body: JSON.stringify({ name: 'Renamed Active' }),
+  });
+
+  const data = await parseJSON(res);
+  assertEquals(res.status, 200);
+  assertEquals(data.data.name, 'Renamed Active');
+});
+
+// ──────────────────────────────────────────────
+// Tenant admin can edit non-active projects
+// ──────────────────────────────────────────────
+
+Deno.test('Projects tenant - tenant admin can edit non-active projects', async () => {
+  clearDatabase();
+  const tenantId = createTenant('TA Status Tenant');
+  createUser('ta@example.com', 'password123', tenantId, 'tenant_admin');
+  const taToken = await login('ta@example.com', 'password123');
+
+  // Create a project
+  const createRes = await testRequest('/api/projects', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${taToken}`,
+    },
+    body: JSON.stringify({ name: 'Completed Project', customer_name: 'Cust' }),
+  });
+  const createData = await parseJSON(createRes);
+  assertEquals(createRes.status, 201);
+  const projectId = createData.data.id;
+
+  // Set status to 'completed' via direct SQL
+  const db = getDb();
+  db.query('UPDATE projects SET status = ? WHERE id = ?', ['completed', projectId]);
+
+  // Tenant admin edits completed project — should succeed
+  const res = await testRequest(`/api/projects/${projectId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${taToken}`,
+    },
+    body: JSON.stringify({ name: 'TA Renamed Completed' }),
+  });
+
+  const data = await parseJSON(res);
+  assertEquals(res.status, 200);
+  assertEquals(data.data.name, 'TA Renamed Completed');
+});

--- a/backend/tests/routes/projects_test.ts
+++ b/backend/tests/routes/projects_test.ts
@@ -18,7 +18,8 @@ async function getAuthToken(): Promise<string> {
   await userRepository.create({
     email: 'test@example.com',
     password_hash: passwordHash,
-    role: 'user',
+    role: 'tenant_admin',
+    tenant_id: 1,
   });
 
   // Login

--- a/backend/tests/routes/security_test.ts
+++ b/backend/tests/routes/security_test.ts
@@ -80,6 +80,7 @@ Deno.test('Security - X-Forwarded-For header is ignored when TRUSTED_PROXY is fa
     email: 'ratelimit@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   // Make requests with different X-Forwarded-For headers

--- a/backend/tests/routes/settings_test.ts
+++ b/backend/tests/routes/settings_test.ts
@@ -20,8 +20,9 @@ async function createUserAndToken(
     email,
     password_hash: hashPassword('password123'),
     role,
+    tenant_id: 1,
   });
-  const token = await generateToken(user.id, email, role);
+  const token = await generateToken(user.id, email, role, 1);
   return { token, userId: user.id };
 }
 

--- a/backend/tests/routes/tenants_test.ts
+++ b/backend/tests/routes/tenants_test.ts
@@ -1,0 +1,535 @@
+import { assertEquals, assertExists } from '@std/assert';
+import { Hono } from 'hono';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { getDb } from '../../src/config/database.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+import tenantRoutes from '../../src/routes/tenants.ts';
+
+const app = new Hono();
+app.route('/tenants', tenantRoutes);
+
+// Setup test database before all tests
+await setupTestDatabase();
+
+/** Helper: generate an admin token for tenant_id=1 */
+async function adminToken(userId = 1): Promise<string> {
+  return await generateToken(userId, 'admin@example.com', 'admin', 1);
+}
+
+/** Helper: generate a tenant_admin token */
+async function tenantAdminToken(userId = 50): Promise<string> {
+  return await generateToken(userId, 'tenantadmin@example.com', 'tenant_admin', 2);
+}
+
+/** Helper: generate a regular user token */
+async function userToken(userId = 60): Promise<string> {
+  return await generateToken(userId, 'user@example.com', 'user', 1);
+}
+
+/** Helper: make a request to the Hono app */
+async function request(
+  path: string,
+  options: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string | null;
+  } = {},
+): Promise<Response> {
+  const url = `http://localhost:8000${path}`;
+  const req = new Request(url, {
+    method: options.method || 'GET',
+    headers: options.headers || {},
+    body: options.body ?? null,
+  });
+  return await app.fetch(req);
+}
+
+/** Helper: create a partner tenant via direct SQL and return its id */
+function createPartnerTenant(name: string, isActive = 1): number {
+  const db = getDb();
+  db.query(
+    'INSERT INTO tenants (name, is_distributor, is_active) VALUES (?, 0, ?)',
+    [name, isActive],
+  );
+  const rows = db.queryEntries<{ id: number }>(
+    'SELECT id FROM tenants WHERE name = ?',
+    [name],
+  );
+  return rows[0].id;
+}
+
+/** Helper: create a user via direct SQL */
+function createUser(email: string, tenantId: number, role = 'user'): number {
+  const db = getDb();
+  db.query(
+    'INSERT INTO users (email, password_hash, role, tenant_id) VALUES (?, ?, ?, ?)',
+    [email, 'hash', role, tenantId],
+  );
+  const rows = db.queryEntries<{ id: number }>(
+    'SELECT id FROM users WHERE email = ?',
+    [email],
+  );
+  return rows[0].id;
+}
+
+/** Helper: create a project via direct SQL */
+function createProject(name: string, tenantId: number): number {
+  const db = getDb();
+  db.query(
+    'INSERT INTO projects (name, customer_name, tenant_id) VALUES (?, ?, ?)',
+    [name, 'Test Customer', tenantId],
+  );
+  const rows = db.queryEntries<{ id: number }>(
+    'SELECT id FROM projects WHERE name = ? AND tenant_id = ?',
+    [name, tenantId],
+  );
+  return rows[0].id;
+}
+
+// ──────────────────────────────────────────────
+// POST /tenants
+// ──────────────────────────────────────────────
+
+Deno.test('Tenants - admin can create a partner tenant', async () => {
+  clearDatabase();
+  const token = await adminToken();
+
+  const res = await request('/tenants', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name: 'Partner A' }),
+  });
+
+  const data = await res.json();
+
+  assertEquals(res.status, 201);
+  assertEquals(data.data.name, 'Partner A');
+  assertEquals(data.data.is_distributor, 0);
+  assertExists(data.data.id);
+});
+
+Deno.test('Tenants - admin can create a distributor tenant', async () => {
+  clearDatabase();
+  const token = await adminToken();
+
+  const res = await request('/tenants', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name: 'Distro Corp', is_distributor: 1 }),
+  });
+
+  const data = await res.json();
+
+  assertEquals(res.status, 201);
+  assertEquals(data.data.name, 'Distro Corp');
+  assertEquals(data.data.is_distributor, 1);
+});
+
+Deno.test('Tenants - rejects duplicate tenant name (409)', async () => {
+  clearDatabase();
+  const token = await adminToken();
+
+  // Create first tenant
+  await request('/tenants', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name: 'Unique Partner' }),
+  });
+
+  // Try to create duplicate
+  const res = await request('/tenants', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name: 'Unique Partner' }),
+  });
+
+  const data = await res.json();
+
+  assertEquals(res.status, 409);
+  assertEquals(data.error, 'A tenant with this name already exists');
+});
+
+Deno.test('Tenants - rejects empty name (400)', async () => {
+  clearDatabase();
+  const token = await adminToken();
+
+  const res = await request('/tenants', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name: '' }),
+  });
+
+  const data = await res.json();
+
+  assertEquals(res.status, 400);
+  assertEquals(data.error, 'Tenant name is required');
+});
+
+// ──────────────────────────────────────────────
+// GET /tenants
+// ──────────────────────────────────────────────
+
+Deno.test('Tenants - admin can list all tenants', async () => {
+  clearDatabase();
+  const token = await adminToken();
+
+  // Distributor already seeded as id=1 by clearDatabase()
+  createPartnerTenant('Partner X');
+  createPartnerTenant('Partner Y');
+
+  const res = await request('/tenants', {
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+
+  const data = await res.json();
+
+  assertEquals(res.status, 200);
+  assertEquals(Array.isArray(data.data), true);
+  // At least the distributor + 2 partners
+  assertEquals(data.data.length >= 3, true);
+});
+
+// ──────────────────────────────────────────────
+// GET /tenants/:id
+// ──────────────────────────────────────────────
+
+Deno.test('Tenants - admin can get single tenant', async () => {
+  clearDatabase();
+  const token = await adminToken();
+  const tenantId = createPartnerTenant('Solo Partner');
+
+  const res = await request(`/tenants/${tenantId}`, {
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+
+  const data = await res.json();
+
+  assertEquals(res.status, 200);
+  assertEquals(data.data.name, 'Solo Partner');
+  assertEquals(data.data.id, tenantId);
+});
+
+Deno.test('Tenants - returns 404 for non-existent tenant', async () => {
+  clearDatabase();
+  const token = await adminToken();
+
+  const res = await request('/tenants/99999', {
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+
+  const data = await res.json();
+
+  assertEquals(res.status, 404);
+  assertEquals(data.error, 'Tenant not found');
+});
+
+// ──────────────────────────────────────────────
+// PUT /tenants/:id
+// ──────────────────────────────────────────────
+
+Deno.test('Tenants - admin can update tenant name', async () => {
+  clearDatabase();
+  const token = await adminToken();
+  const tenantId = createPartnerTenant('Old Name');
+
+  const res = await request(`/tenants/${tenantId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name: 'New Name' }),
+  });
+
+  const data = await res.json();
+
+  assertEquals(res.status, 200);
+  assertEquals(data.data.name, 'New Name');
+});
+
+Deno.test('Tenants - admin can set is_active to 0', async () => {
+  clearDatabase();
+  const token = await adminToken();
+  const tenantId = createPartnerTenant('Deactivate Me');
+
+  const res = await request(`/tenants/${tenantId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ is_active: 0 }),
+  });
+
+  const data = await res.json();
+
+  assertEquals(res.status, 200);
+  assertEquals(data.data.is_active, 0);
+});
+
+// ──────────────────────────────────────────────
+// DELETE /tenants/:id
+// ──────────────────────────────────────────────
+
+Deno.test('Tenants - deletes tenant with no projects (hard delete)', async () => {
+  clearDatabase();
+  const token = await adminToken();
+  const tenantId = createPartnerTenant('Delete Me');
+
+  const res = await request(`/tenants/${tenantId}`, {
+    method: 'DELETE',
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+
+  const data = await res.json();
+
+  assertEquals(res.status, 200);
+  assertEquals(data.message, 'Tenant deleted successfully');
+
+  // Verify it is gone
+  const db = getDb();
+  const rows = db.queryEntries('SELECT * FROM tenants WHERE id = ?', [tenantId]);
+  assertEquals(rows.length, 0);
+});
+
+Deno.test('Tenants - rejects deleting tenant with projects', async () => {
+  clearDatabase();
+  const token = await adminToken();
+  const tenantId = createPartnerTenant('Has Projects');
+  createProject('Test Project', tenantId);
+
+  const res = await request(`/tenants/${tenantId}`, {
+    method: 'DELETE',
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+
+  const data = await res.json();
+
+  assertEquals(res.status, 400);
+  assertEquals(data.error.includes('Cannot delete tenant with'), true);
+});
+
+Deno.test('Tenants - rejects deleting distributor tenant (403)', async () => {
+  clearDatabase();
+  const token = await adminToken();
+
+  // Distributor tenant is seeded as id=1
+  const res = await request('/tenants/1', {
+    method: 'DELETE',
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+
+  const data = await res.json();
+
+  assertEquals(res.status, 403);
+  assertEquals(data.error, 'Cannot delete a distributor tenant');
+});
+
+Deno.test('Tenants - deleting tenant also deletes its users', async () => {
+  clearDatabase();
+  const token = await adminToken();
+  const tenantId = createPartnerTenant('Tenant With Users');
+
+  // Create users in that tenant
+  createUser('alice@partner.com', tenantId);
+  createUser('bob@partner.com', tenantId);
+
+  // Verify users exist
+  const db = getDb();
+  let users = db.queryEntries('SELECT * FROM users WHERE tenant_id = ?', [tenantId]);
+  assertEquals(users.length, 2);
+
+  // Delete the tenant
+  const res = await request(`/tenants/${tenantId}`, {
+    method: 'DELETE',
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+
+  assertEquals(res.status, 200);
+
+  // Verify users are gone
+  users = db.queryEntries('SELECT * FROM users WHERE tenant_id = ?', [tenantId]);
+  assertEquals(users.length, 0);
+});
+
+// ──────────────────────────────────────────────
+// Authorization: tenant_admin gets 403
+// ──────────────────────────────────────────────
+
+Deno.test('Tenants - tenant_admin role gets 403 on all routes', async () => {
+  clearDatabase();
+  const token = await tenantAdminToken();
+
+  const getAll = await request('/tenants', {
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+  assertEquals(getAll.status, 403);
+
+  const getOne = await request('/tenants/1', {
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+  assertEquals(getOne.status, 403);
+
+  const post = await request('/tenants', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name: 'Nope' }),
+  });
+  assertEquals(post.status, 403);
+
+  const put = await request('/tenants/1', {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name: 'Nope' }),
+  });
+  assertEquals(put.status, 403);
+
+  const del = await request('/tenants/1', {
+    method: 'DELETE',
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+  assertEquals(del.status, 403);
+});
+
+// ──────────────────────────────────────────────
+// Authorization: user role gets 403
+// ──────────────────────────────────────────────
+
+Deno.test('Tenants - user role gets 403 on all routes', async () => {
+  clearDatabase();
+  const token = await userToken();
+
+  const getAll = await request('/tenants', {
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+  assertEquals(getAll.status, 403);
+
+  const getOne = await request('/tenants/1', {
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+  assertEquals(getOne.status, 403);
+
+  const post = await request('/tenants', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name: 'Nope' }),
+  });
+  assertEquals(post.status, 403);
+
+  const put = await request('/tenants/1', {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name: 'Nope' }),
+  });
+  assertEquals(put.status, 403);
+
+  const del = await request('/tenants/1', {
+    method: 'DELETE',
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+  assertEquals(del.status, 403);
+});
+
+// ──────────────────────────────────────────────
+// PUT /tenants/:id — is_distributor flag
+// ──────────────────────────────────────────────
+
+Deno.test('Tenants - admin can change is_distributor flag', async () => {
+  clearDatabase();
+  const token = await adminToken();
+  const tenantId = createPartnerTenant('Promote Me');
+
+  // Verify it starts as a non-distributor
+  const before = await request(`/tenants/${tenantId}`, {
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+  const beforeData = await before.json();
+  assertEquals(beforeData.data.is_distributor, 0);
+
+  // Set is_distributor to 1
+  const res = await request(`/tenants/${tenantId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ is_distributor: 1 }),
+  });
+
+  const data = await res.json();
+
+  assertEquals(res.status, 200);
+  assertEquals(data.data.is_distributor, 1);
+});
+
+// ──────────────────────────────────────────────
+// PUT /tenants/:id — is_active flag
+// ──────────────────────────────────────────────
+
+Deno.test('Tenants - admin can change is_active flag from 1 to 0 and back', async () => {
+  clearDatabase();
+  const token = await adminToken();
+  const tenantId = createPartnerTenant('Toggle Active');
+
+  // Starts active (is_active = 1)
+  const before = await request(`/tenants/${tenantId}`, {
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+  const beforeData = await before.json();
+  assertEquals(beforeData.data.is_active, 1);
+
+  // Deactivate
+  const deactivateRes = await request(`/tenants/${tenantId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ is_active: 0 }),
+  });
+  const deactivateData = await deactivateRes.json();
+
+  assertEquals(deactivateRes.status, 200);
+  assertEquals(deactivateData.data.is_active, 0);
+
+  // Re-activate
+  const reactivateRes = await request(`/tenants/${tenantId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ is_active: 1 }),
+  });
+  const reactivateData = await reactivateRes.json();
+
+  assertEquals(reactivateRes.status, 200);
+  assertEquals(reactivateData.data.is_active, 1);
+});

--- a/backend/tests/routes/users_tenant_test.ts
+++ b/backend/tests/routes/users_tenant_test.ts
@@ -1,0 +1,168 @@
+import { assertEquals } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { testRequest, parseJSON } from '../test-client.ts';
+import { getDb } from '../../src/config/database.ts';
+import { hashPassword } from '../../src/services/password.ts';
+
+// Setup test database before all tests
+await setupTestDatabase();
+
+/** Helper: create a partner tenant via direct SQL and return its id */
+function createTenant(name: string, isActive = 1): number {
+  const db = getDb();
+  db.query(
+    'INSERT INTO tenants (name, is_distributor, is_active) VALUES (?, 0, ?)',
+    [name, isActive],
+  );
+  const rows = db.queryEntries<{ id: number }>(
+    'SELECT id FROM tenants WHERE name = ?',
+    [name],
+  );
+  return rows[0].id;
+}
+
+/** Helper: create a user with a known password via direct SQL */
+function createUser(
+  email: string,
+  password: string,
+  tenantId: number,
+  role = 'user',
+): number {
+  const db = getDb();
+  const hash = hashPassword(password);
+  db.query(
+    'INSERT INTO users (email, password_hash, role, tenant_id) VALUES (?, ?, ?, ?)',
+    [email, hash, role, tenantId],
+  );
+  const rows = db.queryEntries<{ id: number }>(
+    'SELECT id FROM users WHERE email = ?',
+    [email],
+  );
+  return rows[0].id;
+}
+
+/** Helper: login and return the access token */
+async function login(email: string, password: string): Promise<string> {
+  const res = await testRequest('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  const data = await parseJSON(res);
+  return data.data.accessToken;
+}
+
+// ──────────────────────────────────────────────
+// Deactivating users
+// ──────────────────────────────────────────────
+
+Deno.test('Users tenant - cannot deactivate admin users (403)', async () => {
+  clearDatabase();
+  // Create an admin user who will be the caller
+  createUser('caller-admin@example.com', 'password123', 1, 'admin');
+  const callerToken = await login('caller-admin@example.com', 'password123');
+
+  // Create another admin user to attempt deactivation on
+  const targetId = createUser('target-admin@example.com', 'password123', 1, 'admin');
+
+  const res = await testRequest(`/api/users/${targetId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${callerToken}`,
+    },
+    body: JSON.stringify({ is_active: 0 }),
+  });
+
+  const data = await parseJSON(res);
+
+  assertEquals(res.status, 403);
+  assertEquals(data.error, 'Cannot deactivate admin users');
+});
+
+Deno.test('Users tenant - can deactivate tenant_admin users (200)', async () => {
+  clearDatabase();
+  // Create admin caller
+  createUser('admin@example.com', 'password123', 1, 'admin');
+  const adminToken = await login('admin@example.com', 'password123');
+
+  // Create a tenant_admin user in a partner tenant
+  const tenantId = createTenant('Partner Corp');
+  const tenantAdminId = createUser('ta@example.com', 'password123', tenantId, 'tenant_admin');
+
+  const res = await testRequest(`/api/users/${tenantAdminId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${adminToken}`,
+    },
+    body: JSON.stringify({ is_active: 0 }),
+  });
+
+  const data = await parseJSON(res);
+
+  assertEquals(res.status, 200);
+  assertEquals(data.data.is_active, 0);
+});
+
+// ──────────────────────────────────────────────
+// Changing user tenant_id
+// ──────────────────────────────────────────────
+
+Deno.test('Users tenant - admin can change user tenant_id', async () => {
+  clearDatabase();
+  // Create admin
+  createUser('admin@example.com', 'password123', 1, 'admin');
+  const adminToken = await login('admin@example.com', 'password123');
+
+  // Create two tenants and a user in the first
+  const tenantA = createTenant('Tenant A');
+  const tenantB = createTenant('Tenant B');
+  const userId = createUser('moveme@example.com', 'password123', tenantA, 'user');
+
+  const res = await testRequest(`/api/users/${userId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${adminToken}`,
+    },
+    body: JSON.stringify({ tenant_id: tenantB }),
+  });
+
+  const data = await parseJSON(res);
+
+  assertEquals(res.status, 200);
+  assertEquals(data.data.tenant_id, tenantB);
+});
+
+Deno.test('Users tenant - tenant admin cannot change user tenant_id (ignored)', async () => {
+  clearDatabase();
+  // Create a partner tenant with a tenant_admin
+  const tenantId = createTenant('My Tenant');
+  createUser('ta@example.com', 'password123', tenantId, 'tenant_admin');
+  const taToken = await login('ta@example.com', 'password123');
+
+  // Create a regular user in the same tenant
+  const userId = createUser('regular@example.com', 'password123', tenantId, 'user');
+
+  // Create another tenant to try moving to
+  const otherTenant = createTenant('Other Tenant');
+
+  // Attempt to change tenant_id — should be ignored by backend
+  const res = await testRequest(`/api/users/${userId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${taToken}`,
+    },
+    body: JSON.stringify({ tenant_id: otherTenant, full_name: 'Updated Name' }),
+  });
+
+  const data = await parseJSON(res);
+
+  assertEquals(res.status, 200);
+  // tenant_id should remain the original tenant
+  assertEquals(data.data.tenant_id, tenantId);
+  // But other fields should still update
+  assertEquals(data.data.full_name, 'Updated Name');
+});

--- a/backend/tests/routes/users_test.ts
+++ b/backend/tests/routes/users_test.ts
@@ -18,6 +18,7 @@ async function getAdminToken(): Promise<string> {
     email: 'admin@example.com',
     password_hash: passwordHash,
     role: 'admin',
+    tenant_id: 1,
   });
 
   // Login as admin
@@ -43,6 +44,7 @@ async function getUserToken(): Promise<string> {
     email: 'user@example.com',
     password_hash: passwordHash,
     role: 'user',
+    tenant_id: 1,
   });
 
   // Login as user
@@ -209,6 +211,7 @@ Deno.test('User management - cannot delete yourself', async () => {
     email: 'selfdelete@example.com',
     password_hash: passwordHash,
     role: 'admin',
+    tenant_id: 1,
   });
 
   const loginResponse = await testRequest('/api/auth/login', {

--- a/backend/tests/services/bom-image-migration_test.ts
+++ b/backend/tests/services/bom-image-migration_test.ts
@@ -22,6 +22,7 @@ Deno.test('BOM Image Migration - runs automatically and is idempotent', async (t
     customer_name: 'Test Customer',
     customer_address: '123 Test St',
     status: 'active',
+    tenant_id: 1,
   });
 
   const floorplan = await floorplanRepository.create({

--- a/backend/tests/services/bom_test.ts
+++ b/backend/tests/services/bom_test.ts
@@ -25,6 +25,7 @@ Deno.test('BOM Service - createBomEntry adds required addons', async (t) => {
     customer_name: 'Test Customer',
     customer_address: '123 Test St',
     status: 'active',
+    tenant_id: 1,
   });
 
   const floorplan = await floorplanRepository.create({
@@ -107,6 +108,7 @@ Deno.test('BOM Service - createBomEntry adds required addons', async (t) => {
       customer_name: 'Test Customer',
       customer_address: '123 Test St',
       status: 'active',
+      tenant_id: 1,
     });
 
     const floorplan2 = await floorplanRepository.create({
@@ -181,6 +183,7 @@ Deno.test('BOM Service - recreateBomEntry with addons', async (t) => {
     customer_name: 'Test Customer',
     customer_address: '123 Test St',
     status: 'active',
+    tenant_id: 1,
   });
 
   const floorplan = await floorplanRepository.create({
@@ -271,6 +274,7 @@ Deno.test('BOM Service - createBomEntry handles image copying', async (t) => {
     customer_name: 'Test Customer',
     customer_address: '123 Test St',
     status: 'active',
+    tenant_id: 1,
   });
 
   const floorplan = await floorplanRepository.create({
@@ -420,6 +424,7 @@ Deno.test('BOM Service - recreateBomEntry copies new images', async (t) => {
     customer_name: 'Test Customer',
     customer_address: '123 Test St',
     status: 'active',
+    tenant_id: 1,
   });
 
   const floorplan = await floorplanRepository.create({
@@ -517,6 +522,7 @@ Deno.test('BOM Service - switchVariant copies new variant image', async (t) => {
     customer_name: 'Test Customer',
     customer_address: '123 Test St',
     status: 'active',
+    tenant_id: 1,
   });
 
   const floorplan = await floorplanRepository.create({
@@ -596,6 +602,7 @@ Deno.test('BOM Service - deleteBomEntry cleans up images', async (t) => {
     customer_name: 'Test Customer',
     customer_address: '123 Test St',
     status: 'active',
+    tenant_id: 1,
   });
 
   const floorplan = await floorplanRepository.create({

--- a/backend/tests/services/jwt_test.ts
+++ b/backend/tests/services/jwt_test.ts
@@ -7,7 +7,7 @@ await setupTestDatabase();
 Deno.test('JWT service - generateToken returns a non-empty string', async () => {
   clearDatabase();
 
-  const token = await generateToken(1, 'test@example.com', 'user');
+  const token = await generateToken(1, 'test@example.com', 'user', 1);
 
   assertExists(token);
   assertEquals(typeof token, 'string');
@@ -24,7 +24,7 @@ Deno.test('JWT service - verifyToken returns correct payload', async () => {
   const email = 'payload@example.com';
   const role = 'admin' as const;
 
-  const token = await generateToken(userId, email, role);
+  const token = await generateToken(userId, email, role, 1);
   const payload = await verifyToken(token);
 
   assertEquals(payload.sub, userId.toString());
@@ -39,7 +39,7 @@ Deno.test('JWT service - verifyToken returns correct payload', async () => {
 Deno.test('JWT service - verifyToken works for user role', async () => {
   clearDatabase();
 
-  const token = await generateToken(7, 'user@example.com', 'user');
+  const token = await generateToken(7, 'user@example.com', 'user', 1);
   const payload = await verifyToken(token);
 
   assertEquals(payload.sub, '7');
@@ -59,7 +59,7 @@ Deno.test('JWT service - verifyToken rejects an invalid token', async () => {
 Deno.test('JWT service - verifyToken rejects a token with tampered payload', async () => {
   clearDatabase();
 
-  const token = await generateToken(1, 'tamper@example.com', 'user');
+  const token = await generateToken(1, 'tamper@example.com', 'user', 1);
   // Replace the payload segment with a different base64 string
   const parts = token.split('.');
   const fakePayload = btoa(JSON.stringify({ sub: '999', email: 'hacker@evil.com', role: 'admin' }))

--- a/backend/tests/services/refresh-token_test.ts
+++ b/backend/tests/services/refresh-token_test.ts
@@ -24,6 +24,7 @@ async function createTestUser(email: string): Promise<number> {
     email,
     password_hash: hashPassword('testpass'),
     role: 'user',
+    tenant_id: 1,
   });
   return user.id;
 }

--- a/backend/tests/test-utils.ts
+++ b/backend/tests/test-utils.ts
@@ -120,6 +120,11 @@ export function clearDatabase(): void {
   
   // Re-enable foreign key checks
   dbInstance.query('PRAGMA foreign_keys = ON');
+
+  // Re-seed the distributor tenant (required for foreign key references)
+  dbInstance.query(
+    "INSERT INTO tenants (id, name, is_distributor, is_active) VALUES (1, 'Distributor', 1, 1)"
+  );
 }
 
 /**

--- a/deno.lock
+++ b/deno.lock
@@ -302,6 +302,17 @@
       ]
     }
   },
+  "remote": {
+    "https://deno.land/x/sqlite@v3.9.1/build/sqlite.js": "2afc7875c7b9c85d89730c4a311ab3a304e5d1bf761fbadd8c07bbdf130f5f9b",
+    "https://deno.land/x/sqlite@v3.9.1/build/vfs.js": "7f7778a9fe499cd10738d6e43867340b50b67d3e39142b0065acd51a84cd2e03",
+    "https://deno.land/x/sqlite@v3.9.1/mod.ts": "e09fc79d8065fe222578114b109b1fd60077bff1bb75448532077f784f4d6a83",
+    "https://deno.land/x/sqlite@v3.9.1/src/constants.ts": "90f3be047ec0a89bcb5d6fc30db121685fc82cb00b1c476124ff47a4b0472aa9",
+    "https://deno.land/x/sqlite@v3.9.1/src/db.ts": "03d0c860957496eadedd86e51a6e650670764630e64f56df0092e86c90752401",
+    "https://deno.land/x/sqlite@v3.9.1/src/error.ts": "f7a15cb00d7c3797da1aefee3cf86d23e0ae92e73f0ba3165496c3816ab9503a",
+    "https://deno.land/x/sqlite@v3.9.1/src/function.ts": "bc778cab7a6d771f690afa27264c524d22fcb96f1bb61959ade7922c15a4ab8d",
+    "https://deno.land/x/sqlite@v3.9.1/src/query.ts": "d58abda928f6582d77bad685ecf551b1be8a15e8e38403e293ec38522e030cad",
+    "https://deno.land/x/sqlite@v3.9.1/src/wasm.ts": "e79d0baa6e42423257fb3c7cc98091c54399254867e0f34a09b5bdef37bd9487"
+  },
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@0.208"

--- a/docs/superpowers/plans/2026-03-26-multi-tenancy.md
+++ b/docs/superpowers/plans/2026-03-26-multi-tenancy.md
@@ -1,0 +1,2342 @@
+# Multi-Tenancy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add multi-tenancy with distributor/partner isolation so partner companies get their own users and projects while sharing a centrally-managed catalog.
+
+**Architecture:** Row-level tenant isolation enforced in `BaseRepository`. A `tenants` table tracks companies. `users` and `projects` gain a `tenant_id` column. The `distributor` role bypasses tenant filtering for cross-tenant oversight. Catalog tables remain shared and unscoped.
+
+**Tech Stack:** Deno + Hono + SQLite (backend), React 18 + TypeScript + Vite + shadcn/ui (frontend)
+
+**Spec:** `docs/superpowers/specs/2026-03-26-multi-tenancy-design.md`
+
+---
+
+## File Structure
+
+### New Files
+- `backend/src/repositories/tenant.ts` — Tenant CRUD repository
+- `backend/src/routes/tenants.ts` — Tenant management API routes
+- `backend/tests/routes/tenants_test.ts` — Tenant route tests
+- `backend/tests/middleware/auth_test_tenancy.ts` — Middleware tenancy tests
+- `frontend/src/services/tenants.ts` — Tenant API service
+- `frontend/src/pages/settings/TenantManagement.tsx` — Tenant admin page
+- `frontend/src/components/settings/TenantFormModal.tsx` — Create/edit tenant modal
+- `frontend/src/components/layout/TenantSwitcher.tsx` — Distributor tenant switcher dropdown
+
+### Modified Files
+- `backend/src/scripts/migrate.ts` — Add migration 031
+- `backend/src/models/index.ts` — Add Tenant types, update User/role types
+- `backend/src/repositories/base.ts` — Add tenant-scoped filtering
+- `backend/src/repositories/user.ts` — Add tenant_id to queries
+- `backend/src/repositories/project.ts` — Add tenant_id to queries
+- `backend/src/middleware/auth.ts` — Add tenantId to context, add distributorMiddleware, update adminMiddleware
+- `backend/src/services/jwt.ts` — Add tenantId to JWT payload
+- `backend/src/routes/auth.ts` — Include tenantId in login response
+- `backend/src/routes/users.ts` — Add tenant filtering, allow distributor cross-tenant
+- `backend/src/routes/projects.ts` — Add tenant filtering
+- `backend/src/routes/items.ts` — Replace adminMiddleware with distributorMiddleware on write routes
+- `backend/src/routes/categories.ts` — Replace adminMiddleware with distributorMiddleware on write routes
+- `backend/src/main.ts` — Mount tenant routes
+- `backend/tests/test-utils.ts` — Update seed data for tenancy
+- `frontend/src/context/AuthContext.tsx` — Add tenantId, tenantName to user type
+- `frontend/src/services/auth.ts` — Handle tenantId in login response
+- `frontend/src/components/auth/ProtectedRoute.tsx` — Add distributor role check
+- `frontend/src/components/layout/Header.tsx` — Add tenant switcher, conditional nav
+- `frontend/src/App.tsx` — Add tenant routes, update admin routing
+- `frontend/src/pages/projects/ProjectList.tsx` — Add tenant column for distributor
+- `frontend/src/pages/settings/UserManagement.tsx` — Add tenant filter for distributor
+
+---
+
+## Task 1: Database Migration
+
+**Files:**
+- Modify: `backend/src/scripts/migrate.ts`
+
+- [ ] **Step 1: Write migration 031_multi_tenancy**
+
+Add this migration to the `migrations` array in `backend/src/scripts/migrate.ts`, after migration 030:
+
+```typescript
+{
+  id: 31,
+  name: '031_multi_tenancy',
+  sql: `
+    -- Create tenants table
+    CREATE TABLE IF NOT EXISTS tenants (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      is_distributor INTEGER NOT NULL DEFAULT 0,
+      is_active INTEGER NOT NULL DEFAULT 1,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_tenants_name ON tenants(name);
+
+    -- Seed the distributor tenant
+    INSERT INTO tenants (id, name, is_distributor, is_active)
+    VALUES (1, 'Distributor', 1, 1);
+
+    -- Add tenant_id to users (default 1 = distributor for existing users)
+    ALTER TABLE users ADD COLUMN tenant_id INTEGER NOT NULL DEFAULT 1 REFERENCES tenants(id);
+    CREATE INDEX IF NOT EXISTS idx_users_tenant ON users(tenant_id);
+
+    -- Update role check constraint: SQLite doesn't support ALTER CHECK,
+    -- but the CHECK was defined as TEXT CHECK(role IN (...)).
+    -- We handle this by updating existing admin users to 'distributor'.
+    -- New role values are enforced at the application layer.
+    UPDATE users SET role = 'distributor' WHERE role = 'admin';
+
+    -- Add tenant_id to projects (default 1 = distributor for existing projects)
+    ALTER TABLE projects ADD COLUMN tenant_id INTEGER NOT NULL DEFAULT 1 REFERENCES tenants(id);
+    CREATE INDEX IF NOT EXISTS idx_projects_tenant ON projects(tenant_id);
+
+    -- Recreate unique index to include tenant_id
+    DROP INDEX IF EXISTS idx_projects_unique_name_customer;
+    CREATE UNIQUE INDEX idx_projects_unique_name_customer ON projects(name, customer_name, tenant_id);
+  `,
+},
+```
+
+- [ ] **Step 2: Run migration**
+
+```bash
+cd backend && deno task migrate
+```
+
+Expected: Migration 031 applied successfully. No errors.
+
+- [ ] **Step 3: Verify migration**
+
+```bash
+cd backend && deno eval "
+import { Database } from 'https://deno.land/x/sqlite3@0.12.0/mod.ts';
+const db = new Database('snapflow.db');
+console.log('tenants:', db.prepare('SELECT * FROM tenants').all());
+console.log('users tenant_id:', db.prepare('SELECT id, email, role, tenant_id FROM users').all());
+console.log('projects tenant_id:', db.prepare('SELECT id, name, tenant_id FROM projects LIMIT 3').all());
+db.close();
+"
+```
+
+Expected: Tenants table has 1 row (Distributor). All users have `tenant_id=1` and `role='distributor'` (previously admin). All projects have `tenant_id=1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/scripts/migrate.ts
+git commit -m "feat: add migration 031 — tenants table, tenant_id on users/projects"
+```
+
+---
+
+## Task 2: Type Definitions
+
+**Files:**
+- Modify: `backend/src/models/index.ts`
+
+- [ ] **Step 1: Add Tenant types and update User role type**
+
+In `backend/src/models/index.ts`, add at the top of the file (after imports, before the User interface):
+
+```typescript
+// === Tenants ===
+
+export type UserRole = 'distributor' | 'admin' | 'user';
+
+export interface Tenant {
+  id: number;
+  name: string;
+  is_distributor: number; // SQLite boolean: 0 or 1
+  is_active: number;      // SQLite boolean: 0 or 1
+  created_at: string;
+}
+
+export interface CreateTenantDTO {
+  name: string;
+}
+
+export interface UpdateTenantDTO {
+  name?: string;
+  is_active?: number;
+}
+```
+
+Then update the existing `User` interface — add `tenant_id` field and change `role`:
+
+```typescript
+export interface User {
+  id: number;
+  email: string;
+  full_name: string | null;
+  password_hash: string;
+  role: UserRole;
+  tenant_id: number;
+  created_at: string;
+}
+```
+
+Update `CreateUserDTO` — add `tenant_id`:
+
+```typescript
+export interface CreateUserDTO {
+  email: string;
+  full_name?: string;
+  password?: string;
+  password_hash?: string;
+  role?: UserRole;
+  tenant_id: number;
+}
+```
+
+Update `UpdateUserDTO` — add optional `tenant_id`:
+
+```typescript
+export interface UpdateUserDTO {
+  email?: string;
+  full_name?: string;
+  password?: string;
+  password_hash?: string;
+  role?: UserRole;
+  tenant_id?: number;
+}
+```
+
+- [ ] **Step 2: Verify types compile**
+
+```bash
+cd backend && deno check src/models/index.ts
+```
+
+Expected: No type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/models/index.ts
+git commit -m "feat: add Tenant types, add tenant_id to User, update role to distributor/admin/user"
+```
+
+---
+
+## Task 3: JWT Service — Add tenantId
+
+**Files:**
+- Modify: `backend/src/services/jwt.ts`
+- Test: `backend/tests/services/jwt_test.ts` (existing)
+
+- [ ] **Step 1: Write test for tenantId in JWT**
+
+Add a test to `backend/tests/services/jwt_test.ts`:
+
+```typescript
+Deno.test('JWT - should include tenantId in token payload', async () => {
+  const token = await generateToken(1, 'test@test.com', 'distributor', 1);
+  const payload = await verifyToken(token);
+  assertEquals(payload.tenantId, 1);
+  assertEquals(payload.role, 'distributor');
+});
+
+Deno.test('JWT - should include tenantId for partner user', async () => {
+  const token = await generateToken(5, 'partner@co.com', 'admin', 3);
+  const payload = await verifyToken(token);
+  assertEquals(payload.tenantId, 3);
+  assertEquals(payload.role, 'admin');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && deno test --allow-all tests/services/jwt_test.ts
+```
+
+Expected: FAIL — `generateToken` doesn't accept 4 arguments yet.
+
+- [ ] **Step 3: Update jwt.ts to include tenantId**
+
+In `backend/src/services/jwt.ts`:
+
+Update the `JWTPayload` interface:
+
+```typescript
+export interface JWTPayload {
+  sub: string;
+  email: string;
+  role: 'distributor' | 'admin' | 'user';
+  tenantId: number;
+  exp: number;
+  iat: number;
+}
+```
+
+Update the `generateToken` function signature and payload:
+
+```typescript
+export async function generateToken(
+  userId: number,
+  email: string,
+  role: 'distributor' | 'admin' | 'user',
+  tenantId: number
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    sub: userId.toString(),
+    email,
+    role,
+    tenantId,
+    exp: now + ACCESS_TOKEN_EXPIRY,
+    iat: now,
+  };
+```
+
+- [ ] **Step 4: Fix all existing callers of generateToken**
+
+Search for all callers of `generateToken` and add the `tenantId` parameter. The main caller is in `backend/src/routes/auth.ts` — the login and refresh routes. Update them:
+
+In `backend/src/routes/auth.ts`, find the `generateToken` call in the login route and add the user's `tenant_id`:
+
+```typescript
+const accessToken = await generateToken(user.id, user.email, user.role, user.tenant_id);
+```
+
+Do the same for the refresh route's `generateToken` call:
+
+```typescript
+const accessToken = await generateToken(user.id, user.email, user.role, user.tenant_id);
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd backend && deno test --allow-all tests/services/jwt_test.ts
+```
+
+Expected: All JWT tests pass, including the new tenantId tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/services/jwt.ts backend/src/routes/auth.ts backend/tests/services/jwt_test.ts
+git commit -m "feat: add tenantId to JWT payload and generateToken"
+```
+
+---
+
+## Task 4: Auth Middleware — tenantId Context & distributorMiddleware
+
+**Files:**
+- Modify: `backend/src/middleware/auth.ts`
+- Create: `backend/tests/middleware/auth_test_tenancy.ts`
+
+- [ ] **Step 1: Write tests for middleware changes**
+
+Create `backend/tests/middleware/auth_test_tenancy.ts`:
+
+```typescript
+import { assertEquals } from 'https://deno.land/std/assert/mod.ts';
+import { Hono } from 'hono';
+import { authMiddleware, adminMiddleware, distributorMiddleware } from '../../src/middleware/auth.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+
+// Helper to create a test app with a protected route
+function createTestApp(middleware: Function[]) {
+  const app = new Hono();
+  for (const mw of middleware) {
+    app.use('/*', mw as any);
+  }
+  app.get('/test', (c) => {
+    return c.json({
+      userId: c.get('userId'),
+      userRole: c.get('userRole'),
+      tenantId: c.get('tenantId'),
+    });
+  });
+  return app;
+}
+
+Deno.test('authMiddleware - should set tenantId on context', async () => {
+  const app = createTestApp([authMiddleware]);
+  const token = await generateToken(1, 'admin@dist.com', 'distributor', 1);
+  const res = await app.request('/test', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.tenantId, 1);
+  assertEquals(body.userRole, 'distributor');
+});
+
+Deno.test('authMiddleware - should set partner tenantId on context', async () => {
+  const app = createTestApp([authMiddleware]);
+  const token = await generateToken(5, 'user@partner.com', 'user', 3);
+  const res = await app.request('/test', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.tenantId, 3);
+  assertEquals(body.userRole, 'user');
+});
+
+Deno.test('distributorMiddleware - should allow distributor role', async () => {
+  const app = createTestApp([authMiddleware, distributorMiddleware]);
+  const token = await generateToken(1, 'admin@dist.com', 'distributor', 1);
+  const res = await app.request('/test', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(res.status, 200);
+});
+
+Deno.test('distributorMiddleware - should reject admin role', async () => {
+  const app = createTestApp([authMiddleware, distributorMiddleware]);
+  const token = await generateToken(2, 'admin@partner.com', 'admin', 2);
+  const res = await app.request('/test', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(res.status, 403);
+});
+
+Deno.test('distributorMiddleware - should reject user role', async () => {
+  const app = createTestApp([authMiddleware, distributorMiddleware]);
+  const token = await generateToken(3, 'user@partner.com', 'user', 2);
+  const res = await app.request('/test', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(res.status, 403);
+});
+
+Deno.test('adminMiddleware - should allow distributor role', async () => {
+  const app = createTestApp([authMiddleware, adminMiddleware]);
+  const token = await generateToken(1, 'admin@dist.com', 'distributor', 1);
+  const res = await app.request('/test', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(res.status, 200);
+});
+
+Deno.test('adminMiddleware - should allow admin role', async () => {
+  const app = createTestApp([authMiddleware, adminMiddleware]);
+  const token = await generateToken(2, 'admin@partner.com', 'admin', 2);
+  const res = await app.request('/test', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(res.status, 200);
+});
+
+Deno.test('adminMiddleware - should reject user role', async () => {
+  const app = createTestApp([authMiddleware, adminMiddleware]);
+  const token = await generateToken(3, 'user@partner.com', 'user', 2);
+  const res = await app.request('/test', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(res.status, 403);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd backend && deno test --allow-all tests/middleware/auth_test_tenancy.ts
+```
+
+Expected: FAIL — `distributorMiddleware` doesn't exist, `tenantId` not set on context.
+
+- [ ] **Step 3: Update auth middleware**
+
+Replace `backend/src/middleware/auth.ts`:
+
+```typescript
+import type { Context, Next } from 'hono';
+import { verifyToken } from '../services/jwt.ts';
+
+/**
+ * Auth middleware - verifies JWT token from Authorization header
+ * Sets userId, userEmail, userRole, tenantId on Hono context
+ */
+export async function authMiddleware(c: Context, next: Next): Promise<Response | void> {
+  const authHeader = c.req.header('Authorization');
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return c.json({ error: 'Unauthorized - No token provided' }, 401);
+  }
+
+  const token = authHeader.substring(7);
+
+  try {
+    const payload = await verifyToken(token);
+
+    c.set('userId', parseInt(payload.sub));
+    c.set('userEmail', payload.email);
+    c.set('userRole', payload.role);
+    c.set('tenantId', payload.tenantId);
+
+    await next();
+  } catch (_error) {
+    return c.json({ error: 'Unauthorized - Invalid token' }, 401);
+  }
+}
+
+/**
+ * Admin middleware - checks if user has admin or distributor role
+ * Must be used after authMiddleware
+ */
+export async function adminMiddleware(c: Context, next: Next): Promise<Response | void> {
+  const userRole = c.get('userRole');
+
+  if (userRole !== 'admin' && userRole !== 'distributor') {
+    return c.json({ error: 'Forbidden - Admin access required' }, 403);
+  }
+
+  await next();
+}
+
+/**
+ * Distributor middleware - checks if user has distributor role
+ * Must be used after authMiddleware
+ */
+export async function distributorMiddleware(c: Context, next: Next): Promise<Response | void> {
+  const userRole = c.get('userRole');
+
+  if (userRole !== 'distributor') {
+    return c.json({ error: 'Forbidden - Distributor access required' }, 403);
+  }
+
+  await next();
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd backend && deno test --allow-all tests/middleware/auth_test_tenancy.ts
+```
+
+Expected: All 8 tests pass.
+
+- [ ] **Step 5: Run full backend tests to check nothing broke**
+
+```bash
+cd backend && deno task test
+```
+
+Expected: All existing tests pass. Some tests that relied on `role === 'admin'` may need updating since existing admin users are now `distributor`. Fix any failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/middleware/auth.ts backend/tests/middleware/auth_test_tenancy.ts
+git commit -m "feat: add tenantId to auth context, add distributorMiddleware, update adminMiddleware"
+```
+
+---
+
+## Task 5: Update Test Utilities
+
+**Files:**
+- Modify: `backend/tests/test-utils.ts`
+
+- [ ] **Step 1: Update test-utils to seed tenants table**
+
+In `backend/tests/test-utils.ts`, update `clearDatabase()` to also clear the `tenants` table, and ensure setup seeds it. Add `tenants` to the list of tables cleared:
+
+```typescript
+// In clearDatabase(), add 'tenants' to the DELETE list, BEFORE users/projects (foreign key order)
+db.exec('DELETE FROM tenants');
+```
+
+Also add a re-seed of the distributor tenant after clearing:
+
+```typescript
+// After all DELETE statements, re-seed the distributor tenant
+db.exec("INSERT INTO tenants (id, name, is_distributor, is_active) VALUES (1, 'Distributor', 1, 1)");
+```
+
+- [ ] **Step 2: Update any test helpers that create users**
+
+Find test helpers or test files that call `INSERT INTO users` or `userRepository.create()` and ensure they include `tenant_id: 1` in the data. Check:
+- `backend/tests/routes/users_test.ts`
+- `backend/tests/routes/auth_test.ts`
+- Any test that registers/creates test users
+
+For direct SQL inserts, add `tenant_id` column:
+```sql
+INSERT INTO users (email, password_hash, role, tenant_id) VALUES (?, ?, 'distributor', 1)
+```
+
+For repository calls, add `tenant_id: 1` to the DTO.
+
+- [ ] **Step 3: Update test user roles from 'admin' to 'distributor'**
+
+In all test files, replace `role: 'admin'` with `role: 'distributor'` for test users that need admin-level access. Search for `role.*admin` in test files and update.
+
+- [ ] **Step 4: Run all backend tests**
+
+```bash
+cd backend && deno task test
+```
+
+Expected: All tests pass with the updated test utilities.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tests/
+git commit -m "fix: update test utilities and test data for multi-tenancy"
+```
+
+---
+
+## Task 6: BaseRepository — Tenant-Scoped Queries
+
+**Files:**
+- Modify: `backend/src/repositories/base.ts`
+
+- [ ] **Step 1: Write tests for tenant-scoped repository**
+
+Create `backend/tests/repositories/base_tenant_test.ts`:
+
+```typescript
+import { assertEquals } from 'https://deno.land/std/assert/mod.ts';
+import { setupTestDatabase, clearDatabase, teardownTestDatabase } from '../test-utils.ts';
+import { BaseRepository } from '../../src/repositories/base.ts';
+import { getDb } from '../../src/config/database.ts';
+
+// Concrete test repository
+class TestTenantRepo extends BaseRepository<any, any, any> {
+  protected tableName = 'projects';
+  protected tenantScoped = true;
+
+  create(data: any): Promise<any> {
+    const db = getDb();
+    db.exec(
+      `INSERT INTO projects (name, customer_name, tenant_id) VALUES ('${data.name}', '${data.customer_name}', ${data.tenant_id})`
+    );
+    const result = db.prepare('SELECT * FROM projects WHERE id = last_insert_rowid()').all();
+    return Promise.resolve(result[0]);
+  }
+
+  update(id: number, data: any): Promise<any> {
+    const db = getDb();
+    db.exec(`UPDATE projects SET name = '${data.name}' WHERE id = ${id}`);
+    const result = db.prepare('SELECT * FROM projects WHERE id = ?').all(id);
+    return Promise.resolve(result[0]);
+  }
+}
+
+Deno.test({
+  name: 'BaseRepository tenant-scoped - findAll filters by tenantId',
+  async fn() {
+    await setupTestDatabase();
+    clearDatabase();
+    const db = getDb();
+
+    // Create a second tenant
+    db.exec("INSERT INTO tenants (id, name, is_distributor, is_active) VALUES (2, 'Partner A', 0, 1)");
+
+    // Create projects in different tenants
+    db.exec("INSERT INTO projects (name, customer_name, tenant_id) VALUES ('P1', 'C1', 1)");
+    db.exec("INSERT INTO projects (name, customer_name, tenant_id) VALUES ('P2', 'C2', 2)");
+    db.exec("INSERT INTO projects (name, customer_name, tenant_id) VALUES ('P3', 'C3', 1)");
+
+    const repo = new TestTenantRepo();
+
+    // Partner user should only see their tenant's projects
+    const tenant2Projects = await repo.findAll({ tenantId: 2, role: 'admin' });
+    assertEquals(tenant2Projects.length, 1);
+    assertEquals(tenant2Projects[0].name, 'P2');
+
+    // Distributor should see all projects
+    const allProjects = await repo.findAll({ tenantId: 1, role: 'distributor' });
+    assertEquals(allProjects.length, 3);
+
+    teardownTestDatabase();
+  },
+});
+
+Deno.test({
+  name: 'BaseRepository tenant-scoped - findById respects tenantId',
+  async fn() {
+    await setupTestDatabase();
+    clearDatabase();
+    const db = getDb();
+
+    db.exec("INSERT INTO tenants (id, name, is_distributor, is_active) VALUES (2, 'Partner A', 0, 1)");
+    db.exec("INSERT INTO projects (id, name, customer_name, tenant_id) VALUES (10, 'P1', 'C1', 2)");
+
+    const repo = new TestTenantRepo();
+
+    // Same tenant can find it
+    const found = await repo.findById(10, { tenantId: 2, role: 'admin' });
+    assertEquals(found?.name, 'P1');
+
+    // Different tenant cannot find it
+    const notFound = await repo.findById(10, { tenantId: 1, role: 'user' });
+    assertEquals(notFound, null);
+
+    // Distributor can find it (bypass)
+    const distributorFound = await repo.findById(10, { tenantId: 1, role: 'distributor' });
+    assertEquals(distributorFound?.name, 'P1');
+
+    teardownTestDatabase();
+  },
+});
+
+Deno.test({
+  name: 'BaseRepository tenant-scoped - delete respects tenantId',
+  async fn() {
+    await setupTestDatabase();
+    clearDatabase();
+    const db = getDb();
+
+    db.exec("INSERT INTO tenants (id, name, is_distributor, is_active) VALUES (2, 'Partner A', 0, 1)");
+    db.exec("INSERT INTO projects (id, name, customer_name, tenant_id) VALUES (10, 'P1', 'C1', 2)");
+
+    const repo = new TestTenantRepo();
+
+    // Different tenant cannot delete it
+    await repo.delete(10, { tenantId: 1, role: 'user' });
+    const stillExists = db.prepare('SELECT * FROM projects WHERE id = 10').all();
+    assertEquals(stillExists.length, 1);
+
+    // Same tenant can delete it
+    await repo.delete(10, { tenantId: 2, role: 'admin' });
+    const deleted = db.prepare('SELECT * FROM projects WHERE id = 10').all();
+    assertEquals(deleted.length, 0);
+
+    teardownTestDatabase();
+  },
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && deno test --allow-all tests/repositories/base_tenant_test.ts
+```
+
+Expected: FAIL — `findAll` doesn't accept a context argument, `tenantScoped` property doesn't exist.
+
+- [ ] **Step 3: Update BaseRepository**
+
+Replace `backend/src/repositories/base.ts`:
+
+```typescript
+import { getDb } from '../config/database.ts';
+
+export interface TenantContext {
+  tenantId: number;
+  role: 'distributor' | 'admin' | 'user';
+}
+
+/**
+ * Base Repository class
+ * Provides common CRUD operations with optional tenant scoping
+ */
+export abstract class BaseRepository<T, CreateDTO, UpdateDTO> {
+  protected abstract tableName: string;
+  protected tenantScoped = false;
+
+  private shouldFilter(ctx?: TenantContext): boolean {
+    if (!this.tenantScoped) return false;
+    if (!ctx) return false;
+    return ctx.role !== 'distributor';
+  }
+
+  private tenantFilter(ctx?: TenantContext): { where: string; params: unknown[] } {
+    if (this.shouldFilter(ctx)) {
+      return { where: ' WHERE tenant_id = ?', params: [ctx!.tenantId] };
+    }
+    return { where: '', params: [] };
+  }
+
+  findAll(ctx?: TenantContext): Promise<T[]> {
+    const { where, params } = this.tenantFilter(ctx);
+    const result = getDb().prepare(`SELECT * FROM ${this.tableName}${where}`).all(...params);
+    return Promise.resolve(result as T[]);
+  }
+
+  findById(id: number, ctx?: TenantContext): Promise<T | null> {
+    if (this.shouldFilter(ctx)) {
+      const result = getDb().prepare(
+        `SELECT * FROM ${this.tableName} WHERE id = ? AND tenant_id = ?`
+      ).all(id, ctx!.tenantId);
+      return Promise.resolve(result.length > 0 ? (result[0] as T) : null);
+    }
+    const result = getDb().prepare(`SELECT * FROM ${this.tableName} WHERE id = ?`).all(id);
+    return Promise.resolve(result.length > 0 ? (result[0] as T) : null);
+  }
+
+  abstract create(data: CreateDTO): Promise<T>;
+  abstract update(id: number, data: UpdateDTO): Promise<T>;
+
+  delete(id: number, ctx?: TenantContext): Promise<void> {
+    if (this.shouldFilter(ctx)) {
+      getDb().exec(
+        `DELETE FROM ${this.tableName} WHERE id = ${id} AND tenant_id = ${ctx!.tenantId}`
+      );
+    } else {
+      getDb().exec(`DELETE FROM ${this.tableName} WHERE id = ${id}`);
+    }
+    return Promise.resolve();
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd backend && deno test --allow-all tests/repositories/base_tenant_test.ts
+```
+
+Expected: All 3 tests pass.
+
+- [ ] **Step 5: Run full backend tests**
+
+```bash
+cd backend && deno task test
+```
+
+Expected: All tests pass. The new `ctx` parameter is optional, so existing callers still work.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/repositories/base.ts backend/tests/repositories/base_tenant_test.ts
+git commit -m "feat: add tenant-scoped filtering to BaseRepository"
+```
+
+---
+
+## Task 7: Tenant Repository
+
+**Files:**
+- Create: `backend/src/repositories/tenant.ts`
+
+- [ ] **Step 1: Write tests**
+
+Create `backend/tests/repositories/tenant_test.ts`:
+
+```typescript
+import { assertEquals, assertNotEquals } from 'https://deno.land/std/assert/mod.ts';
+import { setupTestDatabase, clearDatabase, teardownTestDatabase } from '../test-utils.ts';
+import { TenantRepository } from '../../src/repositories/tenant.ts';
+
+const tenantRepo = new TenantRepository();
+
+Deno.test({
+  name: 'TenantRepository - create a tenant',
+  async fn() {
+    await setupTestDatabase();
+    clearDatabase();
+
+    const tenant = await tenantRepo.create({ name: 'Partner A' });
+    assertNotEquals(tenant.id, undefined);
+    assertEquals(tenant.name, 'Partner A');
+    assertEquals(tenant.is_distributor, 0);
+    assertEquals(tenant.is_active, 1);
+
+    teardownTestDatabase();
+  },
+});
+
+Deno.test({
+  name: 'TenantRepository - list all tenants',
+  async fn() {
+    await setupTestDatabase();
+    clearDatabase();
+
+    await tenantRepo.create({ name: 'Partner A' });
+    await tenantRepo.create({ name: 'Partner B' });
+
+    const tenants = await tenantRepo.findAll();
+    // 3 total: 1 distributor (seeded) + 2 partners
+    assertEquals(tenants.length, 3);
+
+    teardownTestDatabase();
+  },
+});
+
+Deno.test({
+  name: 'TenantRepository - update a tenant',
+  async fn() {
+    await setupTestDatabase();
+    clearDatabase();
+
+    const tenant = await tenantRepo.create({ name: 'Partner A' });
+    const updated = await tenantRepo.update(tenant.id, { name: 'Partner A Renamed' });
+    assertEquals(updated.name, 'Partner A Renamed');
+
+    teardownTestDatabase();
+  },
+});
+
+Deno.test({
+  name: 'TenantRepository - soft delete a tenant',
+  async fn() {
+    await setupTestDatabase();
+    clearDatabase();
+
+    const tenant = await tenantRepo.create({ name: 'Partner A' });
+    const deactivated = await tenantRepo.update(tenant.id, { is_active: 0 });
+    assertEquals(deactivated.is_active, 0);
+
+    teardownTestDatabase();
+  },
+});
+
+Deno.test({
+  name: 'TenantRepository - cannot delete distributor tenant',
+  async fn() {
+    await setupTestDatabase();
+    clearDatabase();
+
+    // The distributor tenant (id=1) is seeded by clearDatabase
+    const tenants = await tenantRepo.findAll();
+    const distributor = tenants.find((t: any) => t.is_distributor === 1);
+    assertNotEquals(distributor, undefined);
+
+    // Attempting to soft-delete distributor should be blocked (tested at route level)
+    teardownTestDatabase();
+  },
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd backend && deno test --allow-all tests/repositories/tenant_test.ts
+```
+
+Expected: FAIL — `TenantRepository` doesn't exist.
+
+- [ ] **Step 3: Create TenantRepository**
+
+Create `backend/src/repositories/tenant.ts`:
+
+```typescript
+import { getDb } from '../config/database.ts';
+import { BaseRepository } from './base.ts';
+import type { Tenant, CreateTenantDTO, UpdateTenantDTO } from '../models/index.ts';
+
+export class TenantRepository extends BaseRepository<Tenant, CreateTenantDTO, UpdateTenantDTO> {
+  protected tableName = 'tenants';
+
+  create(data: CreateTenantDTO): Promise<Tenant> {
+    const db = getDb();
+    db.prepare(
+      'INSERT INTO tenants (name) VALUES (?)'
+    ).run(data.name);
+
+    const result = db.prepare(
+      'SELECT * FROM tenants WHERE id = last_insert_rowid()'
+    ).all();
+    return Promise.resolve(result[0] as Tenant);
+  }
+
+  update(id: number, data: UpdateTenantDTO): Promise<Tenant> {
+    const db = getDb();
+    const fields: string[] = [];
+    const values: unknown[] = [];
+
+    if (data.name !== undefined) {
+      fields.push('name = ?');
+      values.push(data.name);
+    }
+    if (data.is_active !== undefined) {
+      fields.push('is_active = ?');
+      values.push(data.is_active);
+    }
+
+    if (fields.length > 0) {
+      values.push(id);
+      db.prepare(
+        `UPDATE tenants SET ${fields.join(', ')} WHERE id = ?`
+      ).run(...values);
+    }
+
+    const result = db.prepare('SELECT * FROM tenants WHERE id = ?').all(id);
+    return Promise.resolve(result[0] as Tenant);
+  }
+
+  findByName(name: string): Promise<Tenant | null> {
+    const result = getDb().prepare(
+      'SELECT * FROM tenants WHERE name = ?'
+    ).all(name);
+    return Promise.resolve(result.length > 0 ? (result[0] as Tenant) : null);
+  }
+
+  findDistributor(): Promise<Tenant | null> {
+    const result = getDb().prepare(
+      'SELECT * FROM tenants WHERE is_distributor = 1'
+    ).all();
+    return Promise.resolve(result.length > 0 ? (result[0] as Tenant) : null);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd backend && deno test --allow-all tests/repositories/tenant_test.ts
+```
+
+Expected: All 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/repositories/tenant.ts backend/tests/repositories/tenant_test.ts
+git commit -m "feat: add TenantRepository with CRUD operations"
+```
+
+---
+
+## Task 8: Tenant API Routes
+
+**Files:**
+- Create: `backend/src/routes/tenants.ts`
+- Create: `backend/tests/routes/tenants_test.ts`
+- Modify: `backend/src/main.ts`
+
+- [ ] **Step 1: Write route tests**
+
+Create `backend/tests/routes/tenants_test.ts`:
+
+```typescript
+import { assertEquals } from 'https://deno.land/std/assert/mod.ts';
+import { setupTestDatabase, clearDatabase, teardownTestDatabase } from '../test-utils.ts';
+import { Hono } from 'hono';
+import { authMiddleware, distributorMiddleware } from '../../src/middleware/auth.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+import tenantRoutes from '../../src/routes/tenants.ts';
+
+const app = new Hono();
+app.route('/tenants', tenantRoutes);
+
+let distributorToken: string;
+let partnerAdminToken: string;
+
+async function setup() {
+  await setupTestDatabase();
+  clearDatabase();
+  distributorToken = await generateToken(1, 'dist@test.com', 'distributor', 1);
+  partnerAdminToken = await generateToken(2, 'admin@partner.com', 'admin', 2);
+}
+
+Deno.test('Tenants - POST /tenants creates a partner', async () => {
+  await setup();
+  const res = await app.request('/tenants', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${distributorToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name: 'Partner A' }),
+  });
+  assertEquals(res.status, 201);
+  const body = await res.json();
+  assertEquals(body.data.name, 'Partner A');
+  assertEquals(body.data.is_distributor, 0);
+  teardownTestDatabase();
+});
+
+Deno.test('Tenants - GET /tenants lists all tenants', async () => {
+  await setup();
+  // Create a partner
+  await app.request('/tenants', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${distributorToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name: 'Partner A' }),
+  });
+
+  const res = await app.request('/tenants', {
+    headers: { Authorization: `Bearer ${distributorToken}` },
+  });
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.data.length, 2); // Distributor + Partner A
+  teardownTestDatabase();
+});
+
+Deno.test('Tenants - PUT /tenants/:id updates a tenant', async () => {
+  await setup();
+  const createRes = await app.request('/tenants', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${distributorToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name: 'Partner A' }),
+  });
+  const { data: created } = await createRes.json();
+
+  const res = await app.request(`/tenants/${created.id}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${distributorToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name: 'Partner A Updated' }),
+  });
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.data.name, 'Partner A Updated');
+  teardownTestDatabase();
+});
+
+Deno.test('Tenants - DELETE /tenants/:id soft-deletes a tenant', async () => {
+  await setup();
+  const createRes = await app.request('/tenants', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${distributorToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name: 'Partner A' }),
+  });
+  const { data: created } = await createRes.json();
+
+  const res = await app.request(`/tenants/${created.id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${distributorToken}` },
+  });
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.data.is_active, 0);
+  teardownTestDatabase();
+});
+
+Deno.test('Tenants - DELETE /tenants/:id rejects deleting distributor tenant', async () => {
+  await setup();
+  const res = await app.request('/tenants/1', {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${distributorToken}` },
+  });
+  assertEquals(res.status, 403);
+  teardownTestDatabase();
+});
+
+Deno.test('Tenants - non-distributor cannot access tenant routes', async () => {
+  await setup();
+  const res = await app.request('/tenants', {
+    headers: { Authorization: `Bearer ${partnerAdminToken}` },
+  });
+  assertEquals(res.status, 403);
+  teardownTestDatabase();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd backend && deno test --allow-all tests/routes/tenants_test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create tenant routes**
+
+Create `backend/src/routes/tenants.ts`:
+
+```typescript
+import { Hono } from 'hono';
+import { authMiddleware, distributorMiddleware } from '../middleware/auth.ts';
+import { TenantRepository } from '../repositories/tenant.ts';
+
+const tenantRoutes = new Hono();
+const tenantRepo = new TenantRepository();
+
+// All tenant routes require distributor role
+tenantRoutes.use('/*', authMiddleware, distributorMiddleware);
+
+// GET /tenants - List all tenants
+tenantRoutes.get('/', async (c) => {
+  const tenants = await tenantRepo.findAll();
+  return c.json({ data: tenants });
+});
+
+// GET /tenants/:id - Get single tenant
+tenantRoutes.get('/:id', async (c) => {
+  const id = parseInt(c.req.param('id'));
+  const tenant = await tenantRepo.findById(id);
+
+  if (!tenant) {
+    return c.json({ error: 'Tenant not found' }, 404);
+  }
+
+  return c.json({ data: tenant });
+});
+
+// POST /tenants - Create a new partner tenant
+tenantRoutes.post('/', async (c) => {
+  const body = await c.req.json();
+
+  if (!body.name || typeof body.name !== 'string' || body.name.trim().length === 0) {
+    return c.json({ error: 'Tenant name is required' }, 400);
+  }
+
+  const existing = await tenantRepo.findByName(body.name.trim());
+  if (existing) {
+    return c.json({ error: 'A tenant with this name already exists' }, 409);
+  }
+
+  const tenant = await tenantRepo.create({ name: body.name.trim() });
+  return c.json({ data: tenant }, 201);
+});
+
+// PUT /tenants/:id - Update a tenant
+tenantRoutes.put('/:id', async (c) => {
+  const id = parseInt(c.req.param('id'));
+  const tenant = await tenantRepo.findById(id);
+
+  if (!tenant) {
+    return c.json({ error: 'Tenant not found' }, 404);
+  }
+
+  const body = await c.req.json();
+  const updated = await tenantRepo.update(id, {
+    name: body.name?.trim(),
+    is_active: body.is_active,
+  });
+  return c.json({ data: updated });
+});
+
+// DELETE /tenants/:id - Soft delete a tenant
+tenantRoutes.delete('/:id', async (c) => {
+  const id = parseInt(c.req.param('id'));
+  const tenant = await tenantRepo.findById(id);
+
+  if (!tenant) {
+    return c.json({ error: 'Tenant not found' }, 404);
+  }
+
+  if (tenant.is_distributor) {
+    return c.json({ error: 'Cannot deactivate the distributor tenant' }, 403);
+  }
+
+  const deactivated = await tenantRepo.update(id, { is_active: 0 });
+  return c.json({ data: deactivated });
+});
+
+export default tenantRoutes;
+```
+
+- [ ] **Step 4: Mount tenant routes in main.ts**
+
+In `backend/src/main.ts`, add the import and route mounting:
+
+Add import at top:
+```typescript
+import tenantRoutes from './routes/tenants.ts';
+```
+
+Add route mounting alongside other routes (before `app.route('/api', api)`):
+```typescript
+api.route('/tenants', tenantRoutes);
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd backend && deno test --allow-all tests/routes/tenants_test.ts
+```
+
+Expected: All 6 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/routes/tenants.ts backend/src/main.ts backend/tests/routes/tenants_test.ts
+git commit -m "feat: add tenant management API routes (distributor only)"
+```
+
+---
+
+## Task 9: Update Project Routes — Tenant Filtering
+
+**Files:**
+- Modify: `backend/src/repositories/project.ts`
+- Modify: `backend/src/routes/projects.ts`
+
+- [ ] **Step 1: Write tests for tenant-scoped projects**
+
+Create `backend/tests/routes/projects_tenant_test.ts`:
+
+```typescript
+import { assertEquals } from 'https://deno.land/std/assert/mod.ts';
+import { setupTestDatabase, clearDatabase, teardownTestDatabase } from '../test-utils.ts';
+import { getDb } from '../../src/config/database.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+import { Hono } from 'hono';
+import projectRoutes from '../../src/routes/projects.ts';
+
+const app = new Hono();
+app.route('/projects', projectRoutes);
+
+async function setup() {
+  await setupTestDatabase();
+  clearDatabase();
+  const db = getDb();
+  // Create partner tenant
+  db.exec("INSERT INTO tenants (id, name, is_distributor, is_active) VALUES (2, 'Partner A', 0, 1)");
+  // Create projects in different tenants
+  db.exec("INSERT INTO projects (name, customer_name, tenant_id) VALUES ('Dist Project', 'Cust A', 1)");
+  db.exec("INSERT INTO projects (name, customer_name, tenant_id) VALUES ('Partner Project', 'Cust B', 2)");
+}
+
+Deno.test('Projects tenant - partner user sees only own tenant projects', async () => {
+  await setup();
+  const token = await generateToken(2, 'user@partner.com', 'user', 2);
+  const res = await app.request('/projects', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.data.length, 1);
+  assertEquals(body.data[0].name, 'Partner Project');
+  teardownTestDatabase();
+});
+
+Deno.test('Projects tenant - distributor sees all projects', async () => {
+  await setup();
+  const token = await generateToken(1, 'dist@test.com', 'distributor', 1);
+  const res = await app.request('/projects', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.data.length, 2);
+  teardownTestDatabase();
+});
+
+Deno.test('Projects tenant - distributor can filter by tenantId', async () => {
+  await setup();
+  const token = await generateToken(1, 'dist@test.com', 'distributor', 1);
+  const res = await app.request('/projects?tenantId=2', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.data.length, 1);
+  assertEquals(body.data[0].name, 'Partner Project');
+  teardownTestDatabase();
+});
+
+Deno.test('Projects tenant - non-distributor cannot use tenantId param', async () => {
+  await setup();
+  const token = await generateToken(2, 'user@partner.com', 'user', 2);
+  const res = await app.request('/projects?tenantId=1', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  // Should ignore the tenantId param and only show own tenant
+  assertEquals(body.data.length, 1);
+  assertEquals(body.data[0].name, 'Partner Project');
+  teardownTestDatabase();
+});
+
+Deno.test('Projects tenant - new project gets callers tenantId', async () => {
+  await setup();
+  const token = await generateToken(2, 'user@partner.com', 'user', 2);
+  const res = await app.request('/projects', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name: 'New Partner Project', customer_name: 'Cust C' }),
+  });
+  assertEquals(res.status, 201);
+  const body = await res.json();
+  assertEquals(body.data.tenant_id, 2);
+  teardownTestDatabase();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd backend && deno test --allow-all tests/routes/projects_tenant_test.ts
+```
+
+Expected: FAIL — projects not filtered by tenant.
+
+- [ ] **Step 3: Update ProjectRepository**
+
+In `backend/src/repositories/project.ts`, add `protected tenantScoped = true;` to the class. Update the `create` method to include `tenant_id` from the DTO, and update `findAll` and other query methods to use the tenant context from the base class.
+
+The key changes:
+- Add `protected tenantScoped = true;`
+- Update `create()` to include `tenant_id` in INSERT
+- Override `findAll()` to support search while respecting tenant filtering — build the WHERE clause to include both search and tenant_id conditions
+- Ensure `findById`, `update`, `delete` pass through the `ctx` parameter to base class methods
+
+- [ ] **Step 4: Update project routes to pass tenant context**
+
+In `backend/src/routes/projects.ts`, update each route handler to build a `TenantContext` from the Hono context and pass it to repository methods:
+
+```typescript
+import type { TenantContext } from '../repositories/base.ts';
+
+// In each route handler:
+const tenantCtx: TenantContext = {
+  tenantId: c.get('tenantId'),
+  role: c.get('userRole'),
+};
+
+// For distributor with ?tenantId query param:
+const queryTenantId = c.req.query('tenantId');
+if (queryTenantId && tenantCtx.role === 'distributor') {
+  tenantCtx.tenantId = parseInt(queryTenantId);
+  tenantCtx.role = 'admin'; // Force filtering by the specified tenant
+}
+```
+
+For project creation, set `tenant_id` from the caller's context:
+```typescript
+const project = await projectRepo.create({ ...body, tenant_id: c.get('tenantId') });
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd backend && deno test --allow-all tests/routes/projects_tenant_test.ts
+```
+
+Expected: All 5 tests pass.
+
+- [ ] **Step 6: Run full backend tests**
+
+```bash
+cd backend && deno task test
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/repositories/project.ts backend/src/routes/projects.ts backend/tests/routes/projects_tenant_test.ts
+git commit -m "feat: add tenant filtering to project routes and repository"
+```
+
+---
+
+## Task 10: Update User Routes — Tenant Filtering
+
+**Files:**
+- Modify: `backend/src/repositories/user.ts`
+- Modify: `backend/src/routes/users.ts`
+
+- [ ] **Step 1: Write tests for tenant-scoped users**
+
+Create `backend/tests/routes/users_tenant_test.ts`:
+
+```typescript
+import { assertEquals } from 'https://deno.land/std/assert/mod.ts';
+import { setupTestDatabase, clearDatabase, teardownTestDatabase } from '../test-utils.ts';
+import { getDb } from '../../src/config/database.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+import { Hono } from 'hono';
+import userRoutes from '../../src/routes/users.ts';
+import * as bcrypt from 'https://deno.land/x/bcrypt/mod.ts';
+
+const app = new Hono();
+app.route('/users', userRoutes);
+
+async function setup() {
+  await setupTestDatabase();
+  clearDatabase();
+  const db = getDb();
+  const hash = await bcrypt.hash('password123');
+
+  // Create tenants
+  db.exec("INSERT INTO tenants (id, name, is_distributor, is_active) VALUES (2, 'Partner A', 0, 1)");
+
+  // Create users in different tenants
+  db.prepare(
+    "INSERT INTO users (id, email, password_hash, role, tenant_id) VALUES (?, ?, ?, ?, ?)"
+  ).run(1, 'dist@test.com', hash, 'distributor', 1);
+  db.prepare(
+    "INSERT INTO users (id, email, password_hash, role, tenant_id) VALUES (?, ?, ?, ?, ?)"
+  ).run(2, 'admin@partner.com', hash, 'admin', 2);
+  db.prepare(
+    "INSERT INTO users (id, email, password_hash, role, tenant_id) VALUES (?, ?, ?, ?, ?)"
+  ).run(3, 'user@partner.com', hash, 'user', 2);
+}
+
+Deno.test('Users tenant - partner admin sees only own tenant users', async () => {
+  await setup();
+  const token = await generateToken(2, 'admin@partner.com', 'admin', 2);
+  const res = await app.request('/users', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.data.length, 2); // admin + user in tenant 2
+  teardownTestDatabase();
+});
+
+Deno.test('Users tenant - distributor sees all users', async () => {
+  await setup();
+  const token = await generateToken(1, 'dist@test.com', 'distributor', 1);
+  const res = await app.request('/users', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.data.length, 3); // all users
+  teardownTestDatabase();
+});
+
+Deno.test('Users tenant - partner admin creates user in own tenant', async () => {
+  await setup();
+  const token = await generateToken(2, 'admin@partner.com', 'admin', 2);
+  const res = await app.request('/users', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email: 'new@partner.com',
+      password: 'password123',
+      role: 'user',
+    }),
+  });
+  assertEquals(res.status, 201);
+  const body = await res.json();
+  assertEquals(body.data.tenant_id, 2);
+  teardownTestDatabase();
+});
+
+Deno.test('Users tenant - distributor creates user in any tenant', async () => {
+  await setup();
+  const token = await generateToken(1, 'dist@test.com', 'distributor', 1);
+  const res = await app.request('/users', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email: 'new@partner.com',
+      password: 'password123',
+      role: 'user',
+      tenant_id: 2,
+    }),
+  });
+  assertEquals(res.status, 201);
+  const body = await res.json();
+  assertEquals(body.data.tenant_id, 2);
+  teardownTestDatabase();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd backend && deno test --allow-all tests/routes/users_tenant_test.ts
+```
+
+Expected: FAIL — users not filtered by tenant.
+
+- [ ] **Step 3: Update UserRepository**
+
+In `backend/src/repositories/user.ts`:
+- Add `protected tenantScoped = true;`
+- Update `create()` to include `tenant_id`
+- Update `findAll()` to accept and use `TenantContext`
+
+- [ ] **Step 4: Update user routes**
+
+In `backend/src/routes/users.ts`:
+- Build `TenantContext` in each handler from Hono context
+- Pass context to repository methods
+- On create: use caller's `tenantId` unless distributor specifies `tenant_id` in body
+- Support `?tenantId=X` query param for distributor on GET /users
+- Prevent partner admin from creating users with `distributor` role
+- Prevent partner admin from assigning users to other tenants
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd backend && deno test --allow-all tests/routes/users_tenant_test.ts
+```
+
+Expected: All 4 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/repositories/user.ts backend/src/routes/users.ts backend/tests/routes/users_tenant_test.ts
+git commit -m "feat: add tenant filtering to user routes and repository"
+```
+
+---
+
+## Task 11: Update Catalog Routes — Distributor-Only Writes
+
+**Files:**
+- Modify: `backend/src/routes/items.ts`
+- Modify: `backend/src/routes/categories.ts`
+
+- [ ] **Step 1: Write test for catalog access control**
+
+Create `backend/tests/routes/catalog_access_test.ts`:
+
+```typescript
+import { assertEquals } from 'https://deno.land/std/assert/mod.ts';
+import { setupTestDatabase, clearDatabase, teardownTestDatabase } from '../test-utils.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+import { Hono } from 'hono';
+import categoryRoutes from '../../src/routes/categories.ts';
+
+const app = new Hono();
+app.route('/categories', categoryRoutes);
+
+Deno.test('Catalog - partner admin cannot create category', async () => {
+  await setupTestDatabase();
+  clearDatabase();
+  const token = await generateToken(2, 'admin@partner.com', 'admin', 2);
+  const res = await app.request('/categories', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name: 'New Category' }),
+  });
+  assertEquals(res.status, 403);
+  teardownTestDatabase();
+});
+
+Deno.test('Catalog - distributor can create category', async () => {
+  await setupTestDatabase();
+  clearDatabase();
+  const token = await generateToken(1, 'dist@test.com', 'distributor', 1);
+  const res = await app.request('/categories', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name: 'New Category' }),
+  });
+  assertEquals(res.status, 201);
+  teardownTestDatabase();
+});
+
+Deno.test('Catalog - partner user can read categories', async () => {
+  await setupTestDatabase();
+  clearDatabase();
+  const token = await generateToken(3, 'user@partner.com', 'user', 2);
+  const res = await app.request('/categories', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  // Categories GET is public (no auth), so this should work
+  assertEquals(res.status, 200);
+  teardownTestDatabase();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd backend && deno test --allow-all tests/routes/catalog_access_test.ts
+```
+
+Expected: FAIL — partner admin can still create categories (currently uses `adminMiddleware` which allows `admin` role).
+
+- [ ] **Step 3: Replace adminMiddleware with distributorMiddleware on catalog write routes**
+
+In `backend/src/routes/items.ts`:
+- Add import: `import { authMiddleware, distributorMiddleware } from '../middleware/auth.ts';`
+- Replace every `adminMiddleware` with `distributorMiddleware` on write routes (POST, PUT, DELETE, PATCH)
+- Keep read routes (GET) unchanged — no auth needed
+
+In `backend/src/routes/categories.ts`:
+- Same change: replace `adminMiddleware` with `distributorMiddleware` on write routes
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd backend && deno test --allow-all tests/routes/catalog_access_test.ts
+```
+
+Expected: All 3 tests pass.
+
+- [ ] **Step 5: Run full backend tests**
+
+```bash
+cd backend && deno task test
+```
+
+Expected: All tests pass (existing tests that used `admin` role for catalog writes need updating to `distributor`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/routes/items.ts backend/src/routes/categories.ts backend/tests/routes/catalog_access_test.ts
+git commit -m "feat: restrict catalog writes to distributor role only"
+```
+
+---
+
+## Task 12: Update Auth Route — Include tenantId in Login Response
+
+**Files:**
+- Modify: `backend/src/routes/auth.ts`
+
+- [ ] **Step 1: Write test for login response tenantId**
+
+Add to the existing auth tests or create `backend/tests/routes/auth_tenant_test.ts`:
+
+```typescript
+import { assertEquals } from 'https://deno.land/std/assert/mod.ts';
+import { setupTestDatabase, clearDatabase, teardownTestDatabase } from '../test-utils.ts';
+import { getDb } from '../../src/config/database.ts';
+import { Hono } from 'hono';
+import authRoutes from '../../src/routes/auth.ts';
+import * as bcrypt from 'https://deno.land/x/bcrypt/mod.ts';
+
+const app = new Hono();
+app.route('/auth', authRoutes);
+
+Deno.test('Auth - login response includes tenantId and tenantName', async () => {
+  await setupTestDatabase();
+  clearDatabase();
+  const db = getDb();
+  const hash = await bcrypt.hash('password123');
+  db.prepare(
+    "INSERT INTO users (email, password_hash, role, tenant_id, full_name) VALUES (?, ?, ?, ?, ?)"
+  ).run('dist@test.com', hash, 'distributor', 1, 'Distributor Admin');
+
+  const res = await app.request('/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'dist@test.com', password: 'password123' }),
+  });
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.data.user.tenantId, 1);
+  assertEquals(body.data.user.tenantName, 'Distributor');
+  assertEquals(body.data.user.role, 'distributor');
+  teardownTestDatabase();
+});
+
+Deno.test('Auth - login blocked for deactivated tenant', async () => {
+  await setupTestDatabase();
+  clearDatabase();
+  const db = getDb();
+  const hash = await bcrypt.hash('password123');
+  db.exec("INSERT INTO tenants (id, name, is_distributor, is_active) VALUES (2, 'Partner A', 0, 0)");
+  db.prepare(
+    "INSERT INTO users (email, password_hash, role, tenant_id) VALUES (?, ?, ?, ?)"
+  ).run('user@partner.com', hash, 'user', 2);
+
+  const res = await app.request('/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'user@partner.com', password: 'password123' }),
+  });
+  assertEquals(res.status, 403);
+  teardownTestDatabase();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd backend && deno test --allow-all tests/routes/auth_tenant_test.ts
+```
+
+Expected: FAIL — login response doesn't include tenantId/tenantName, and deactivated tenant check doesn't exist.
+
+- [ ] **Step 3: Update auth routes**
+
+In `backend/src/routes/auth.ts`, update the login handler:
+
+1. After verifying the user's password, look up the user's tenant:
+```typescript
+import { TenantRepository } from '../repositories/tenant.ts';
+const tenantRepo = new TenantRepository();
+
+// In login handler, after user is verified:
+const tenant = await tenantRepo.findById(user.tenant_id);
+if (!tenant || !tenant.is_active) {
+  return c.json({ error: 'Account disabled - contact your distributor' }, 403);
+}
+```
+
+2. Include tenantId and tenantName in the login response user object:
+```typescript
+return c.json({
+  data: {
+    accessToken,
+    refreshToken: newRefreshToken,
+    user: {
+      id: user.id,
+      email: user.email,
+      role: user.role,
+      fullName: user.full_name,
+      tenantId: user.tenant_id,
+      tenantName: tenant.name,
+    },
+  },
+});
+```
+
+3. Update the `/auth/me` endpoint similarly — look up tenant and include tenantId/tenantName.
+
+4. Update the refresh token endpoint — include tenantId in the new access token (already done in Task 3).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd backend && deno test --allow-all tests/routes/auth_tenant_test.ts
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Run full backend tests**
+
+```bash
+cd backend && deno task test
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/routes/auth.ts backend/tests/routes/auth_tenant_test.ts
+git commit -m "feat: include tenantId/tenantName in login, block deactivated tenants"
+```
+
+---
+
+## Task 13: Backend Lint & Full Test Pass
+
+**Files:** All backend files
+
+- [ ] **Step 1: Run deno lint**
+
+```bash
+cd backend && deno lint
+```
+
+Expected: No lint errors. Fix any that appear.
+
+- [ ] **Step 2: Run full backend tests**
+
+```bash
+cd backend && deno task test
+```
+
+Expected: All tests pass (existing + new).
+
+- [ ] **Step 3: Commit any fixes**
+
+```bash
+git add -A backend/
+git commit -m "fix: resolve lint errors and test failures from multi-tenancy backend"
+```
+
+---
+
+## Task 14: Frontend — Update Auth Types & Context
+
+**Files:**
+- Modify: `frontend/src/context/AuthContext.tsx`
+- Modify: `frontend/src/services/auth.ts`
+
+- [ ] **Step 1: Update auth service types**
+
+In `frontend/src/services/auth.ts`, update the user type in the login response to include tenantId and tenantName. Find where the login response user object is typed and add:
+
+```typescript
+export interface AuthUser {
+  id: number;
+  email: string;
+  role: 'distributor' | 'admin' | 'user';
+  fullName?: string;
+  tenantId: number;
+  tenantName: string;
+}
+```
+
+Update `getCurrentUser()` return type to include `tenantId` and `tenantName`.
+
+- [ ] **Step 2: Update AuthContext**
+
+In `frontend/src/context/AuthContext.tsx`:
+
+Update the `User` type/interface to include `tenantId` and `tenantName`:
+
+```typescript
+interface User {
+  id: number;
+  email: string;
+  role: 'distributor' | 'admin' | 'user';
+  fullName?: string;
+  tenantId: number;
+  tenantName: string;
+}
+```
+
+- [ ] **Step 3: Update ProtectedRoute**
+
+In `frontend/src/components/auth/ProtectedRoute.tsx`:
+
+Update the admin check to also allow `distributor`:
+
+```typescript
+if (requireAdmin && user?.role !== 'admin' && user?.role !== 'distributor') {
+  return <Navigate to="/" replace />;
+}
+```
+
+Add a new `requireDistributor` prop:
+
+```typescript
+interface ProtectedRouteProps {
+  children: ReactNode;
+  requireAdmin?: boolean;
+  requireDistributor?: boolean;
+}
+
+// Add distributor check:
+if (requireDistributor && user?.role !== 'distributor') {
+  return <Navigate to="/" replace />;
+}
+```
+
+- [ ] **Step 4: Verify frontend compiles**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: No type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/context/AuthContext.tsx frontend/src/services/auth.ts frontend/src/components/auth/ProtectedRoute.tsx
+git commit -m "feat: add tenantId/tenantName to frontend auth types, update ProtectedRoute"
+```
+
+---
+
+## Task 15: Frontend — Tenant Service
+
+**Files:**
+- Create: `frontend/src/services/tenants.ts`
+
+- [ ] **Step 1: Create tenant API service**
+
+Create `frontend/src/services/tenants.ts`:
+
+```typescript
+import api from './api';
+
+export interface Tenant {
+  id: number;
+  name: string;
+  is_distributor: number;
+  is_active: number;
+  created_at: string;
+}
+
+export interface CreateTenantDTO {
+  name: string;
+}
+
+export interface UpdateTenantDTO {
+  name?: string;
+  is_active?: number;
+}
+
+export const tenantService = {
+  async getAll(): Promise<Tenant[]> {
+    const response = await api.get('/tenants');
+    return response.data.data;
+  },
+
+  async getById(id: number): Promise<Tenant> {
+    const response = await api.get(`/tenants/${id}`);
+    return response.data.data;
+  },
+
+  async create(data: CreateTenantDTO): Promise<Tenant> {
+    const response = await api.post('/tenants', data);
+    return response.data.data;
+  },
+
+  async update(id: number, data: UpdateTenantDTO): Promise<Tenant> {
+    const response = await api.put(`/tenants/${id}`, data);
+    return response.data.data;
+  },
+
+  async deactivate(id: number): Promise<Tenant> {
+    const response = await api.delete(`/tenants/${id}`);
+    return response.data.data;
+  },
+};
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/services/tenants.ts
+git commit -m "feat: add tenant API service"
+```
+
+---
+
+## Task 16: Frontend — Tenant Management Page
+
+**Files:**
+- Create: `frontend/src/pages/settings/TenantManagement.tsx`
+- Create: `frontend/src/components/settings/TenantFormModal.tsx`
+- Modify: `frontend/src/App.tsx`
+
+- [ ] **Step 1: Create TenantFormModal**
+
+Create `frontend/src/components/settings/TenantFormModal.tsx` following the existing modal pattern (like UserFormModal). Props:
+
+```typescript
+interface TenantFormModalProps {
+  tenant: Tenant | null;  // null = create, object = edit
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: CreateTenantDTO | UpdateTenantDTO) => Promise<void>;
+}
+```
+
+Form fields:
+- Name (text input, required)
+
+Buttons: "Create" / "Update" + "Cancel"
+
+- [ ] **Step 2: Create TenantManagement page**
+
+Create `frontend/src/pages/settings/TenantManagement.tsx` following the `UserManagement.tsx` pattern:
+
+- State: `tenants[]`, `isLoading`, `error`, modal state
+- Fetch tenants on mount
+- Table columns: Name, Status (Active/Inactive badge), Type (Distributor/Partner badge), Created, Actions
+- Distributor tenant row has disabled delete button
+- Actions: Edit, Deactivate/Activate
+- Modals: TenantFormModal, ConfirmDeleteModal (for deactivation)
+
+- [ ] **Step 3: Add route in App.tsx**
+
+In `frontend/src/App.tsx`, add the tenant management route inside the admin routes section. Wrap with `<ProtectedRoute requireDistributor>`:
+
+```tsx
+import TenantManagement from './pages/settings/TenantManagement';
+
+// Inside Route definitions, in the admin section:
+<Route
+  path="settings/tenants"
+  element={
+    <ProtectedRoute requireDistributor>
+      <TenantManagement />
+    </ProtectedRoute>
+  }
+/>
+```
+
+- [ ] **Step 4: Verify it renders**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/settings/TenantManagement.tsx frontend/src/components/settings/TenantFormModal.tsx frontend/src/App.tsx
+git commit -m "feat: add Tenant Management page (distributor only)"
+```
+
+---
+
+## Task 17: Frontend — Header & Navigation Updates
+
+**Files:**
+- Modify: `frontend/src/components/layout/Header.tsx`
+- Create: `frontend/src/components/layout/TenantSwitcher.tsx`
+
+- [ ] **Step 1: Create TenantSwitcher component**
+
+Create `frontend/src/components/layout/TenantSwitcher.tsx`:
+
+A dropdown component that:
+- Fetches tenants list on mount (distributor only)
+- Shows "All Tenants" as default + list of tenant names
+- Stores selected tenant ID in state (or URL query param)
+- Passes selected tenant to a context or callback so ProjectList/UserManagement can filter
+
+```typescript
+interface TenantSwitcherProps {
+  selectedTenantId: number | null;  // null = all
+  onTenantChange: (tenantId: number | null) => void;
+}
+```
+
+Uses shadcn/ui Select or DropdownMenu component, consistent with existing header dropdowns.
+
+- [ ] **Step 2: Update Header navigation**
+
+In `frontend/src/components/layout/Header.tsx`:
+
+1. Show "Catalog" dropdown for all authenticated users (not just admin). Items inside are read-only for non-distributors (handled at page level).
+2. Show "Settings" dropdown:
+   - "User Management" — visible to `distributor` and `admin`
+   - "Tenant Management" — visible to `distributor` only
+3. Show tenant name badge next to user info for partner users
+4. Show TenantSwitcher for distributor role (in the header bar)
+
+Conditional logic based on `user.role`:
+```typescript
+const isDistributor = user?.role === 'distributor';
+const isAdmin = user?.role === 'admin' || isDistributor;
+```
+
+- [ ] **Step 3: Verify it renders**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/layout/Header.tsx frontend/src/components/layout/TenantSwitcher.tsx
+git commit -m "feat: update header navigation for multi-tenancy roles, add TenantSwitcher"
+```
+
+---
+
+## Task 18: Frontend — Update ProjectList for Tenant Awareness
+
+**Files:**
+- Modify: `frontend/src/pages/projects/ProjectList.tsx`
+
+- [ ] **Step 1: Add tenant column for distributor**
+
+In `frontend/src/pages/projects/ProjectList.tsx`:
+
+1. If user is distributor, show a "Tenant" column in the table
+2. Pass `?tenantId=X` to the API when the TenantSwitcher has a selection
+3. Read the selected tenant from URL search params or a shared state
+
+Add to fetch call:
+```typescript
+const params: Record<string, string> = {};
+if (searchQuery) params.search = searchQuery;
+if (selectedTenantId && user?.role === 'distributor') {
+  params.tenantId = selectedTenantId.toString();
+}
+```
+
+Add tenant column (only for distributor):
+```tsx
+{user?.role === 'distributor' && <th>Tenant</th>}
+// ...
+{user?.role === 'distributor' && <td>{project.tenant_name}</td>}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/projects/ProjectList.tsx
+git commit -m "feat: add tenant column and filtering to ProjectList for distributor"
+```
+
+---
+
+## Task 19: Frontend — Update UserManagement for Tenant Awareness
+
+**Files:**
+- Modify: `frontend/src/pages/settings/UserManagement.tsx`
+
+- [ ] **Step 1: Add tenant filtering for distributor**
+
+In `frontend/src/pages/settings/UserManagement.tsx`:
+
+1. If user is distributor, show a tenant filter dropdown at the top
+2. Pass `?tenantId=X` to the API when filtering
+3. Show tenant column in the table for distributor
+4. When distributor creates a user, allow selecting which tenant to add them to
+5. Hide `distributor` role option for partner admins in the create/edit form
+
+- [ ] **Step 2: Update role options in user form**
+
+In the user create/edit form (UserFormModal or inline):
+- Distributor can assign: `distributor`, `admin`, `user`
+- Partner admin can assign: `admin`, `user` (within own tenant only)
+
+- [ ] **Step 3: Verify it compiles**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/settings/UserManagement.tsx
+git commit -m "feat: add tenant filtering to UserManagement for distributor"
+```
+
+---
+
+## Task 20: Frontend — Hide Catalog Write Actions for Non-Distributors
+
+**Files:**
+- Modify: `frontend/src/pages/catalog/ItemManagement.tsx`
+- Modify: `frontend/src/pages/catalog/CategoryManagement.tsx`
+
+- [ ] **Step 1: Conditionally hide action buttons**
+
+In both `ItemManagement.tsx` and `CategoryManagement.tsx`:
+
+```typescript
+const { user } = useAuth();
+const isDistributor = user?.role === 'distributor';
+```
+
+Then wrap action buttons with the condition:
+- Hide "Add Product" / "Add Category" buttons if `!isDistributor`
+- Hide "Import Catalog" button if `!isDistributor`
+- Hide Edit/Delete action buttons in table rows if `!isDistributor`
+- Keep the pages accessible (read-only browsing) for all roles
+
+- [ ] **Step 2: Update App.tsx routing**
+
+In `frontend/src/App.tsx`, change catalog routes from `requireAdmin` to just `ProtectedRoute` (no admin requirement) — all authenticated users can browse the catalog:
+
+```tsx
+<Route path="catalog/products" element={<ProtectedRoute><ItemManagement /></ProtectedRoute>} />
+<Route path="catalog/categories" element={<ProtectedRoute><CategoryManagement /></ProtectedRoute>} />
+```
+
+Keep user management routes as `requireAdmin`:
+```tsx
+<Route path="settings/users" element={<ProtectedRoute requireAdmin><UserManagement /></ProtectedRoute>} />
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/catalog/ItemManagement.tsx frontend/src/pages/catalog/CategoryManagement.tsx frontend/src/App.tsx
+git commit -m "feat: make catalog read-only for non-distributors, hide write actions"
+```
+
+---
+
+## Task 21: Frontend Lint & Build
+
+**Files:** All frontend files
+
+- [ ] **Step 1: Run ESLint**
+
+```bash
+cd frontend && npm run lint
+```
+
+Expected: No errors. Fix any that appear.
+
+- [ ] **Step 2: Run frontend tests**
+
+```bash
+cd frontend && npm run test:run
+```
+
+Expected: All tests pass. Update any that fail due to role changes (`admin` → `distributor`).
+
+- [ ] **Step 3: Run build**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: Clean build, no errors.
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+git add -A frontend/
+git commit -m "fix: resolve lint errors and test failures from multi-tenancy frontend"
+```
+
+---
+
+## Task 22: End-to-End Smoke Test
+
+- [ ] **Step 1: Start backend and frontend**
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 2: Test distributor flow**
+
+1. Log in as existing admin (now distributor)
+2. Verify catalog management works (create/edit/delete items)
+3. Navigate to Settings > Tenants — create a new partner "Partner A"
+4. Navigate to Settings > Users — create a user in Partner A (role: admin)
+5. Verify projects show all projects, tenant column visible
+
+- [ ] **Step 3: Test partner admin flow**
+
+1. Log out, log in as the Partner A admin
+2. Verify they see only Partner A's projects (initially empty)
+3. Create a project — verify it's associated with Partner A
+4. Navigate to catalog — verify browse works but no edit/delete buttons
+5. Navigate to Users — verify they only see Partner A users
+
+- [ ] **Step 4: Test isolation**
+
+1. Log in as distributor, create another partner "Partner B" with a user
+2. Log in as Partner B user, create a project
+3. Log in as Partner A admin — verify they cannot see Partner B's project
+4. Log in as distributor — verify they see both projects
+
+- [ ] **Step 5: Commit any fixes found during smoke testing**
+
+```bash
+git add -A
+git commit -m "fix: address issues found during multi-tenancy smoke testing"
+```

--- a/docs/superpowers/specs/2026-03-26-multi-tenancy-design.md
+++ b/docs/superpowers/specs/2026-03-26-multi-tenancy-design.md
@@ -1,0 +1,224 @@
+# Multi-Tenancy Design Spec
+
+**Date:** 2026-03-26
+**Status:** Draft
+
+## Overview
+
+SnapFlow currently operates as a single-tenant, single-workspace system where all users share the same projects and catalog. This design adds multi-tenancy to support the stakeholder's business model: a **distributor** who sells hardware and manages the product catalog, and **partner companies** who use SnapFlow to create their own projects/proposals.
+
+### Business Model
+
+- The **distributor** is the hardware supplier. They maintain the shared product catalog and also create their own projects.
+- **Partner companies** are the distributor's customers. Each partner has their own admins, users, and projects — fully isolated from other partners.
+- The distributor has full visibility and edit access across all tenants for oversight and support.
+
+## Architecture: Row-Level Tenant Isolation via BaseRepository
+
+Tenant filtering is enforced at the repository layer. The `BaseRepository` class automatically appends `WHERE tenant_id = ?` to all CRUD operations on tenant-scoped tables. Routes do not need manual filtering — isolation is automatic and cannot be accidentally skipped.
+
+- **Distributor role** bypasses the tenant filter (cross-tenant visibility).
+- **Catalog tables** (items, categories, variants, addons) are exempt — they have no `tenant_id` and are shared across all tenants.
+
+## Data Model
+
+### New Table: `tenants`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PRIMARY KEY | Auto-increment |
+| name | TEXT NOT NULL | Company name |
+| is_distributor | BOOLEAN DEFAULT FALSE | Only one tenant is the distributor |
+| is_active | BOOLEAN DEFAULT TRUE | Soft delete flag |
+| created_at | DATETIME | Default CURRENT_TIMESTAMP |
+
+### Modified Table: `users`
+
+| Change | Column | Details |
+|--------|--------|---------|
+| ADD | tenant_id | INTEGER NOT NULL REFERENCES tenants(id) |
+| ALTER | role | CHECK(role IN ('distributor', 'admin', 'user')) — was ('admin', 'user') |
+
+- Email remains globally unique (no duplicate emails across tenants).
+
+### Modified Table: `projects`
+
+| Change | Column | Details |
+|--------|--------|---------|
+| ADD | tenant_id | INTEGER NOT NULL REFERENCES tenants(id) |
+
+- Unique index changes from `(name, customer_name)` to `(name, customer_name, tenant_id)` so partners can reuse project/customer names independently.
+
+### Unchanged Tables
+
+- `categories`, `items`, `item_variants`, `variant_addons` — shared catalog, no tenant_id.
+- `floorplans`, `placements`, `project_bom`, `areas` — isolated implicitly via their parent `project` which has `tenant_id`. No direct `tenant_id` column needed.
+
+## Role System
+
+Three roles replace the current binary (admin/user) system:
+
+### distributor
+
+- Belongs to the distributor tenant (is_distributor = true)
+- Manage product catalog (CRUD items, categories, variants, addons, Excel import)
+- Create and manage tenants (partner companies)
+- View and edit ALL projects across all tenants (oversight + support)
+- Manage users in any tenant
+- Access via distributor bypass in BaseRepository (no tenant filter applied)
+
+### admin
+
+- Belongs to a specific partner tenant
+- Manage users within own tenant only
+- View and edit projects within own tenant only
+- Read-only catalog access (browse items, no edit/delete/import)
+- Cannot see other tenants' data
+
+### user
+
+- Belongs to a specific partner tenant
+- Create and edit projects within own tenant only
+- Read-only catalog access
+- Cannot manage users
+- Cannot see other tenants' data
+
+## Backend Changes
+
+### JWT Payload
+
+```typescript
+interface JWTPayload {
+  sub: string;        // user id
+  email: string;
+  role: 'distributor' | 'admin' | 'user';
+  tenantId: number;   // tenant the user belongs to
+  exp: number;
+  iat: number;
+}
+```
+
+### Middleware
+
+- **Auth middleware update:** Extracts `tenantId` and `role` from JWT, sets both on Hono context.
+- **New `distributorMiddleware`:** Checks `role === 'distributor'`, returns 403 otherwise. Used on catalog write routes and tenant management routes.
+- **Existing `adminMiddleware` update:** Allows both `distributor` and `admin` roles (for user management within a tenant).
+
+### BaseRepository Changes
+
+The base CRUD class gains tenant-awareness:
+
+- Constructor accepts a `tenantScoped: boolean` flag (default false for catalog repos, true for project/user repos).
+- When `tenantScoped` is true, all query methods (`findAll`, `findById`, `create`, `update`, `delete`) automatically include `tenant_id` in their WHERE clause.
+- A `tenantId` is passed to repository methods via the Hono context.
+- When the caller's role is `distributor`, the tenant filter is bypassed.
+- Catalog repositories (`ItemRepository`, `CategoryRepository`, etc.) remain unscoped.
+
+### New Routes: Tenant Management
+
+All require `distributorMiddleware`:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | /api/tenants | Create a new partner company |
+| GET | /api/tenants | List all tenants |
+| PUT | /api/tenants/:id | Update tenant (name, is_active) |
+| DELETE | /api/tenants/:id | Soft delete (sets is_active = false) |
+
+### Modified Routes: Catalog
+
+- Read routes (GET): No change — all authenticated users can browse.
+- Write routes (POST, PUT, DELETE, Excel import): Add `distributorMiddleware` to restrict to distributor only.
+
+### Modified Routes: Projects
+
+- All project queries filtered by `tenant_id` via BaseRepository.
+- Distributor sees all projects (bypass). Can optionally filter by `?tenantId=X` query param.
+
+### Modified Routes: Users
+
+- Partner admins see only users in their own tenant.
+- Distributor sees all users, can filter by `?tenantId=X`, and can create users in any tenant.
+
+### Cross-Tenant Access for Distributor
+
+When the distributor uses a tenant switcher to view a specific partner's data, the frontend sends `?tenantId=X` as a query parameter. The backend:
+
+1. Checks that the caller's role is `distributor`.
+2. Uses the provided `tenantId` for filtering instead of the caller's own `tenantId`.
+3. Returns 403 if a non-distributor tries to use this parameter.
+
+## Frontend Changes
+
+### Auth Context
+
+`AuthContext` expands to include:
+
+```typescript
+interface AuthUser {
+  id: number;
+  email: string;
+  role: 'distributor' | 'admin' | 'user';
+  tenantId: number;
+  tenantName: string;
+  fullName?: string;
+}
+```
+
+### Navigation & Routing
+
+**Distributor sees:**
+- Catalog management (existing pages, unchanged)
+- Tenants page (new — list/create/edit partner companies)
+- Tenant switcher in header (dropdown: "All Tenants" + list of partners)
+- Users page (with tenant filter)
+- Projects page (with tenant column and filter)
+
+**Partner admin sees:**
+- Projects (own tenant only)
+- Users management (own tenant only)
+- Catalog (read-only — action buttons hidden)
+
+**Partner user sees:**
+- Projects (own tenant only)
+- Catalog (read-only)
+
+### Key UI Changes
+
+1. **Header:** Displays tenant name for partner users. Distributor gets a tenant switcher dropdown.
+2. **Catalog pages:** Conditionally hide add/edit/delete/import buttons based on `role !== 'distributor'`.
+3. **Users page:** Partner admin sees own tenant's users. Distributor gets tenant filter dropdown.
+4. **Projects page:** Partner users see own projects. Distributor sees all with tenant column/filter.
+5. **New Tenants page:** Simple CRUD table (distributor only), following existing UI patterns (modal for create/edit, table with action buttons).
+
+### API Service
+
+No major changes. The JWT carries tenant context automatically. The frontend only adds `?tenantId=X` when the distributor uses the tenant switcher.
+
+## Migration Plan
+
+A single migration that:
+
+1. Creates the `tenants` table.
+2. Inserts the distributor tenant (id=1, name from env or default, is_distributor=true).
+3. Adds `tenant_id` column to `users` with default 1 (all existing users become distributor tenant).
+4. Adds `tenant_id` column to `projects` with default 1 (all existing projects become distributor tenant).
+5. Updates existing users with `role='admin'` to `role='distributor'`.
+6. Drops and recreates the unique index on projects: `(name, customer_name)` → `(name, customer_name, tenant_id)`.
+
+This is backwards-compatible — existing data is assigned to the distributor tenant, existing admins become distributors.
+
+## Edge Cases
+
+- **Tenant deletion:** Soft delete only (set `is_active = false`). Users of deactivated tenants cannot log in. Projects are preserved for historical reference.
+- **Email uniqueness:** Globally unique. A person cannot have accounts in two tenants with the same email. This avoids login ambiguity.
+- **Distributor tenant protection:** The distributor tenant (is_distributor=true) cannot be deactivated or deleted.
+- **At least one distributor:** The system must always have at least one user with `role='distributor'`. Prevent deletion/demotion of the last distributor user.
+- **Branding:** Out of scope for now. The `tenants` table can later gain columns like `logo_path`, `primary_color` for per-tenant branding on proposals.
+
+## Out of Scope
+
+- Per-tenant branding/logos on proposals
+- Per-tenant catalog customization (all partners see the full catalog)
+- Partner-to-partner collaboration
+- Billing/subscription management

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import Profile from '@/pages/Profile';
 import ProjectList from '@/pages/projects/ProjectList';
 import ProjectDashboard from '@/pages/projects/ProjectDashboard';
 import UserManagement from '@/pages/settings/UserManagement';
+import TenantManagement from './pages/settings/TenantManagement';
 import CategoryManagement from '@/pages/catalog/CategoryManagement';
 import ItemManagement from '@/pages/catalog/ItemManagement';
 
@@ -42,20 +43,27 @@ function App() {
                 </ErrorBoundary>
               } />
               
-              {/* Admin only routes */}
+              {/* Catalog routes - browsable by all authenticated users */}
               <Route path="catalog/products" element={
-                <ProtectedRoute requireAdmin>
+                <ProtectedRoute>
                   <ItemManagement />
                 </ProtectedRoute>
               } />
               <Route path="catalog/categories" element={
-                <ProtectedRoute requireAdmin>
+                <ProtectedRoute>
                   <CategoryManagement />
                 </ProtectedRoute>
               } />
+
+              {/* Admin only routes */}
               <Route path="settings/users" element={
-                <ProtectedRoute requireAdmin>
+                <ProtectedRoute requireTenantAdmin>
                   <UserManagement />
+                </ProtectedRoute>
+              } />
+              <Route path="settings/tenants" element={
+                <ProtectedRoute requireAdmin>
+                  <TenantManagement />
                 </ProtectedRoute>
               } />
             </Route>

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -5,11 +5,13 @@ import { Loader2 } from 'lucide-react';
 interface ProtectedRouteProps {
   children: React.ReactNode;
   requireAdmin?: boolean;
+  requireTenantAdmin?: boolean;
 }
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   children,
-  requireAdmin = false
+  requireAdmin = false,
+  requireTenantAdmin = false,
 }) => {
   const { isAuthenticated, user, isLoading } = useAuth();
 
@@ -26,6 +28,10 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   }
 
   if (requireAdmin && user?.role !== 'admin') {
+    return <Navigate to="/" replace />;
+  }
+
+  if (requireTenantAdmin && user?.role !== 'admin' && user?.role !== 'tenant_admin') {
     return <Navigate to="/" replace />;
   }
 

--- a/frontend/src/components/common/ConfirmDeleteModal.tsx
+++ b/frontend/src/components/common/ConfirmDeleteModal.tsx
@@ -46,7 +46,7 @@ export function ConfirmDeleteModal({
           <DialogDescription>
             {disabled
               ? disabledMessage
-              : `Are you sure you want to delete ${itemName ? <strong>{itemName}</strong> : 'this item'}? This action cannot be undone.`}
+              : <>Are you sure you want to delete {itemName ? <strong>{itemName}</strong> : 'this item'}? This action cannot be undone.</>}
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/src/components/floorplans/FloorplanTabs.tsx
+++ b/frontend/src/components/floorplans/FloorplanTabs.tsx
@@ -9,6 +9,7 @@ interface FloorplanTabsProps {
   onDelete: (floorplan: Floorplan) => void;
   onReorder: (floorplanId: number, direction: 'up' | 'down') => void;
   onAdd: () => void;
+  readOnly?: boolean;
 }
 
 export function FloorplanTabs({
@@ -19,6 +20,7 @@ export function FloorplanTabs({
   onDelete,
   onReorder,
   onAdd,
+  readOnly = false,
 }: FloorplanTabsProps) {
   return (
     <div className="flex items-center justify-start border-b bg-muted/30 px-4 py-2 flex-shrink-0 h-10">
@@ -34,7 +36,7 @@ export function FloorplanTabs({
             onClick={() => onSelect(floorplan)}
           >
             <span className="text-sm">{floorplan.name}</span>
-            <div className="flex items-center gap-0.5 ml-1">
+            {!readOnly && <div className="flex items-center gap-0.5 ml-1">
               <button
                 onClick={(e) => {
                   e.stopPropagation();
@@ -77,17 +79,19 @@ export function FloorplanTabs({
               >
                 <Trash className="h-3 w-3" />
               </button>
-            </div>
+            </div>}
           </div>
         ))}
         
-        <div
-          className="flex items-center px-3 py-2 cursor-pointer transition-colors whitespace-nowrap border-b-2 text-muted-foreground border-transparent hover:text-foreground"
-          onClick={onAdd}
-          title="Add Floorplan"
-        >
-          <Plus className="h-4 w-4" />
-        </div>
+        {!readOnly && (
+          <div
+            className="flex items-center px-3 py-2 cursor-pointer transition-colors whitespace-nowrap border-b-2 text-muted-foreground border-transparent hover:text-foreground"
+            onClick={onAdd}
+            title="Add Floorplan"
+          >
+            <Plus className="h-4 w-4" />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/context/AuthContext';
+import { roleLabels } from '@/types';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import {
@@ -11,7 +12,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { ThemeToggle } from '@/components/common/ThemeToggle';
-import { User, LogOut, LayoutGrid, Tags, Settings, ChevronDown } from 'lucide-react';
+import { User, LogOut, LayoutGrid, Tags, Settings, ChevronDown, Building2 } from 'lucide-react';
 
 const Header = () => {
   const { user, isAuthenticated, logout } = useAuth();
@@ -22,6 +23,9 @@ const Header = () => {
     const name = user?.full_name || user?.email || 'U';
     return name.charAt(0).toUpperCase();
   };
+
+  const isTenantAdmin = user?.role === 'tenant_admin' || user?.role === 'admin';
+  const isAdmin = user?.role === 'admin';
 
   const handleLogout = () => {
     logout();
@@ -55,7 +59,7 @@ const Header = () => {
               Projects
             </Link>
 
-            {user?.role === 'admin' && (
+            {isAuthenticated && (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <button className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors">
@@ -63,8 +67,8 @@ const Header = () => {
                     <ChevronDown className="h-4 w-4" />
                   </button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent 
-                  align="start" 
+                <DropdownMenuContent
+                  align="start"
                   side="bottom"
                   sideOffset={16}
                   className="min-w-[--radix-dropdown-menu-trigger-width] rounded-t-none border-t-0 shadow-none"
@@ -85,7 +89,7 @@ const Header = () => {
               </DropdownMenu>
             )}
 
-            {user?.role === 'admin' && (
+            {isTenantAdmin && (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <button className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors">
@@ -93,8 +97,8 @@ const Header = () => {
                     <ChevronDown className="h-4 w-4" />
                   </button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent 
-                  align="start" 
+                <DropdownMenuContent
+                  align="start"
                   side="bottom"
                   sideOffset={16}
                   className="min-w-[--radix-dropdown-menu-trigger-width] rounded-t-none border-t-0 shadow-none"
@@ -105,6 +109,14 @@ const Header = () => {
                       User Management
                     </Link>
                   </DropdownMenuItem>
+                  {isAdmin && (
+                    <DropdownMenuItem asChild>
+                      <Link to="/settings/tenants" className="flex items-center gap-2">
+                        <Building2 className="h-4 w-4" />
+                        Tenants
+                      </Link>
+                    </DropdownMenuItem>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
             )}
@@ -127,8 +139,8 @@ const Header = () => {
                       <span className="text-sm font-medium leading-none">
                         {getDisplayName()}
                       </span>
-                      <span className="text-xs text-muted-foreground capitalize">
-                        {user?.role}
+                      <span className="text-xs text-muted-foreground">
+                        {user?.role ? roleLabels[user.role] : 'User'}
                       </span>
                     </div>
                   </button>
@@ -137,7 +149,10 @@ const Header = () => {
                   <DropdownMenuLabel className="font-normal">
                     <div className="flex flex-col space-y-1">
                       <p className="text-sm font-medium">{user?.full_name || user?.email}</p>
-                      <p className="text-xs text-muted-foreground capitalize">{user?.role} Account</p>
+                      <p className="text-xs text-muted-foreground">{user?.role ? roleLabels[user.role] : 'User'}</p>
+                      {!isAdmin && user?.tenantName && (
+                        <p className="text-xs text-muted-foreground">{user.tenantName}</p>
+                      )}
                     </div>
                   </DropdownMenuLabel>
                   <DropdownMenuSeparator />

--- a/frontend/src/components/projects/ProjectFormModal.tsx
+++ b/frontend/src/components/projects/ProjectFormModal.tsx
@@ -21,17 +21,20 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Separator } from '@/components/ui/separator';
 import { Loader2, FolderPlus, Save, X } from 'lucide-react';
 import type { Project, CreateProjectDTO, UpdateProjectDTO } from '@/services/project';
+import type { Tenant } from '@/services/tenants';
 import { extractErrorMessage } from '@/utils';
 
 interface ProjectFormModalProps {
   project: Project | null;
+  tenants?: Tenant[];
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (data: CreateProjectDTO | UpdateProjectDTO) => Promise<void>;
 }
 
-export function ProjectFormModal({ project, isOpen, onClose, onSubmit }: ProjectFormModalProps) {
+export function ProjectFormModal({ project, tenants, isOpen, onClose, onSubmit }: ProjectFormModalProps) {
   const isEdit = !!project;
+  const isAdmin = tenants && tenants.length > 0;
   const [formData, setFormData] = useState({
     name: '',
     status: 'active' as 'active' | 'completed' | 'cancelled',
@@ -39,6 +42,7 @@ export function ProjectFormModal({ project, isOpen, onClose, onSubmit }: Project
     customer_email: '',
     customer_phone: '',
     customer_address: '',
+    tenant_id: 0,
   });
   const [error, setError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -53,6 +57,7 @@ export function ProjectFormModal({ project, isOpen, onClose, onSubmit }: Project
           customer_email: project.customer_email || '',
           customer_phone: project.customer_phone || '',
           customer_address: project.customer_address || '',
+          tenant_id: project.tenant_id || 0,
         });
       } else {
         setFormData({
@@ -62,6 +67,7 @@ export function ProjectFormModal({ project, isOpen, onClose, onSubmit }: Project
           customer_email: '',
           customer_phone: '',
           customer_address: '',
+          tenant_id: tenants?.[0]?.id ?? 0,
         });
       }
       setError('');
@@ -76,7 +82,7 @@ export function ProjectFormModal({ project, isOpen, onClose, onSubmit }: Project
     try {
       if (isEdit) {
         // Always include all fields so clearing optional fields actually saves
-        const updateData: UpdateProjectDTO = {
+        const updateData: UpdateProjectDTO & { tenant_id?: number } = {
           name: formData.name,
           status: formData.status,
           customer_name: formData.customer_name,
@@ -84,9 +90,10 @@ export function ProjectFormModal({ project, isOpen, onClose, onSubmit }: Project
           customer_phone: formData.customer_phone,
           customer_address: formData.customer_address,
         };
+        if (isAdmin && formData.tenant_id) updateData.tenant_id = formData.tenant_id;
         await onSubmit(updateData);
       } else {
-        const createData: CreateProjectDTO = {
+        const createData: CreateProjectDTO & { tenant_id?: number } = {
           name: formData.name,
           status: formData.status,
           customer_name: formData.customer_name,
@@ -94,6 +101,7 @@ export function ProjectFormModal({ project, isOpen, onClose, onSubmit }: Project
         if (formData.customer_email) createData.customer_email = formData.customer_email;
         if (formData.customer_phone) createData.customer_phone = formData.customer_phone;
         if (formData.customer_address) createData.customer_address = formData.customer_address;
+        if (isAdmin && formData.tenant_id) createData.tenant_id = formData.tenant_id;
         await onSubmit(createData);
       }
       onClose();
@@ -152,6 +160,29 @@ export function ProjectFormModal({ project, isOpen, onClose, onSubmit }: Project
               </SelectContent>
             </Select>
           </div>
+
+          {isAdmin && (
+            <div className="space-y-2">
+              <Label htmlFor="tenant">Tenant</Label>
+              <Select
+                value={formData.tenant_id.toString()}
+                onValueChange={(value) =>
+                  setFormData({ ...formData, tenant_id: parseInt(value) })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a tenant" />
+                </SelectTrigger>
+                <SelectContent>
+                  {tenants!.map((t) => (
+                    <SelectItem key={t.id} value={t.id.toString()}>
+                      {t.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
 
           <Separator />
 

--- a/frontend/src/components/settings/TenantFormModal.tsx
+++ b/frontend/src/components/settings/TenantFormModal.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { X, Save, Plus } from 'lucide-react';
+import type { Tenant, CreateTenantDTO, UpdateTenantDTO } from '@/services/tenants';
+import { extractErrorMessage } from '@/utils';
+
+interface TenantFormModalProps {
+  tenant: Tenant | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: CreateTenantDTO | UpdateTenantDTO) => Promise<void>;
+}
+
+export function TenantFormModal({ tenant, isOpen, onClose, onSubmit }: TenantFormModalProps) {
+  const isEdit = !!tenant;
+  const [formData, setFormData] = useState({
+    name: '',
+    is_distributor: 0,
+    is_active: 1,
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (tenant) {
+      setFormData({
+        name: tenant.name,
+        is_distributor: tenant.is_distributor,
+        is_active: tenant.is_active,
+      });
+    } else {
+      setFormData({
+        name: '',
+        is_distributor: 0,
+        is_active: 1,
+      });
+    }
+    setError('');
+  }, [tenant, isOpen]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setIsLoading(true);
+
+    try {
+      if (isEdit) {
+        const updateData: UpdateTenantDTO = {
+          name: formData.name,
+          is_active: formData.is_active,
+          is_distributor: formData.is_distributor,
+        };
+        await onSubmit(updateData);
+      } else {
+        const createData: CreateTenantDTO = {
+          name: formData.name,
+          is_distributor: formData.is_distributor,
+        };
+        await onSubmit(createData);
+      }
+      onClose();
+    } catch (err: unknown) {
+      setError(extractErrorMessage(err) || 'Failed to save tenant');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit Tenant' : 'Create Tenant'}</DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? 'Update tenant details below.'
+              : 'Fill in the details to create a new tenant.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <div className="text-sm text-destructive bg-destructive/10 p-3 rounded">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              value={formData.name}
+              onChange={(e) =>
+                setFormData({ ...formData, name: e.target.value })
+              }
+              placeholder="Company name"
+              required
+            />
+          </div>
+
+          {isEdit && !tenant?.is_distributor && (
+            <div className="flex items-center justify-between">
+              <Label htmlFor="is_active">Active</Label>
+              <Switch
+                id="is_active"
+                checked={!!formData.is_active}
+                onCheckedChange={(checked) =>
+                  setFormData({ ...formData, is_active: checked ? 1 : 0 })
+                }
+              />
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="type">Type</Label>
+            <Select
+              value={formData.is_distributor.toString()}
+              onValueChange={(value) =>
+                setFormData({ ...formData, is_distributor: parseInt(value) })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="0">Partner</SelectItem>
+                <SelectItem value="1">Distributor</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              <X className="mr-2 h-4 w-4" />
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isLoading}>
+              {isLoading ? (
+                'Saving...'
+              ) : isEdit ? (
+                <>
+                  <Save className="mr-2 h-4 w-4" />
+                  Update
+                </>
+              ) : (
+                <>
+                  <Plus className="mr-2 h-4 w-4" />
+                  Create
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/users/UserFormModal.tsx
+++ b/frontend/src/components/users/UserFormModal.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { X, Save, Plus } from 'lucide-react';
 import {
   Select,
@@ -18,24 +19,30 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import type { User } from '@/types';
+import type { User, UserRole } from '@/types';
 import type { CreateUserDTO, UpdateUserDTO } from '@/services/user';
+import type { Tenant } from '@/services/tenants';
 import { extractErrorMessage } from '@/utils';
 
 interface UserFormModalProps {
   user: User | null;
+  currentUserRole: UserRole;
+  tenants?: Tenant[];
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (data: CreateUserDTO | UpdateUserDTO) => Promise<void>;
 }
 
-export function UserFormModal({ user, isOpen, onClose, onSubmit }: UserFormModalProps) {
+export function UserFormModal({ user, currentUserRole, tenants, isOpen, onClose, onSubmit }: UserFormModalProps) {
   const isEdit = !!user;
+  const isAdmin = currentUserRole === 'admin';
   const [formData, setFormData] = useState({
     full_name: '',
     email: '',
     password: '',
-    role: 'user' as 'admin' | 'user',
+    role: 'user' as UserRole,
+    is_active: 1,
+    tenant_id: 0,
   });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
@@ -47,6 +54,8 @@ export function UserFormModal({ user, isOpen, onClose, onSubmit }: UserFormModal
         email: user.email,
         password: '',
         role: user.role,
+        is_active: user.is_active ?? 1,
+        tenant_id: user.tenant_id ?? 0,
       });
     } else {
       setFormData({
@@ -54,6 +63,8 @@ export function UserFormModal({ user, isOpen, onClose, onSubmit }: UserFormModal
         email: '',
         password: '',
         role: 'user',
+        is_active: 1,
+        tenant_id: tenants?.[0]?.id ?? 0,
       });
     }
     setError('');
@@ -71,6 +82,8 @@ export function UserFormModal({ user, isOpen, onClose, onSubmit }: UserFormModal
           email: formData.email,
           ...(formData.password ? { password: formData.password } : {}),
           role: formData.role,
+          is_active: formData.is_active,
+          ...(isAdmin && formData.tenant_id ? { tenant_id: formData.tenant_id } : {}),
         };
         await onSubmit(updateData);
       } else {
@@ -79,6 +92,7 @@ export function UserFormModal({ user, isOpen, onClose, onSubmit }: UserFormModal
           email: formData.email,
           password: formData.password,
           role: formData.role,
+          ...(isAdmin && formData.tenant_id ? { tenant_id: formData.tenant_id } : {}),
         };
         await onSubmit(createData);
       }
@@ -155,7 +169,7 @@ export function UserFormModal({ user, isOpen, onClose, onSubmit }: UserFormModal
             <Label htmlFor="role">Role</Label>
             <Select
               value={formData.role}
-              onValueChange={(value: 'admin' | 'user') =>
+              onValueChange={(value: UserRole) =>
                 setFormData({ ...formData, role: value })
               }
             >
@@ -164,10 +178,49 @@ export function UserFormModal({ user, isOpen, onClose, onSubmit }: UserFormModal
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="user">User</SelectItem>
-                <SelectItem value="admin">Admin</SelectItem>
+                <SelectItem value="tenant_admin">Tenant Admin</SelectItem>
+                {currentUserRole === 'admin' && (
+                  <SelectItem value="admin">Admin</SelectItem>
+                )}
               </SelectContent>
             </Select>
           </div>
+
+          {isAdmin && tenants && tenants.length > 0 && (
+            <div className="space-y-2">
+              <Label htmlFor="tenant">Tenant</Label>
+              <Select
+                value={formData.tenant_id.toString()}
+                onValueChange={(value) =>
+                  setFormData({ ...formData, tenant_id: parseInt(value) })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a tenant" />
+                </SelectTrigger>
+                <SelectContent>
+                  {tenants.map((t) => (
+                    <SelectItem key={t.id} value={t.id.toString()}>
+                      {t.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {isEdit && user?.role !== 'admin' && (
+            <div className="flex items-center justify-between">
+              <Label htmlFor="is_active">Active</Label>
+              <Switch
+                id="is_active"
+                checked={!!formData.is_active}
+                onCheckedChange={(checked) =>
+                  setFormData({ ...formData, is_active: checked ? 1 : 0 })
+                }
+              />
+            </div>
+          )}
 
           <DialogFooter>
             <Button type="button" variant="outline" onClick={onClose}>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useAuth } from '@/context/AuthContext';
+import { roleLabels } from '@/types';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -94,7 +95,7 @@ const Profile = () => {
             </Avatar>
             <div>
               <CardTitle className="text-xl">{getDisplayName()}</CardTitle>
-              <p className="text-sm text-muted-foreground capitalize">{user?.role}</p>
+              <p className="text-sm text-muted-foreground">{user?.role ? roleLabels[user.role] : 'User'}</p>
             </div>
           </div>
         </CardHeader>

--- a/frontend/src/pages/catalog/CategoryManagement.tsx
+++ b/frontend/src/pages/catalog/CategoryManagement.tsx
@@ -15,9 +15,12 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { CategoryFormModal } from '@/components/categories/CategoryFormModal';
 import { ConfirmDeleteModal } from '@/components/common/ConfirmDeleteModal';
 import { Plus, Pencil, Trash2, ArrowUp, ArrowDown, Loader2, CheckCircle, XCircle } from 'lucide-react';
+import { useAuth } from '@/context/AuthContext';
 import { extractErrorMessage } from '@/utils';
 
 const CategoryManagement = () => {
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
   const [categories, setCategories] = useState<Category[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
@@ -122,10 +125,12 @@ const CategoryManagement = () => {
           <h1 className="text-3xl font-bold tracking-tight">Category Management</h1>
           <p className="text-muted-foreground">Organize product categories and arrange their display order</p>
         </div>
-        <Button onClick={openCreateModal}>
-          <Plus className="mr-2 h-4 w-4" />
-          Add Category
-        </Button>
+        {isAdmin && (
+          <Button onClick={openCreateModal}>
+            <Plus className="mr-2 h-4 w-4" />
+            Add Category
+          </Button>
+        )}
       </div>
 
       {error && (
@@ -173,26 +178,28 @@ const CategoryManagement = () => {
                     <TableCell>
                       <div className="flex items-center gap-2">
                         <span className="text-muted-foreground w-6">{category.sort_order}</span>
-                        <div className="flex flex-col">
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-6 w-6"
-                            onClick={() => moveCategory(index, 'up')}
-                            disabled={index === 0}
-                          >
-                            <ArrowUp className="h-3 w-3" />
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-6 w-6"
-                            onClick={() => moveCategory(index, 'down')}
-                            disabled={index === categories.length - 1}
-                          >
-                            <ArrowDown className="h-3 w-3" />
-                          </Button>
-                        </div>
+                        {isAdmin && (
+                          <div className="flex flex-col">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-6 w-6"
+                              onClick={() => moveCategory(index, 'up')}
+                              disabled={index === 0}
+                            >
+                              <ArrowUp className="h-3 w-3" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-6 w-6"
+                              onClick={() => moveCategory(index, 'down')}
+                              disabled={index === categories.length - 1}
+                            >
+                              <ArrowDown className="h-3 w-3" />
+                            </Button>
+                          </div>
+                        )}
                       </div>
                     </TableCell>
                     <TableCell className="font-medium">
@@ -212,24 +219,26 @@ const CategoryManagement = () => {
                       )}
                     </TableCell>
                     <TableCell>
-                      <div className="flex gap-2">
-                        <Button 
-                          variant="outline" 
-                          size="sm" 
-                          onClick={() => openEditModal(category)}
-                        >
-                          <Pencil className="mr-1 h-3 w-3" />
-                          Edit
-                        </Button>
-                        <Button 
-                          variant="destructive" 
-                          size="sm" 
-                          onClick={() => openDeleteModal(category)}
-                        >
-                          <Trash2 className="mr-1 h-3 w-3" />
-                          Delete
-                        </Button>
-                      </div>
+                      {isAdmin && (
+                        <div className="flex gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => openEditModal(category)}
+                          >
+                            <Pencil className="mr-1 h-3 w-3" />
+                            Edit
+                          </Button>
+                          <Button
+                            variant="destructive"
+                            size="sm"
+                            onClick={() => openDeleteModal(category)}
+                          >
+                            <Trash2 className="mr-1 h-3 w-3" />
+                            Delete
+                          </Button>
+                        </div>
+                      )}
                     </TableCell>
                   </TableRow>
                 ))

--- a/frontend/src/pages/catalog/ItemManagement.tsx
+++ b/frontend/src/pages/catalog/ItemManagement.tsx
@@ -50,9 +50,12 @@ import {
   Pencil,
   Trash2,
 } from 'lucide-react';
+import { useAuth } from '@/context/AuthContext';
 import { extractErrorMessage } from '@/utils';
 
 const ItemManagement = () => {
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
   const [items, setItems] = useState<Item[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -342,14 +345,18 @@ const ItemManagement = () => {
           <p className="text-muted-foreground">Manage products and their details</p>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={() => setShowImportModal(true)}>
-            <Upload className="mr-2 h-4 w-4" />
-            Import Catalog
-          </Button>
-          <Button onClick={() => openItemModal()}>
-            <Plus className="mr-2 h-4 w-4" />
-            Add Product
-          </Button>
+          {isAdmin && (
+            <Button variant="outline" onClick={() => setShowImportModal(true)}>
+              <Upload className="mr-2 h-4 w-4" />
+              Import Catalog
+            </Button>
+          )}
+          {isAdmin && (
+            <Button onClick={() => openItemModal()}>
+              <Plus className="mr-2 h-4 w-4" />
+              Add Product
+            </Button>
+          )}
         </div>
       </div>
 
@@ -494,24 +501,26 @@ const ItemManagement = () => {
                           )}
                         </TableCell>
                         <TableCell>
-                          <div className="flex gap-2">
-                            <Button 
-                              variant="outline" 
-                              size="sm"
-                              onClick={() => openItemModal(item)}
-                            >
-                              <Pencil className="mr-1 h-3 w-3" />
-                              Edit
-                            </Button>
-                            <Button 
-                              variant="destructive" 
-                              size="sm"
-                              onClick={() => openDeleteModal(item)}
-                            >
-                              <Trash2 className="mr-1 h-3 w-3" />
-                              Delete
-                            </Button>
-                          </div>
+                          {isAdmin && (
+                            <div className="flex gap-2">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => openItemModal(item)}
+                              >
+                                <Pencil className="mr-1 h-3 w-3" />
+                                Edit
+                              </Button>
+                              <Button
+                                variant="destructive"
+                                size="sm"
+                                onClick={() => openDeleteModal(item)}
+                              >
+                                <Trash2 className="mr-1 h-3 w-3" />
+                                Delete
+                              </Button>
+                            </div>
+                          )}
                         </TableCell>
                       </TableRow>
                       
@@ -527,13 +536,15 @@ const ItemManagement = () => {
                                   </Badge>
                                   Styles
                                 </h4>
-                                <Button 
-                                  size="sm" 
-                                  variant="outline"
-                                  onClick={() => openVariantModal(item)}
-                                >
-                                  <Plus className="mr-1 h-3 w-3" /> Add Style
-                                </Button>
+                                {isAdmin && (
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => openVariantModal(item)}
+                                  >
+                                    <Plus className="mr-1 h-3 w-3" /> Add Style
+                                  </Button>
+                                )}
                               </div>
                               
                               {isLoadingVar ? (
@@ -588,24 +599,26 @@ const ItemManagement = () => {
                                           )}
                                         </td>
                                         <td className="py-3 px-4 text-right">
-                                          <div className="flex gap-2 justify-end">
-                                            <Button 
-                                              size="sm" 
-                                              variant="outline"
-                                              onClick={() => openVariantModal(item, variant)}
-                                            >
-                                              <Pencil className="mr-1 h-3 w-3" />
-                                              Edit
-                                            </Button>
-                                            <Button 
-                                              size="sm" 
-                                              variant="destructive"
-                                              onClick={() => openDeleteVariantModal(item.id, variant)}
-                                            >
-                                              <Trash2 className="mr-1 h-3 w-3" />
-                                              Delete
-                                            </Button>
-                                          </div>
+                                          {isAdmin && (
+                                            <div className="flex gap-2 justify-end">
+                                              <Button
+                                                size="sm"
+                                                variant="outline"
+                                                onClick={() => openVariantModal(item, variant)}
+                                              >
+                                                <Pencil className="mr-1 h-3 w-3" />
+                                                Edit
+                                              </Button>
+                                              <Button
+                                                size="sm"
+                                                variant="destructive"
+                                                onClick={() => openDeleteVariantModal(item.id, variant)}
+                                              >
+                                                <Trash2 className="mr-1 h-3 w-3" />
+                                                Delete
+                                              </Button>
+                                            </div>
+                                          )}
                                         </td>
                                       </tr>
                                     ))}

--- a/frontend/src/pages/projects/ProjectDashboard.tsx
+++ b/frontend/src/pages/projects/ProjectDashboard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useAuth } from '@/context/AuthContext';
 import type { Project } from '@/services/project';
 import { floorplanService, type Floorplan, type CreateFloorplanDTO } from '@/services/floorplan';
 import type { InvoiceSettings } from '@/services/invoice-settings';
@@ -43,6 +44,7 @@ const generateProjectNumber = (project: Project): string => {
 const ProjectDashboard = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { user } = useAuth();
   const projectId = parseInt(id || '0');
 
   const [placementsVersion, setPlacementsVersion] = useState(0);
@@ -68,6 +70,9 @@ const ProjectDashboard = () => {
     fetchProjectData,
     fetchFloorplanBom,
   } = useProjectData({ projectId });
+
+  // Users can only edit active projects; admins/tenant_admins can edit any
+  const canEdit = user?.role !== 'user' || project?.status === 'active';
 
   // BOM calculations
   const { floorplanTotals, projectTotal } = useBomCalculations(floorplans, floorplanBoms, items, categories);
@@ -522,28 +527,35 @@ const ProjectDashboard = () => {
     <div className="fixed inset-0 top-12 flex flex-col">
       <ProjectHeader project={project} onBack={() => navigate('/projects')} />
 
+      {!canEdit && (
+        <div className="bg-muted border-b px-4 py-2 text-sm text-muted-foreground text-center">
+          This project is read-only because it is no longer active.
+        </div>
+      )}
+
       {/* Configurator Area */}
       <DndContext
-        sensors={sensors}
-        onDragStart={handleDragStart}
-        onDragEnd={handleDragEnd}
+        sensors={canEdit ? sensors : []}
+        onDragStart={canEdit ? handleDragStart : undefined}
+        onDragEnd={canEdit ? handleDragEnd : undefined}
         collisionDetection={pointerWithin}
       >
         <div className="flex-1 flex overflow-hidden">
           {/* Left Side - Canvas Area */}
           <div className="flex-1 flex flex-col min-w-0 bg-card">
             {floorplans.length === 0 ? (
-              <EmptyFloorplanState onAdd={openCreateFloorplanModal} />
+              <EmptyFloorplanState onAdd={canEdit ? openCreateFloorplanModal : () => {}} />
             ) : (
               <div className="flex-1 flex flex-col overflow-hidden">
                 <FloorplanTabs
                   floorplans={floorplans}
                   activeFloorplan={activeFloorplan}
                   onSelect={setActiveFloorplan}
-                  onEdit={openEditFloorplanModal}
-                  onDelete={openDeleteFloorplanModal}
-                  onReorder={handleReorderFloorplans}
-                  onAdd={openCreateFloorplanModal}
+                  onEdit={canEdit ? openEditFloorplanModal : () => {}}
+                  onDelete={canEdit ? openDeleteFloorplanModal : () => {}}
+                  onReorder={canEdit ? handleReorderFloorplans : () => {}}
+                  onAdd={canEdit ? openCreateFloorplanModal : () => {}}
+                  readOnly={!canEdit}
                 />
 
                 {/* Canvas Area */}
@@ -557,8 +569,8 @@ const ProjectDashboard = () => {
                         items={items}
                         bom={floorplanBoms.get(activeFloorplan.id) || null}
                         placementAddons={placementAddons}
-                        onPlacementUpdate={handlePlacementUpdate}
-                        onPlacementDelete={handlePlacementDelete}
+                        onPlacementUpdate={canEdit ? handlePlacementUpdate : () => {}}
+                        onPlacementDelete={canEdit ? handlePlacementDelete : () => {}}
                         isResizingRef={isResizingRef}
                         zoomRef={canvasZoomRef}
                         scaleRef={canvasScaleRef}
@@ -569,17 +581,17 @@ const ProjectDashboard = () => {
                         hiddenAreaIds={hiddenAreaIds}
                         selectedAreaId={selectedAreaId}
                         onSelectArea={setSelectedAreaId}
-                        onAreaMove={handleAreaMove}
-                        onAreaVertexMove={handleAreaVertexMove}
-                        onAreaVerticesReplace={handleAreaVerticesReplace}
-                        onAreaVertexAdd={handleAreaVertexAdd}
-                        onAreaVertexDelete={handleAreaVertexDelete}
-                        onAreaVerticesCommit={handleAreaVerticesCommit}
-                        onAreaEdit={(id) => setEditingArea(localAreas.find(a => a.id === id) || null)}
-                        onAreaDelete={async (id) => {
+                        onAreaMove={canEdit ? handleAreaMove : () => {}}
+                        onAreaVertexMove={canEdit ? handleAreaVertexMove : () => {}}
+                        onAreaVerticesReplace={canEdit ? handleAreaVerticesReplace : () => {}}
+                        onAreaVertexAdd={canEdit ? handleAreaVertexAdd : () => {}}
+                        onAreaVertexDelete={canEdit ? handleAreaVertexDelete : () => {}}
+                        onAreaVerticesCommit={canEdit ? handleAreaVerticesCommit : () => {}}
+                        onAreaEdit={canEdit ? (id) => setEditingArea(localAreas.find(a => a.id === id) || null) : () => {}}
+                        onAreaDelete={canEdit ? async (id) => {
                           await deleteArea(id);
                           if (activeFloorplan) fetchPlacements(activeFloorplan.id);
-                        }}
+                        } : () => {}}
                       />
                     </div>
                   </div>
@@ -630,11 +642,11 @@ const ProjectDashboard = () => {
                   areas={areas}
                   selectedAreaId={selectedAreaId}
                   onSelectArea={setSelectedAreaId}
-                  onEditArea={(id) => setEditingArea(areas.find(a => a.id === id) || null)}
-                  onDeleteArea={async (id) => {
+                  onEditArea={canEdit ? (id) => setEditingArea(areas.find(a => a.id === id) || null) : () => {}}
+                  onDeleteArea={canEdit ? async (id) => {
                     await deleteArea(id);
                     if (activeFloorplan) fetchPlacements(activeFloorplan.id);
-                  }}
+                  } : () => {}}
                   onToggleAreaVisibility={handleToggleAreaVisibility}
                   onToggleAllAreasVisibility={handleToggleAllAreasVisibility}
                   hiddenAreaIds={hiddenAreaIds}
@@ -674,7 +686,7 @@ const ProjectDashboard = () => {
                   floorplanTotals={floorplanTotals}
                   projectTotal={projectTotal}
                   invoiceSettings={invoiceSettings}
-                  onConfigureInvoice={() => setShowInvoiceModal(true)}
+                  onConfigureInvoice={canEdit ? () => setShowInvoiceModal(true) : () => {}}
                   items={items}
                   categories={categories}
                   getFloorplanAreaData={getFloorplanAreaData}

--- a/frontend/src/pages/projects/ProjectList.tsx
+++ b/frontend/src/pages/projects/ProjectList.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuth } from '@/context/AuthContext';
 import { projectService, type Project, type CreateProjectDTO, type UpdateProjectDTO } from '@/services/project';
 import { floorplanService } from '@/services/floorplan';
+import { tenantService, type Tenant } from '@/services/tenants';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import {
@@ -38,7 +40,13 @@ const generateProjectNumber = (project: Project): string => {
 const ProjectList = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
+  const isUser = user?.role === 'user';
+  const canManage = !isUser; // admin and tenant_admin can manage all projects
   const [projects, setProjects] = useState<Project[]>([]);
+  const [tenants, setTenants] = useState<Tenant[]>([]);
+  const [tenantMap, setTenantMap] = useState<Record<number, string>>({});
   const [isLoading, setIsLoading] = useState(true);
   const [isSearching, setIsSearching] = useState(false);
   const [error, setError] = useState('');
@@ -86,10 +94,20 @@ const ProjectList = () => {
     const controller = new AbortController();
     fetchProjects(controller.signal);
 
+    // Fetch tenants for admin
+    if (isAdmin) {
+      tenantService.getAll(controller.signal).then((data) => {
+        setTenants(data);
+        const map: Record<number, string> = {};
+        data.forEach((t: Tenant) => { map[t.id] = t.name; });
+        setTenantMap(map);
+      }).catch(() => { /* ignore */ });
+    }
+
     return () => {
       controller.abort();
     };
-  }, [fetchProjects]);
+  }, [fetchProjects, isAdmin]);
 
   // Debounced search
   useEffect(() => {
@@ -235,6 +253,7 @@ const ProjectList = () => {
                 <TableHead>Project Number</TableHead>
                 <TableHead>Project Name</TableHead>
                 <TableHead>Customer</TableHead>
+                {isAdmin && <TableHead>Tenant</TableHead>}
                 <TableHead>Status</TableHead>
                 <TableHead className="w-40"></TableHead>
               </TableRow>
@@ -242,7 +261,7 @@ const ProjectList = () => {
             <TableBody>
               {filteredProjects.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
+                  <TableCell colSpan={isAdmin ? 6 : 5} className="text-center py-8 text-muted-foreground">
                     No projects found. Create your first project to get started.
                   </TableCell>
                 </TableRow>
@@ -254,6 +273,11 @@ const ProjectList = () => {
                     </TableCell>
                     <TableCell className="font-medium">{project.name}</TableCell>
                     <TableCell>{project.customer_name}</TableCell>
+                    {isAdmin && (
+                      <TableCell className="text-muted-foreground">
+                        {tenantMap[project.tenant_id] || '—'}
+                      </TableCell>
+                    )}
                     <TableCell>
                       {project.status === 'active' ? (
                         <span className="inline-flex items-center text-green-600 text-sm">
@@ -282,22 +306,26 @@ const ProjectList = () => {
                           <Eye className="mr-1 h-3 w-3" />
                           Open
                         </Button>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => openEditModal(project)}
-                        >
-                          <Pencil className="mr-1 h-3 w-3" />
-                          Edit
-                        </Button>
-                        <Button
-                          variant="destructive"
-                          size="sm"
-                          onClick={() => openDeleteModal(project)}
-                        >
-                          <Trash2 className="mr-1 h-3 w-3" />
-                          Delete
-                        </Button>
+                        {(canManage || project.status === 'active') && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => openEditModal(project)}
+                          >
+                            <Pencil className="mr-1 h-3 w-3" />
+                            Edit
+                          </Button>
+                        )}
+                        {canManage && (
+                          <Button
+                            variant="destructive"
+                            size="sm"
+                            onClick={() => openDeleteModal(project)}
+                          >
+                            <Trash2 className="mr-1 h-3 w-3" />
+                            Delete
+                          </Button>
+                        )}
                       </div>
                     </TableCell>
                   </TableRow>
@@ -310,6 +338,7 @@ const ProjectList = () => {
 
       <ProjectFormModal
         project={projectToEdit}
+        tenants={isAdmin ? tenants : undefined}
         isOpen={showFormModal}
         onClose={() => {
           setShowFormModal(false);

--- a/frontend/src/pages/settings/TenantManagement.tsx
+++ b/frontend/src/pages/settings/TenantManagement.tsx
@@ -1,0 +1,203 @@
+import { useState, useEffect } from 'react';
+import { tenantService, type Tenant, type CreateTenantDTO, type UpdateTenantDTO } from '@/services/tenants';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { TenantFormModal } from '@/components/settings/TenantFormModal';
+import { ConfirmDeleteModal } from '@/components/common/ConfirmDeleteModal';
+import { Plus, Pencil, Trash2, Loader2 } from 'lucide-react';
+import { extractErrorMessage } from '@/utils';
+
+const TenantManagement = () => {
+  const [tenants, setTenants] = useState<Tenant[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [showFormModal, setShowFormModal] = useState(false);
+  const [showDeactivateModal, setShowDeactivateModal] = useState(false);
+  const [tenantToEdit, setTenantToEdit] = useState<Tenant | null>(null);
+  const [tenantToDeactivate, setTenantToDeactivate] = useState<Tenant | null>(null);
+
+  const fetchTenants = async (signal?: AbortSignal) => {
+    try {
+      setIsLoading(true);
+      const data = await tenantService.getAll(signal);
+      setTenants(data);
+      setError('');
+    } catch (err: unknown) {
+      const errorMessage = extractErrorMessage(err, '');
+      if (errorMessage !== 'AbortError') {
+        setError(extractErrorMessage(err) || 'Failed to fetch tenants');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchTenants(controller.signal);
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  const handleSubmitTenant = async (data: CreateTenantDTO | UpdateTenantDTO) => {
+    if (tenantToEdit) {
+      await tenantService.update(tenantToEdit.id, data as UpdateTenantDTO);
+    } else {
+      await tenantService.create(data as CreateTenantDTO);
+    }
+    fetchTenants();
+  };
+
+  const handleDeleteTenant = async () => {
+    if (!tenantToDeactivate) return;
+    try {
+      await tenantService.deactivate(tenantToDeactivate.id);
+      fetchTenants();
+    } catch (err: unknown) {
+      setError(extractErrorMessage(err) || 'Failed to delete tenant');
+    }
+  };
+
+  const openCreateModal = () => {
+    setTenantToEdit(null);
+    setShowFormModal(true);
+  };
+
+  const openEditModal = (tenant: Tenant) => {
+    setTenantToEdit(tenant);
+    setShowFormModal(true);
+  };
+
+  const openDeactivateModal = (tenant: Tenant) => {
+    setTenantToDeactivate(tenant);
+    setShowDeactivateModal(true);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Tenants</h1>
+          <p className="text-muted-foreground">Manage distributor and partner companies</p>
+        </div>
+        <Button onClick={openCreateModal}>
+          <Plus className="mr-2 h-4 w-4" />
+          Add Tenant
+        </Button>
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <Card>
+        <CardHeader />
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="w-32"></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {tenants.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center py-8 text-muted-foreground">
+                    No tenants found. Create your first tenant to get started.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                tenants.map((tenant) => (
+                  <TableRow key={tenant.id}>
+                    <TableCell className="font-medium">
+                      {tenant.name}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={tenant.is_distributor ? 'default' : 'outline'}>
+                        {tenant.is_distributor ? 'Distributor' : 'Partner'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={tenant.is_active ? 'default' : 'secondary'}>
+                        {tenant.is_active ? 'Active' : 'Inactive'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => openEditModal(tenant)}
+                        >
+                          <Pencil className="mr-1 h-3 w-3" />
+                          Edit
+                        </Button>
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => openDeactivateModal(tenant)}
+                          disabled={!!tenant.is_distributor}
+                        >
+                          <Trash2 className="mr-1 h-3 w-3" />
+                          Delete
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <TenantFormModal
+        tenant={tenantToEdit}
+        isOpen={showFormModal}
+        onClose={() => {
+          setShowFormModal(false);
+          setTenantToEdit(null);
+        }}
+        onSubmit={handleSubmitTenant}
+      />
+
+      <ConfirmDeleteModal
+        title="Delete Tenant"
+        itemName={tenantToDeactivate?.name || ''}
+        isOpen={showDeactivateModal}
+        onClose={() => {
+          setShowDeactivateModal(false);
+          setTenantToDeactivate(null);
+        }}
+        onConfirm={handleDeleteTenant}
+      />
+    </div>
+  );
+};
+
+export default TenantManagement;

--- a/frontend/src/pages/settings/UserManagement.tsx
+++ b/frontend/src/pages/settings/UserManagement.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import { userService, type CreateUserDTO, type UpdateUserDTO } from '@/services/user';
+import { tenantService, type Tenant } from '@/services/tenants';
 import type { User } from '@/types';
+import { roleLabels } from '@/types';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import {
@@ -21,6 +23,8 @@ import { extractErrorMessage } from '@/utils';
 
 const UserManagement = () => {
   const [users, setUsers] = useState<User[]>([]);
+  const [tenants, setTenants] = useState<Tenant[]>([]);
+  const [tenantMap, setTenantMap] = useState<Record<number, string>>({});
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
   const [showFormModal, setShowFormModal] = useState(false);
@@ -29,11 +33,23 @@ const UserManagement = () => {
   const [userToDelete, setUserToDelete] = useState<User | null>(null);
   const { user: currentUser } = useAuth();
 
+  const isAdmin = currentUser?.role === 'admin';
+
   const fetchUsers = async (signal?: AbortSignal) => {
     try {
       setIsLoading(true);
       const data = await userService.getAll(signal);
       setUsers(data);
+
+      // Fetch tenants for admin users
+      if (currentUser?.role === 'admin') {
+        const tenantData = await tenantService.getAll(signal);
+        setTenants(tenantData);
+        const map: Record<number, string> = {};
+        tenantData.forEach((t: Tenant) => { map[t.id] = t.name; });
+        setTenantMap(map);
+      }
+
       setError('');
     } catch (err: unknown) {
       const errorMessage = extractErrorMessage(err, '');
@@ -121,15 +137,16 @@ const UserManagement = () => {
               <TableRow>
                 <TableHead>Name</TableHead>
                 <TableHead>Email</TableHead>
+                {isAdmin && <TableHead>Tenant</TableHead>}
                 <TableHead>Role</TableHead>
-                <TableHead>Created</TableHead>
+                <TableHead>Status</TableHead>
                 <TableHead className="w-32"></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {users.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
+                  <TableCell colSpan={isAdmin ? 6 : 5} className="text-center py-8 text-muted-foreground">
                     No users found. Create your first user to get started.
                   </TableCell>
                 </TableRow>
@@ -140,13 +157,20 @@ const UserManagement = () => {
                       {getDisplayName(user)}
                     </TableCell>
                     <TableCell className="text-muted-foreground">{user.email}</TableCell>
+                    {isAdmin && (
+                      <TableCell className="text-muted-foreground">
+                        {tenantMap[user.tenant_id ?? 0] || '—'}
+                      </TableCell>
+                    )}
                     <TableCell>
-                      <Badge variant={user.role === 'admin' ? 'default' : 'secondary'}>
-                        {user.role}
+                      <Badge variant={user.role === 'admin' ? 'destructive' : user.role === 'tenant_admin' ? 'default' : 'secondary'}>
+                        {roleLabels[user.role] || user.role}
                       </Badge>
                     </TableCell>
-                    <TableCell className="text-muted-foreground">
-                      {new Date(user.created_at).toLocaleDateString()}
+                    <TableCell>
+                      <Badge variant={user.is_active ? 'default' : 'secondary'}>
+                        {user.is_active ? 'Active' : 'Inactive'}
+                      </Badge>
                     </TableCell>
                     <TableCell>
                       <div className="flex gap-2">
@@ -180,6 +204,8 @@ const UserManagement = () => {
 
       <UserFormModal
         user={userToEdit}
+        currentUserRole={currentUser?.role ?? 'user'}
+        tenants={isAdmin ? tenants : undefined}
         isOpen={showFormModal}
         onClose={() => {
           setShowFormModal(false);

--- a/frontend/src/services/project.ts
+++ b/frontend/src/services/project.ts
@@ -16,6 +16,7 @@ export interface Project {
   services_usd: number;
   local_currency_code: string;
   exchange_rate: number;
+  tenant_id: number;
 }
 
 export interface CreateProjectDTO {

--- a/frontend/src/services/tenants.ts
+++ b/frontend/src/services/tenants.ts
@@ -1,0 +1,48 @@
+import api from './api';
+import type { ApiResponse } from '@/types';
+
+export interface Tenant {
+  id: number;
+  name: string;
+  is_distributor: number;
+  is_active: number;
+  created_at: string;
+}
+
+export interface CreateTenantDTO {
+  name: string;
+  is_distributor?: number;
+}
+
+export interface UpdateTenantDTO {
+  name?: string;
+  is_active?: number;
+  is_distributor?: number;
+}
+
+export const tenantService = {
+  async getAll(signal?: AbortSignal): Promise<Tenant[]> {
+    const response = await api.get<ApiResponse<Tenant[]>>('/tenants', { signal });
+    return response.data.data;
+  },
+
+  async getById(id: number): Promise<Tenant> {
+    const response = await api.get<ApiResponse<Tenant>>(`/tenants/${id}`);
+    return response.data.data;
+  },
+
+  async create(data: CreateTenantDTO): Promise<Tenant> {
+    const response = await api.post<ApiResponse<Tenant>>('/tenants', data);
+    return response.data.data;
+  },
+
+  async update(id: number, data: UpdateTenantDTO): Promise<Tenant> {
+    const response = await api.put<ApiResponse<Tenant>>(`/tenants/${id}`, data);
+    return response.data.data;
+  },
+
+  async deactivate(id: number): Promise<Tenant> {
+    const response = await api.delete<ApiResponse<Tenant>>(`/tenants/${id}`);
+    return response.data.data;
+  },
+};

--- a/frontend/src/services/user.ts
+++ b/frontend/src/services/user.ts
@@ -1,18 +1,21 @@
 import api from './api';
-import type { User } from '@/types';
+import type { User, UserRole } from '@/types';
 
 export interface CreateUserDTO {
   email: string;
   full_name?: string;
   password: string;
-  role?: 'admin' | 'user';
+  role?: UserRole;
+  tenant_id?: number;
 }
 
 export interface UpdateUserDTO {
   full_name?: string | null;
   email?: string;
   password?: string;
-  role?: 'admin' | 'user';
+  role?: UserRole;
+  tenant_id?: number;
+  is_active?: number;
 }
 
 export const userService = {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2,11 +2,23 @@
 // Note: domain types (Item, Project, Placement, Category, etc.) are defined
 // in their respective service files (e.g. services/item.ts, services/project.ts).
 
+export type UserRole = 'admin' | 'tenant_admin' | 'user';
+
+export const roleLabels: Record<UserRole, string> = {
+  admin: 'Admin',
+  tenant_admin: 'Tenant Admin',
+  user: 'User',
+};
+
 export interface User {
   id: number;
   email: string;
   full_name: string | null;
-  role: 'admin' | 'user';
+  role: UserRole;
+  tenantId: number;
+  tenantName: string;
+  tenant_id?: number;
+  is_active?: number;
   created_at: string;
 }
 

--- a/frontend/tests/CategoryManagement.test.tsx
+++ b/frontend/tests/CategoryManagement.test.tsx
@@ -8,6 +8,14 @@ vi.mock('@/services/auth', () => ({
   authService: { getCurrentUser: vi.fn(), getAccessToken: vi.fn(), clearTokens: vi.fn() },
 }));
 
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 1, role: 'admin', tenantId: 1, tenantName: 'Admin' },
+    isAuthenticated: true,
+    isLoading: false,
+  }),
+}));
+
 vi.mock('@/services/category', () => ({
   categoryService: {
     getAll: vi.fn(),

--- a/frontend/tests/Header.test.tsx
+++ b/frontend/tests/Header.test.tsx
@@ -151,7 +151,7 @@ describe('Header', () => {
   });
 
   it('displays user role in dropdown', async () => {
-    const mockUser = { id: 1, email: 'admin@example.com', full_name: 'Admin User', role: 'admin' };
+    const mockUser = { id: 1, email: 'admin@example.com', full_name: 'Admin User', role: 'tenant_admin' };
     const { authService } = await import('@/services/auth');
     authService.getAccessToken.mockReturnValue('admin-token');
     authService.getRefreshToken.mockReturnValue('refresh-token');
@@ -168,12 +168,12 @@ describe('Header', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('admin')).toBeInTheDocument();
+      expect(screen.getByText('Tenant Admin')).toBeInTheDocument();
     });
   });
 
   it('shows admin menu items for admin users', async () => {
-    const mockUser = { id: 1, email: 'admin@example.com', full_name: 'Admin User', role: 'admin' };
+    const mockUser = { id: 1, email: 'admin@example.com', full_name: 'Admin User', role: 'tenant_admin' };
     const { authService } = await import('@/services/auth');
     authService.getAccessToken.mockReturnValue('admin-token');
     authService.getRefreshToken.mockReturnValue('refresh-token');
@@ -219,8 +219,9 @@ describe('Header', () => {
       expect(screen.getByText('Regular User')).toBeInTheDocument();
     });
 
-    // Admin items should not be present in top nav
-    expect(screen.queryByText('Catalog')).not.toBeInTheDocument();
+    // Catalog is visible to all authenticated users (read-only for non-admins)
+    expect(screen.queryByText('Catalog')).toBeInTheDocument();
+    // Settings should not be present for regular users
     expect(screen.queryByText('Settings')).not.toBeInTheDocument();
   });
 

--- a/frontend/tests/ItemManagement.test.tsx
+++ b/frontend/tests/ItemManagement.test.tsx
@@ -25,6 +25,18 @@ vi.mock('@/services/item', () => ({
   },
 }));
 
+vi.mock('@/services/auth', () => ({
+  authService: { getCurrentUser: vi.fn(), getAccessToken: vi.fn(), clearTokens: vi.fn() },
+}));
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 1, role: 'admin', tenantId: 1, tenantName: 'Admin' },
+    isAuthenticated: true,
+    isLoading: false,
+  }),
+}));
+
 import { categoryService } from '@/services/category';
 import { itemService } from '@/services/item';
 

--- a/frontend/tests/Profile.test.tsx
+++ b/frontend/tests/Profile.test.tsx
@@ -47,7 +47,7 @@ describe('Profile', () => {
     );
 
     expect(screen.getByText('John Doe')).toBeInTheDocument();
-    expect(screen.getByText('user')).toBeInTheDocument();
+    expect(screen.getByText('User')).toBeInTheDocument();
   });
 
   it('displays user avatar with first letter', () => {

--- a/frontend/tests/ProjectList.test.tsx
+++ b/frontend/tests/ProjectList.test.tsx
@@ -11,6 +11,13 @@ vi.mock('@/services/project', () => ({
   },
 }));
 
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: vi.fn(() => ({
+    user: { id: 1, email: 'test@example.com', role: 'tenant_admin', tenantId: 1 },
+    isAuthenticated: true,
+  })),
+}));
+
 describe('ProjectList', () => {
   const mockProjects = [
     {

--- a/frontend/tests/ProtectedRoute.test.tsx
+++ b/frontend/tests/ProtectedRoute.test.tsx
@@ -94,9 +94,9 @@ describe('ProtectedRoute', () => {
     expect(document.querySelector('.animate-spin')).toBeInTheDocument();
   });
 
-  it('redirects non-admin to home when admin required', async () => {
+  it('redirects non-tenant-admin to home when tenant admin required', async () => {
     const mockUser = { id: 1, email: 'user@example.com', role: 'user' };
-    
+
     const { authService } = await import('@/services/auth');
     authService.getAccessToken.mockReturnValue('user-token');
     authService.getRefreshToken.mockReturnValue('refresh-token');
@@ -111,7 +111,7 @@ describe('ProtectedRoute', () => {
               <Route
                 path="/admin"
                 element={
-                  <ProtectedRoute requireAdmin>
+                  <ProtectedRoute requireTenantAdmin>
                     <div>Admin Content</div>
                   </ProtectedRoute>
                 }
@@ -169,9 +169,9 @@ describe('ProtectedRoute', () => {
     expect(screen.getByText('Protected Content')).toBeInTheDocument();
   });
 
-  it('renders content for admin when admin required', async () => {
-    const mockUser = { id: 1, email: 'admin@example.com', role: 'admin' };
-    
+  it('renders content for tenant_admin when tenant admin required', async () => {
+    const mockUser = { id: 1, email: 'admin@example.com', role: 'tenant_admin' };
+
     const { authService } = await import('@/services/auth');
     authService.getAccessToken.mockReturnValue('admin-token');
     authService.getRefreshToken.mockReturnValue('refresh-token');
@@ -186,7 +186,7 @@ describe('ProtectedRoute', () => {
               <Route
                 path="/admin"
                 element={
-                  <ProtectedRoute requireAdmin>
+                  <ProtectedRoute requireTenantAdmin>
                     <div>Admin Content</div>
                   </ProtectedRoute>
                 }

--- a/frontend/tests/UserManagement.test.tsx
+++ b/frontend/tests/UserManagement.test.tsx
@@ -27,7 +27,7 @@ describe('UserManagement', () => {
     id: 1,
     email: 'admin@example.com',
     full_name: 'Admin User',
-    role: 'admin',
+    role: 'tenant_admin',
   };
 
   const mockUsers = [
@@ -35,7 +35,7 @@ describe('UserManagement', () => {
       id: 1,
       email: 'admin@example.com',
       full_name: 'Admin User',
-      role: 'admin',
+      role: 'tenant_admin',
       created_at: '2024-01-01T00:00:00Z',
     },
     {
@@ -115,27 +115,10 @@ describe('UserManagement', () => {
     );
 
     await waitFor(() => {
-      const adminBadge = screen.getByText('admin');
-      const userBadge = screen.getByText('user');
+      const adminBadge = screen.getByText('Tenant Admin');
+      const userBadge = screen.getByText('User');
       expect(adminBadge).toBeInTheDocument();
       expect(userBadge).toBeInTheDocument();
-    });
-  });
-
-  it('displays creation dates', async () => {
-    userService.getAll.mockResolvedValueOnce(mockUsers);
-
-    render(
-      <BrowserRouter>
-        <UserManagement />
-      </BrowserRouter>
-    );
-
-    await waitFor(() => {
-      // Check for "Created" column header (uppercase)
-      expect(screen.getByText('Created')).toBeInTheDocument();
-      // Check that users are displayed
-      expect(screen.getByText('Admin User')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- **Multi-tenancy**: Tenants table with distributor/partner types, tenant isolation via row-level filtering in repositories
- **Role system**: `admin` (system-wide), `tenant_admin` (per-tenant), `user` — replaces old binary admin/user
- **Tenant management**: CRUD page for admin to create/edit/delete partner companies, set active/inactive, change type
- **User management**: Tenant column + assignment for admin, is_active toggle, role-based UI visibility
- **Project restrictions**: Users can only edit active projects and cannot delete; non-active projects show read-only dashboard
- **Catalog access**: Read-only for non-admin roles, write restricted to admin
- **Auth hardening**: Login/refresh blocked for inactive users and inactive tenants
- **Migration 031**: Transactional (all-or-nothing) — creates tenants table, adds tenant_id to users/projects, updates role constraint

## Test plan
- [x] 267 backend tests passing (including 39 new multi-tenancy tests)
- [x] 248 frontend tests passing
- [x] Backend lint clean, frontend tsc + build clean
- [x] Migration verified against prod-like DB copy
- [ ] Smoke test: login as admin, create tenant, create user in tenant, verify isolation
- [ ] Smoke test: login as tenant_admin, verify can only see own tenant data
- [ ] Smoke test: login as user, verify read-only on non-active projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)