### PR TITLE
fix: improve Ctrl+drag duplicate UX and reduce API calls

### DIFF
--- a/backend/src/repositories/placement.ts
+++ b/backend/src/repositories/placement.ts
@@ -35,7 +35,8 @@ export class PlacementRepository {
   findById(id: number): Promise<Placement | null> {
     const result = getDb().queryEntries(`
       SELECT p.id, p.bom_id, p.floorplan_id, p.type, p.area_id, p.x, p.y, p.width, p.height, p.rotation, p.created_at,
-             b.item_id, b.variant_id as item_variant_id
+             b.item_id, b.variant_id as item_variant_id,
+             b.picture_path as item_variant_image_path
       FROM placements p
       LEFT JOIN project_bom b ON p.bom_id = b.id
       WHERE p.id = ?

--- a/backend/src/routes/placements.ts
+++ b/backend/src/routes/placements.ts
@@ -329,8 +329,12 @@ placementRoutes.post('/:id/duplicate', authMiddleware, zValidator('json', duplic
       rotation: placement.rotation,
     });
 
+    // Assign to containing area
+    await areaRepository.recheckContainment(placement.floorplan_id);
+    const updated = await placementRepository.findById(newPlacement!.id);
+
     return c.json({
-      data: newPlacement,
+      data: updated,
       message: 'Placement duplicated successfully',
     }, 201);
   } catch (error) {

--- a/backend/tests/routes/placements_test.ts
+++ b/backend/tests/routes/placements_test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertExists } from '@std/assert';
 import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
 import { testRequest, parseJSON } from '../test-client.ts';
 import { hashPassword } from '../../src/services/password.ts';
+import { getDb } from '../../src/config/database.ts';
 import type { Placement } from '../../src/models/index.ts';
 
 // Setup test database before all tests
@@ -362,5 +363,210 @@ Deno.test('Placement - duplicate endpoint', async (t) => {
     assertEquals(response.status, 400);
     const data = await parseJSON(response);
     assertExists(data.error);
+  });
+
+  await t.step('Duplicate returns item_variant_image_path', async () => {
+    const response = await testRequest(`/api/placements/${originalPlacementId}/duplicate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({ x: 300, y: 300 }),
+    });
+
+    assertEquals(response.status, 201);
+    const data = await parseJSON(response);
+    // findById now includes picture_path as item_variant_image_path
+    assertEquals(data.data.item_variant_image_path !== undefined, true);
+  });
+});
+
+Deno.test('Placement - duplicate assigns area_id via containment', async (t) => {
+  const token = await getAuthToken();
+
+  const db = getDb();
+
+  // Create project + floorplan
+  const project = await projectRepository.create({
+    name: 'Area Containment Test',
+    customer_name: 'Test Customer',
+    customer_address: '123 Test St',
+    status: 'active',
+    tenant_id: 1,
+  });
+
+  const floorplan = await floorplanRepository.create({
+    project_id: project.id,
+    name: 'Floor With Area',
+    image_path: 'floorplans/test.jpg',
+  });
+
+  // Create an area covering (0,0) to (500,500)
+  db.query(
+    `INSERT INTO placements (floorplan_id, type, x, y, width, height, rotation) VALUES (?, 'area', 0, 0, 500, 500, 0)`,
+    [floorplan.id],
+  );
+  const areaPlacementId = Number(db.lastInsertRowId);
+  db.query(
+    `INSERT INTO area_properties (placement_id, name, color, opacity) VALUES (?, 'Test Area', '#FF0000', 0.3)`,
+    [areaPlacementId],
+  );
+  // Create polygon vertices covering (0,0)-(500,0)-(500,500)-(0,500)
+  db.query(`INSERT INTO area_vertices (placement_id, vertex_index, x, y) VALUES (?, 0, 0, 0)`, [areaPlacementId]);
+  db.query(`INSERT INTO area_vertices (placement_id, vertex_index, x, y) VALUES (?, 1, 500, 0)`, [areaPlacementId]);
+  db.query(`INSERT INTO area_vertices (placement_id, vertex_index, x, y) VALUES (?, 2, 500, 500)`, [areaPlacementId]);
+  db.query(`INSERT INTO area_vertices (placement_id, vertex_index, x, y) VALUES (?, 3, 0, 500)`, [areaPlacementId]);
+
+  // Create category + item + variant
+  const category = await categoryRepository.create({ name: 'Area Test Category' });
+  const item = await itemRepository.create({
+    category_id: category.id,
+    name: 'Area Test Item',
+    description: 'Test',
+    base_model_number: 'AREA-001',
+    dimensions: '50x50',
+    is_active: true,
+  });
+  const variant = await itemVariantRepository.create({
+    item_id: item.id,
+    style_name: 'Default',
+    price: 10,
+    image_path: 'items/area-test.jpg',
+  });
+
+  // Create original placement inside the area
+  const createResponse = await testRequest('/api/placements', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      floorplan_id: floorplan.id,
+      item_variant_id: variant.id,
+      x: 100,
+      y: 100,
+      width: 50,
+      height: 50,
+    }),
+  });
+
+  const createData = await parseJSON(createResponse);
+  const originalId = createData.data.id;
+
+  await t.step('Original placement gets area_id from containment', async () => {
+    assertEquals(createData.data.area_id, areaPlacementId);
+  });
+
+  await t.step('Duplicate inside area gets area_id', async () => {
+    const response = await testRequest(`/api/placements/${originalId}/duplicate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({ x: 200, y: 200 }),
+    });
+
+    assertEquals(response.status, 201);
+    const data = await parseJSON(response);
+    assertEquals(data.data.area_id, areaPlacementId);
+  });
+
+  await t.step('Duplicate outside area gets null area_id', async () => {
+    const response = await testRequest(`/api/placements/${originalId}/duplicate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({ x: 600, y: 600 }),
+    });
+
+    assertEquals(response.status, 201);
+    const data = await parseJSON(response);
+    assertEquals(data.data.area_id, null);
+  });
+});
+
+Deno.test('Placement - findById returns image path', async (t) => {
+  const token = await getAuthToken();
+
+  const db = getDb();
+
+  const project = await projectRepository.create({
+    name: 'Image Path Test',
+    customer_name: 'Test',
+    customer_address: '123 St',
+    status: 'active',
+    tenant_id: 1,
+  });
+
+  const floorplan = await floorplanRepository.create({
+    project_id: project.id,
+    name: 'Floor',
+    image_path: 'floorplans/test.jpg',
+  });
+
+  const category = await categoryRepository.create({ name: 'Image Test Category' });
+  const item = await itemRepository.create({
+    category_id: category.id,
+    name: 'Image Test Item',
+    description: 'Test',
+    base_model_number: 'IMG-001',
+    dimensions: '50x50',
+    is_active: true,
+  });
+  const variant = await itemVariantRepository.create({
+    item_id: item.id,
+    style_name: 'Default',
+    price: 10,
+    image_path: 'items/test-image.jpg',
+  });
+
+  await t.step('Create placement response includes item_variant_image_path', async () => {
+    const response = await testRequest('/api/placements', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        floorplan_id: floorplan.id,
+        item_variant_id: variant.id,
+        x: 50,
+        y: 50,
+        width: 40,
+        height: 40,
+      }),
+    });
+
+    assertEquals(response.status, 201);
+    const data = await parseJSON(response);
+    assertExists(data.data.item_variant_image_path);
+  });
+
+  await t.step('Update placement response includes item_variant_image_path', async () => {
+    // Get the placement we just created
+    const listResponse = await testRequest(`/api/placements?floorplan_id=${floorplan.id}`, {
+      method: 'GET',
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+    const listData = await parseJSON(listResponse);
+    const placementId = listData.data[0].id;
+
+    const response = await testRequest(`/api/placements/${placementId}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({ x: 100, y: 100 }),
+    });
+
+    assertEquals(response.status, 200);
+    const data = await parseJSON(response);
+    assertExists(data.data.item_variant_image_path);
   });
 });

--- a/frontend/src/components/configurator/ConfiguratorCanvas.tsx
+++ b/frontend/src/components/configurator/ConfiguratorCanvas.tsx
@@ -152,10 +152,8 @@ function DraggablePlacement({
 
   const dragTransform = transform ? CSS.Translate.toString(transform) : '';
   const rotationTransform = `rotate(${placement.rotation || 0}deg)`;
-  // For all drags (including duplication), element moves with cursor
-  // The copy is now a separate placement that moves normally
-  const combinedTransform = dragTransform 
-    ? `${dragTransform} ${rotationTransform}` 
+  const combinedTransform = dragTransform
+    ? `${dragTransform} ${rotationTransform}`
     : rotationTransform;
 
   const handleClick = (e: React.MouseEvent) => {
@@ -486,7 +484,7 @@ function DraggablePlacement({
         isSelected
           ? 'ring-2 ring-destructive shadow-lg z-50'
           : isDuplicating && isDragging
-            ? 'border-2 border-dashed border-primary overflow-hidden'
+            ? 'border-2 border-dashed border-primary overflow-hidden opacity-60'
             : 'border-2 border-primary overflow-hidden'
       } ${isDragging ? (isCtrlPressed ? 'cursor-copy z-50' : 'cursor-grabbing z-50') : isResizing ? 'cursor-nwse-resize z-50' : isSelected ? 'cursor-default' : isCtrlPressed ? 'cursor-copy' : 'cursor-move'}`}
       title={displayName}

--- a/frontend/src/components/configurator/DragOverlayContent.tsx
+++ b/frontend/src/components/configurator/DragOverlayContent.tsx
@@ -67,7 +67,7 @@ export function DragOverlayContent({
         width: `${placementWidth}px`, 
         height: `${placementHeight}px`,
         transform: `scale(${scaleX}, ${scaleY})`,
-        transformOrigin: 'top left'
+        transformOrigin: 'center center'
       }}
     >
       {item.preview_image ? (

--- a/frontend/src/hooks/useDragHandlers.ts
+++ b/frontend/src/hooks/useDragHandlers.ts
@@ -34,13 +34,13 @@ interface UseDragHandlersProps {
     item_variant_id?: number;
     addon_ids?: number[];
     rotation?: number;
-  }, isFinal?: boolean) => Promise<void>;
-  fetchPlacements: (floorplanId: number) => Promise<void>;
-  setPlacementsVersion: React.Dispatch<React.SetStateAction<number>>;
+  }, isFinal?: boolean) => Promise<Placement | undefined>;
+  setPlacements: React.Dispatch<React.SetStateAction<Placement[]>>;
   clearItemMemory: (itemId: number) => void;
   handleAreaCreate?: (data: { floorplan_id: number; x: number; y: number; width: number; height: number }) => Promise<void>;
   areas?: Area[];
-  refreshAreas?: () => void;
+  fetchAreas?: () => void;
+  setPlacementsVersion: React.Dispatch<React.SetStateAction<number>>;
 }
 
 interface UseDragHandlersReturn {
@@ -69,12 +69,12 @@ export function useDragHandlers({
   isResizingRef,
   handlePlacementCreate,
   handlePlacementUpdate,
-  fetchPlacements,
-  setPlacementsVersion,
+  setPlacements,
   clearItemMemory,
   handleAreaCreate,
   areas = [],
-  refreshAreas,
+  fetchAreas,
+  setPlacementsVersion,
 }: UseDragHandlersProps): UseDragHandlersReturn {
   const [activeDragItem, setActiveDragItem] = useState<Item | null>(null);
   const [activeDragPlacement, setActiveDragPlacement] = useState<Placement | null>(null);
@@ -82,7 +82,6 @@ export function useDragHandlers({
   const [isDropping, setIsDropping] = useState(false);
   const [isCtrlDraggingItem, setIsCtrlDraggingItem] = useState(false);
   const [isDraggingArea, setIsDraggingArea] = useState(false);
-  const duplicatePromiseRef = useRef<Promise<unknown> | null>(null);
   const areasRef = useRef(areas);
   areasRef.current = areas;
 
@@ -106,34 +105,24 @@ export function useDragHandlers({
       const placementId = parseInt(activeId.replace('placement-', ''));
       const placement = placements.find(p => p.id === placementId);
       if (placement) {
-        const activeData = event.active.data.current as { isCtrlPressed?: boolean } | undefined;
-        const isCtrlPressed = activeData?.isCtrlPressed ?? false;
+        // Read Ctrl state from the actual mouse event, not React state (which may be stale)
+        const isCtrlPressed = event.activatorEvent
+          ? (event.activatorEvent as MouseEvent).ctrlKey || (event.activatorEvent as MouseEvent).metaKey
+          : false;
         
-        if (isCtrlPressed && activeFloorplan) {
-          setActiveDragPlacement(placement);
-          setIsDuplicating(true);
-          
-          duplicatePromiseRef.current = placementService.duplicate(placementId, placement.x, placement.y)
-            .then((newPlacement) => {
-              setActiveDragPlacement(newPlacement);
-              fetchPlacements(activeFloorplan.id);
-              setPlacementsVersion(prev => prev + 1);
-              return newPlacement;
-            })
-            .catch((err) => {
-              console.error('Failed to duplicate placement:', err);
-              setIsDuplicating(false);
-              duplicatePromiseRef.current = null;
-            });
-        } else {
-          setActiveDragPlacement(placement);
-          setIsDuplicating(false);
+        const isDup = isCtrlPressed && !!activeFloorplan;
+        setActiveDragPlacement(placement);
+        setIsDuplicating(isDup);
+        if (isDup) {
+          // Add a local-only clone at the original position so it looks like the original stays.
+          // It will be replaced by the real server duplicate on drop.
+          setPlacements(prev => [...prev, { ...placement, id: -1 }]);
         }
       }
     } else if (activeId === 'new-area') {
       setIsDraggingArea(true);
     }
-  }, [items, placements, activeFloorplan, fetchPlacements, setPlacementsVersion]);
+  }, [items, placements, activeFloorplan, setPlacements]);
 
   const handleDragEnd = useCallback(async (event: DragEndEvent) => {
     const { active, over } = event;
@@ -144,6 +133,10 @@ export function useDragHandlers({
     }
     
     if (!over || !activeFloorplan) {
+      // Clean up placeholder if drag cancelled
+      if (isDuplicating) {
+        setPlacements(prev => prev.filter(p => p.id !== -1));
+      }
       setActiveDragItem(null);
       setActiveDragPlacement(null);
       setIsDuplicating(false);
@@ -189,21 +182,25 @@ export function useDragHandlers({
         const newX = placement.x + deltaX;
         const newY = placement.y + deltaY;
 
-        // If duplicating, wait for duplicate to resolve and use its ID
-        let targetPlacementId = placementId;
-        if (duplicatePromiseRef.current) {
-          try {
-            const duplicated = await duplicatePromiseRef.current as { id: number };
-            targetPlacementId = duplicated.id;
-          } catch {
-            // Duplicate failed — position update goes to original
-          }
-          duplicatePromiseRef.current = null;
-        }
+        const oldAreaId = placement.area_id;
 
-        handlePlacementUpdate(targetPlacementId, { x: newX, y: newY });
-        // Containment is handled server-side in PUT /placements/:id
-        refreshAreas?.();
+        if (isDuplicating) {
+          // Remove the local placeholder, create real duplicate at drop position
+          setPlacements(prev => prev.filter(p => p.id !== -1));
+          try {
+            const newPlacement = await placementService.duplicate(placementId, newX, newY);
+            setPlacements(prev => [...prev, newPlacement]);
+            setPlacementsVersion(prev => prev + 1);
+            fetchAreas?.();
+          } catch (err) {
+            console.error('Failed to duplicate placement:', err);
+          }
+        } else {
+          const updated = await handlePlacementUpdate(placementId, { x: newX, y: newY });
+          if (!updated || updated.area_id !== oldAreaId) {
+            fetchAreas?.();
+          }
+        }
       }
       setActiveDragItem(null);
       setActiveDragPlacement(null);
@@ -314,18 +311,21 @@ export function useDragHandlers({
           
           let screenX: number;
           let screenY: number;
-          
+
           if (activeRect) {
-            screenX = activeRect.left - imageRect.left;
-            screenY = activeRect.top - imageRect.top;
+            // Use center of the dragged element to position under cursor
+            const centerX = activeRect.left + activeRect.width / 2;
+            const centerY = activeRect.top + activeRect.height / 2;
+            screenX = centerX - imageRect.left;
+            screenY = centerY - imageRect.top;
           } else {
             screenX = event.delta.x;
             screenY = event.delta.y;
           }
-          
-          screenX = Math.max(0, Math.min(screenX, imageRect.width - 100));
-          screenY = Math.max(0, Math.min(screenY, imageRect.height - 100));
-          
+
+          screenX = Math.max(0, Math.min(screenX, imageRect.width));
+          screenY = Math.max(0, Math.min(screenY, imageRect.height));
+
           const dropX = screenX / scaleX;
           const dropY = screenY / scaleY;
           
@@ -393,8 +393,8 @@ export function useDragHandlers({
             }
 
             await handlePlacementCreate({
-              x: dropX,
-              y: dropY,
+              x: dropX - placementWidth / 2,
+              y: dropY - placementHeight / 2,
               width: placementWidth,
               height: placementHeight,
               item_id: itemData.itemId,
@@ -404,7 +404,8 @@ export function useDragHandlers({
             });
 
             // Containment is handled server-side in POST /placements
-            refreshAreas?.();
+            // Only fetch area counts (not full refresh) — BOM already updates via setPlacementsVersion
+            fetchAreas?.();
 
             setIsDropping(false);
             setActiveDragItem(null);
@@ -427,6 +428,7 @@ export function useDragHandlers({
     activeFloorplan,
     placements,
     items,
+    isDuplicating,
     isCtrlDraggingItem,
     itemSizeMemory,
     itemVariantMemory,
@@ -434,9 +436,11 @@ export function useDragHandlers({
     isResizingRef,
     handlePlacementCreate,
     handlePlacementUpdate,
+    setPlacements,
     clearItemMemory,
     handleAreaCreate,
-    refreshAreas,
+    fetchAreas,
+    setPlacementsVersion,
   ]);
 
   return {

--- a/frontend/src/hooks/usePlacements.ts
+++ b/frontend/src/hooks/usePlacements.ts
@@ -10,6 +10,7 @@ interface UsePlacementsProps {
   persistSizeMemory: () => void;
   persistVariantMemory: () => void;
   setPlacementsVersion: React.Dispatch<React.SetStateAction<number>>;
+  onPlacementChanged?: () => void;
 }
 
 interface UsePlacementsReturn {
@@ -33,7 +34,7 @@ interface UsePlacementsReturn {
     item_variant_id?: number;
     addon_ids?: number[];
     rotation?: number;
-  }, isFinal?: boolean) => Promise<void>;
+  }, isFinal?: boolean) => Promise<Placement | undefined>;
   handlePlacementDelete: (id: number) => Promise<void>;
   fetchPlacements: (floorplanId: number, signal?: AbortSignal) => Promise<void>;
   placementAddons: React.MutableRefObject<Map<number, number[]>>;
@@ -46,6 +47,7 @@ export function usePlacements({
   persistSizeMemory,
   persistVariantMemory,
   setPlacementsVersion,
+  onPlacementChanged,
 }: UsePlacementsProps): UsePlacementsReturn {
   const [placements, setPlacements] = useState<Placement[]>([]);
   const placementsRef = useRef(placements);
@@ -87,10 +89,11 @@ export function usePlacements({
       height,
     };
 
-    const newPlacement = await placementService.create(createData);
+    let newPlacement = await placementService.create(createData);
 
     if (placement.addon_ids !== undefined) {
-      await placementService.updateBom(newPlacement.id, placement.item_variant_id, placement.addon_ids);
+      const result = await placementService.updateBom(newPlacement.id, placement.item_variant_id, placement.addon_ids);
+      newPlacement = result.placement;
     }
 
     if (!placement.ignoreDefaults) {
@@ -160,7 +163,10 @@ export function usePlacements({
     }
     
     if (isFinal !== false) {
-      await placementService.update(id, placement);
+      const updated = await placementService.update(id, placement);
+      // Apply server response (includes recalculated area_id from containment check)
+      setPlacements(prev => prev.map(p => p.id === id ? updated : p));
+      return updated;
     }
   }, [itemSizeMemory, itemVariantMemory, persistSizeMemory, persistVariantMemory, setPlacementsVersion]);
 
@@ -171,7 +177,8 @@ export function usePlacements({
       await fetchPlacements(activeFloorplan.id);
     }
     setPlacementsVersion(prev => prev + 1);
-  }, [activeFloorplan, fetchPlacements, setPlacementsVersion]);
+    onPlacementChanged?.();
+  }, [activeFloorplan, fetchPlacements, setPlacementsVersion, onPlacementChanged]);
 
   return {
     placements,

--- a/frontend/src/pages/projects/ProjectDashboard.tsx
+++ b/frontend/src/pages/projects/ProjectDashboard.tsx
@@ -155,6 +155,7 @@ const ProjectDashboard = () => {
   // Placements hook - MUST be called before useEffect that uses fetchPlacements
   const {
     placements,
+    setPlacements,
     handlePlacementCreate,
     handlePlacementUpdate,
     handlePlacementDelete,
@@ -167,6 +168,7 @@ const ProjectDashboard = () => {
     persistSizeMemory,
     persistVariantMemory,
     setPlacementsVersion,
+    onPlacementChanged: activeFloorplan ? () => fetchAreas(activeFloorplan.id) : undefined,
   });
 
   // Areas hook
@@ -382,11 +384,11 @@ const ProjectDashboard = () => {
     isResizingRef,
     handlePlacementCreate,
     handlePlacementUpdate,
-    fetchPlacements,
-    setPlacementsVersion,
+    setPlacements,
     clearItemMemory,
     areas,
-    refreshAreas: refreshAfterContainment,
+    fetchAreas: activeFloorplan ? () => fetchAreas(activeFloorplan.id) : undefined,
+    setPlacementsVersion,
     handleAreaCreate: async (data) => {
       const AREA_COLORS = [
         '#3b82f6', '#ef4444', '#22c55e', '#f59e0b', '#8b5cf6',
@@ -708,7 +710,6 @@ const ProjectDashboard = () => {
           </div>
         </div>
         
-        {/* Drag Overlay - only for items from palette, not for duplication */}
         <DragOverlay dropAnimation={null}>
           {activeDragItem && !isDropping && (
             <DragOverlayContent


### PR DESCRIPTION
## Summary
- Fix unreliable Ctrl+drag detection by reading key state from mouse event instead of React state
- Move duplicate API call from drag start to drag end — zero API calls mid-drag
- Reduce API calls per operation: normal move 4→1-2, duplicate 8→3-4, palette drop 7→4
- Add `recheckContainment` to duplicate endpoint so copies get assigned to correct areas
- Include `item_variant_image_path` in `findById` so images render on first drop
- Improve duplicate visual: original stays in place, dragged element shown as ghost copy
- Refresh area device counts after placement delete

## Test plan
- [x] Backend tests: 269 passed (2 new test groups for containment + image path)
- [x] Frontend tests: 248 passed
- [x] tsc build: clean, no warnings
- [x] ESLint: 0 errors
- [ ] Manual: Ctrl+drag duplicate onto area — verify area count updates
- [ ] Manual: Delete placement inside area — verify area count decreases
- [ ] Manual: Drag item from palette — verify image shows on first drop
- [ ] Manual: Normal drag move — verify only 1 PUT request in network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)