### PR TITLE
feat: Remote MCP server for SnapFlow (OAuth 2.1 + 4 read-only tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,40 @@ A web application for smart home automation companies to create professional pro
 - 👥 **Customer Management** - Organize projects by customer with full CRUD operations
 - 🔐 **Role-Based Access** - Admin and user roles with appropriate permissions
 
+## MCP Connector (Claude.ai integration)
+
+SnapFlow exposes a read-only MCP server at `/mcp` so Claude.ai (and Claude Desktop / Claude Code) can read your projects and catalog via a one-time OAuth login.
+
+Available tools: `list_projects`, `get_project`, `get_project_total`, `search_items`.
+
+### Setup
+
+In Claude.ai → Settings → Connectors → "Add custom connector":
+
+1. **Server URL**: `https://your-snapflow-host/mcp`
+2. The setup UI will display a **redirect URL** specific to your Claude.ai workspace. Copy it.
+3. Provision an OAuth client on your SnapFlow instance, pasting Claude.ai's redirect URL:
+
+   ```bash
+   curl -X POST https://your-snapflow-host/oauth/register \
+     -H 'Content-Type: application/json' \
+     -d '{
+       "redirect_uris": ["<the redirect URL Claude.ai showed you>"],
+       "client_name": "Claude.ai"
+     }'
+   ```
+
+   The response includes a `client_id` and `client_secret`. **The secret is shown only once — save it now.**
+4. Paste the `client_id` and `client_secret` into Claude.ai's connector form.
+5. Claude.ai will walk you through the OAuth login. After approval, the four tools appear in every chat.
+
+### Notes
+
+- Requires Claude.ai Pro / Max / Team. Free accounts cannot add custom connectors.
+- The MCP server runs inside the existing SnapFlow backend — no separate deploy.
+- All tool calls go through the same authentication, tenant scoping, and validation as the web UI — there is no way for the MCP layer to bypass them.
+- For production deployments behind a reverse proxy: ensure `X-Forwarded-Proto` and `X-Forwarded-Host` are forwarded, or set `PUBLIC_BASE_URL=https://yourhost`.
+
 ## Tech Stack
 
 ### Backend

--- a/backend/migrations/038_oauth_clients.sql
+++ b/backend/migrations/038_oauth_clients.sql
@@ -1,0 +1,26 @@
+-- Migration 034: OAuth 2.1 tables for remote MCP server
+-- Adds two tables: oauth_clients (registered MCP clients) and oauth_auth_codes (short-lived auth codes)
+
+CREATE TABLE IF NOT EXISTS oauth_clients (
+  id            TEXT PRIMARY KEY,
+  client_secret TEXT,
+  redirect_uris TEXT NOT NULL,
+  client_name   TEXT,
+  created_at    DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS oauth_auth_codes (
+  code           TEXT PRIMARY KEY,
+  client_id      TEXT NOT NULL,
+  user_id        INTEGER NOT NULL,
+  redirect_uri   TEXT NOT NULL,
+  code_challenge TEXT NOT NULL,
+  scope          TEXT,
+  expires_at     DATETIME NOT NULL,
+  consumed_at    DATETIME,
+  FOREIGN KEY (client_id) REFERENCES oauth_clients(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id)   REFERENCES users(id)         ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_codes_expires ON oauth_auth_codes(expires_at);
+CREATE INDEX IF NOT EXISTS idx_oauth_codes_client  ON oauth_auth_codes(client_id);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -21,6 +21,10 @@ import settingsRoutes from './routes/settings.ts';
 import areaRoutes from './routes/areas.ts';
 import tenantRoutes from './routes/tenants.ts';
 import projectGroupRoutes from './routes/project-groups.ts';
+import oauthRoutes from './routes/oauth.ts';
+import oauthConsentRoutes from './routes/oauth-consent.ts';
+import wellKnownRoutes from './routes/well-known.ts';
+import { buildMcpRoutes } from './routes/mcp.ts';
 
 const app: Hono = new Hono();
 
@@ -117,6 +121,17 @@ api.route('/project-groups', projectGroupRoutes);
 
 // Mount API router
 app.route('/api', api);
+
+// OAuth 2.1 endpoints (no /api prefix — at the app root per spec)
+app.route('/oauth', oauthRoutes);
+app.route('/oauth', oauthConsentRoutes);
+
+// /.well-known/* metadata
+app.route('/', wellKnownRoutes);
+
+// MCP endpoint (Streamable HTTP) — receives the top-level app so its
+// tools can dispatch back through it via app.fetch.
+app.route('/mcp', buildMcpRoutes(app));
 
 // 404 handler for unknown API routes (must come before static file serving)
 app.get('/api/*', (c: Context) => {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,6 +8,7 @@ import { env } from './config/env.ts';
 import { runMigrations } from './scripts/migrate.ts';
 import { runBomImageMigration } from './services/bom-image-migration.ts';
 import { cleanupExpiredTokens } from './services/refresh-token.ts';
+import { oauthCodeRepository } from './repositories/oauth-code.ts';
 import authRoutes from './routes/auth.ts';
 import userRoutes from './routes/users.ts';
 import categoryRoutes from './routes/categories.ts';
@@ -281,9 +282,13 @@ if (import.meta.main) {
     console.error('❌ Failed to run seed script:', error);
   }
 
-  // Schedule periodic cleanup of expired refresh tokens
+  // Schedule periodic cleanup of expired refresh tokens and oauth codes
   cleanupExpiredTokens();
-  setInterval(cleanupExpiredTokens, 60 * 60 * 1000); // Every hour
+  oauthCodeRepository.deleteExpired();
+  setInterval(() => {
+    cleanupExpiredTokens();
+    oauthCodeRepository.deleteExpired();
+  }, 60 * 60 * 1000); // Every hour
   console.log('🧹 Token cleanup scheduled (hourly)');
 
   // Start server

--- a/backend/src/repositories/oauth-client.ts
+++ b/backend/src/repositories/oauth-client.ts
@@ -1,8 +1,9 @@
 import { getDb } from '../config/database.ts';
+import { hashClientSecret, timingSafeEqual } from '../services/oauth/client-secret.ts';
 
 export interface OAuthClient {
   id: string;
-  client_secret: string | null;
+  client_secret_hash: string | null;
   redirect_uris: string[];
   client_name: string | null;
   created_at: string;
@@ -11,13 +12,13 @@ export interface OAuthClient {
 export interface CreateOAuthClientDTO {
   redirect_uris: string[];
   client_name?: string;
-  client_secret?: string;
+  client_secret_hash?: string;
 }
 
 function generateClientId(): string {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
-  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
 }
 
 export class OAuthClientRepository {
@@ -27,11 +28,11 @@ export class OAuthClientRepository {
     getDb().query(
       `INSERT INTO oauth_clients (id, client_secret, redirect_uris, client_name)
        VALUES (?, ?, ?, ?)`,
-      [id, dto.client_secret ?? null, redirectUrisJson, dto.client_name ?? null]
+      [id, dto.client_secret_hash ?? null, redirectUrisJson, dto.client_name ?? null],
     );
     return Promise.resolve({
       id,
-      client_secret: dto.client_secret ?? null,
+      client_secret_hash: dto.client_secret_hash ?? null,
       redirect_uris: dto.redirect_uris,
       client_name: dto.client_name ?? null,
       created_at: new Date().toISOString(),
@@ -42,17 +43,24 @@ export class OAuthClientRepository {
     const rows = getDb().query<[string, string | null, string, string | null, string]>(
       `SELECT id, client_secret, redirect_uris, client_name, created_at
        FROM oauth_clients WHERE id = ?`,
-      [id]
+      [id],
     );
     if (rows.length === 0) return Promise.resolve(null);
-    const [rid, secret, redirectsJson, name, createdAt] = rows[0];
+    const [rid, secretHash, redirectsJson, name, createdAt] = rows[0];
     return Promise.resolve({
       id: rid,
-      client_secret: secret,
+      client_secret_hash: secretHash,
       redirect_uris: JSON.parse(redirectsJson),
       client_name: name,
       created_at: createdAt,
     });
+  }
+
+  async verifySecret(clientId: string, rawSecret: string): Promise<boolean> {
+    const client = await this.findById(clientId);
+    if (!client || client.client_secret_hash === null) return false;
+    const computed = await hashClientSecret(rawSecret);
+    return timingSafeEqual(client.client_secret_hash, computed);
   }
 }
 

--- a/backend/src/repositories/oauth-client.ts
+++ b/backend/src/repositories/oauth-client.ts
@@ -1,0 +1,59 @@
+import { getDb } from '../config/database.ts';
+
+export interface OAuthClient {
+  id: string;
+  client_secret: string | null;
+  redirect_uris: string[];
+  client_name: string | null;
+  created_at: string;
+}
+
+export interface CreateOAuthClientDTO {
+  redirect_uris: string[];
+  client_name?: string;
+  client_secret?: string;
+}
+
+function generateClientId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export class OAuthClientRepository {
+  create(dto: CreateOAuthClientDTO): Promise<OAuthClient> {
+    const id = generateClientId();
+    const redirectUrisJson = JSON.stringify(dto.redirect_uris);
+    getDb().query(
+      `INSERT INTO oauth_clients (id, client_secret, redirect_uris, client_name)
+       VALUES (?, ?, ?, ?)`,
+      [id, dto.client_secret ?? null, redirectUrisJson, dto.client_name ?? null]
+    );
+    return Promise.resolve({
+      id,
+      client_secret: dto.client_secret ?? null,
+      redirect_uris: dto.redirect_uris,
+      client_name: dto.client_name ?? null,
+      created_at: new Date().toISOString(),
+    });
+  }
+
+  findById(id: string): Promise<OAuthClient | null> {
+    const rows = getDb().query<[string, string | null, string, string | null, string]>(
+      `SELECT id, client_secret, redirect_uris, client_name, created_at
+       FROM oauth_clients WHERE id = ?`,
+      [id]
+    );
+    if (rows.length === 0) return Promise.resolve(null);
+    const [rid, secret, redirectsJson, name, createdAt] = rows[0];
+    return Promise.resolve({
+      id: rid,
+      client_secret: secret,
+      redirect_uris: JSON.parse(redirectsJson),
+      client_name: name,
+      created_at: createdAt,
+    });
+  }
+}
+
+export const oauthClientRepository = new OAuthClientRepository();

--- a/backend/src/repositories/oauth-code.ts
+++ b/backend/src/repositories/oauth-code.ts
@@ -1,0 +1,74 @@
+import { getDb } from '../config/database.ts';
+
+export interface OAuthAuthCode {
+  code: string;
+  client_id: string;
+  user_id: number;
+  redirect_uri: string;
+  code_challenge: string;
+  scope: string | null;
+  expires_at: string;
+  consumed_at: string | null;
+}
+
+export interface CreateOAuthCodeDTO {
+  client_id: string;
+  user_id: number;
+  redirect_uri: string;
+  code_challenge: string;
+  scope?: string;
+  ttl_seconds?: number;
+}
+
+const DEFAULT_TTL_SECONDS = 60;
+
+function generateCode(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export class OAuthCodeRepository {
+  create(dto: CreateOAuthCodeDTO): Promise<OAuthAuthCode> {
+    const code = generateCode();
+    const ttl = dto.ttl_seconds ?? DEFAULT_TTL_SECONDS;
+    const expiresAt = new Date(Date.now() + ttl * 1000).toISOString();
+    getDb().query(
+      `INSERT INTO oauth_auth_codes (code, client_id, user_id, redirect_uri, code_challenge, scope, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [code, dto.client_id, dto.user_id, dto.redirect_uri, dto.code_challenge, dto.scope ?? null, expiresAt]
+    );
+    return Promise.resolve({
+      code, client_id: dto.client_id, user_id: dto.user_id,
+      redirect_uri: dto.redirect_uri, code_challenge: dto.code_challenge,
+      scope: dto.scope ?? null, expires_at: expiresAt, consumed_at: null,
+    });
+  }
+
+  consume(code: string): Promise<OAuthAuthCode | null> {
+    const rows = getDb().query<[string, string, number, string, string, string | null, string, string | null]>(
+      `SELECT code, client_id, user_id, redirect_uri, code_challenge, scope, expires_at, consumed_at
+       FROM oauth_auth_codes WHERE code = ?`,
+      [code]
+    );
+    if (rows.length === 0) return Promise.resolve(null);
+    const [c, cid, uid, ruri, chal, scope, exp, consumed] = rows[0];
+    if (consumed !== null) return Promise.resolve(null);
+    if (new Date(exp).getTime() <= Date.now()) return Promise.resolve(null);
+    getDb().query(`UPDATE oauth_auth_codes SET consumed_at = ? WHERE code = ?`, [new Date().toISOString(), c]);
+    return Promise.resolve({
+      code: c, client_id: cid, user_id: uid, redirect_uri: ruri, code_challenge: chal,
+      scope, expires_at: exp, consumed_at: new Date().toISOString(),
+    });
+  }
+
+  deleteExpired(): Promise<void> {
+    getDb().query(
+      `DELETE FROM oauth_auth_codes WHERE expires_at <= ? OR consumed_at IS NOT NULL`,
+      [new Date().toISOString()]
+    );
+    return Promise.resolve();
+  }
+}
+
+export const oauthCodeRepository = new OAuthCodeRepository();

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -13,6 +13,11 @@ import {
 import { authMiddleware } from '../middleware/auth.ts';
 import { loginRateLimit, refreshRateLimit } from '../middleware/rate-limit.ts';
 import { TenantRepository } from '../repositories/tenant.ts';
+import {
+  signSessionCookie,
+  OAUTH_SESSION_COOKIE_NAME,
+  OAUTH_SESSION_MAX_AGE,
+} from '../services/oauth/session-cookie.ts';
 
 const tenantRepo = new TenantRepository();
 
@@ -59,6 +64,12 @@ authRoutes.post('/login', loginRateLimit(), zValidator('json', loginSchema), asy
 
     // Generate refresh token (long-lived)
     const refreshToken = await createRefreshToken(user.id);
+
+    const oauthCookie = await signSessionCookie(user.id);
+    c.header(
+      'Set-Cookie',
+      `${OAUTH_SESSION_COOKIE_NAME}=${oauthCookie}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${OAUTH_SESSION_MAX_AGE}`
+    );
 
     return c.json({
       data: {

--- a/backend/src/routes/mcp.ts
+++ b/backend/src/routes/mcp.ts
@@ -1,0 +1,33 @@
+import { Hono } from 'hono';
+import { authMiddleware } from '../middleware/auth.ts';
+import { handleMcpRequest } from '../services/mcp/server.ts';
+
+/**
+ * Build the /mcp route. Takes the top-level Hono app as a closure so the MCP
+ * tools can dispatch back through it via app.fetch (Pattern B).
+ */
+export function buildMcpRoutes(app: Hono): Hono {
+  const mcpRoutes = new Hono();
+
+  mcpRoutes.use('/', async (c, next) => {
+    const auth = c.req.header('Authorization');
+    if (!auth || !auth.startsWith('Bearer ')) {
+      const baseUrl = new URL(c.req.url);
+      c.header(
+        'WWW-Authenticate',
+        `Bearer resource_metadata="${baseUrl.protocol}//${baseUrl.host}/.well-known/oauth-protected-resource"`,
+      );
+      return c.json({ error: 'unauthorized' }, 401);
+    }
+    return await authMiddleware(c, next);
+  });
+
+  mcpRoutes.post('/', async (c) => {
+    const accessToken = c.req.header('Authorization')!.substring(7);
+    const body = await c.req.json();
+    const result = await handleMcpRequest(app, accessToken, body);
+    return c.json(result);
+  });
+
+  return mcpRoutes;
+}

--- a/backend/src/routes/mcp.ts
+++ b/backend/src/routes/mcp.ts
@@ -1,6 +1,8 @@
+import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { authMiddleware } from '../middleware/auth.ts';
 import { handleMcpRequest } from '../services/mcp/server.ts';
+import { publicBaseUrl } from '../utils/public-url.ts';
 
 /**
  * Build the /mcp route. Takes the top-level Hono app as a closure so the MCP
@@ -9,17 +11,31 @@ import { handleMcpRequest } from '../services/mcp/server.ts';
 export function buildMcpRoutes(app: Hono): Hono {
   const mcpRoutes = new Hono();
 
+  function setWwwAuthenticate(c: Context, baseUrl: string): void {
+    c.header(
+      'WWW-Authenticate',
+      `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`,
+    );
+  }
+
   mcpRoutes.use('/', async (c, next) => {
+    const baseUrl = publicBaseUrl(c);
     const auth = c.req.header('Authorization');
     if (!auth || !auth.startsWith('Bearer ')) {
-      const baseUrl = new URL(c.req.url);
-      c.header(
-        'WWW-Authenticate',
-        `Bearer resource_metadata="${baseUrl.protocol}//${baseUrl.host}/.well-known/oauth-protected-resource"`,
-      );
+      setWwwAuthenticate(c, baseUrl);
       return c.json({ error: 'unauthorized' }, 401);
     }
-    return await authMiddleware(c, next);
+    // Delegate to authMiddleware. If it returns a 401, annotate the response.
+    const res = await authMiddleware(c, next);
+    if (res && res.status === 401) {
+      const headers = new Headers(res.headers);
+      headers.set(
+        'WWW-Authenticate',
+        `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`,
+      );
+      return new Response(res.body, { status: res.status, headers });
+    }
+    return res;
   });
 
   mcpRoutes.post('/', async (c) => {

--- a/backend/src/routes/oauth-consent.ts
+++ b/backend/src/routes/oauth-consent.ts
@@ -1,0 +1,99 @@
+import { Hono } from 'hono';
+import { verifySessionCookie, OAUTH_SESSION_COOKIE_NAME } from '../services/oauth/session-cookie.ts';
+import { oauthClientRepository } from '../repositories/oauth-client.ts';
+import { oauthCodeRepository } from '../repositories/oauth-code.ts';
+import { userRepository } from '../repositories/user.ts';
+
+export const oauthConsentRoutes = new Hono();
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (ch) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[ch] as string));
+}
+
+function getCookieUserId(cookieHeader: string | undefined): Promise<number | null> {
+  if (!cookieHeader) return Promise.resolve(null);
+  const m = cookieHeader.match(new RegExp(`(?:^|;\\s*)${OAUTH_SESSION_COOKIE_NAME}=([^;]+)`));
+  if (!m) return Promise.resolve(null);
+  return verifySessionCookie(m[1]);
+}
+
+oauthConsentRoutes.get('/consent', async (c) => {
+  const userId = await getCookieUserId(c.req.header('Cookie'));
+  if (userId === null) {
+    const returnTo = encodeURIComponent(c.req.url);
+    return c.redirect(`/login?return_to=${returnTo}`, 302);
+  }
+  const clientId = c.req.query('client_id') ?? '';
+  const redirectUri = c.req.query('redirect_uri') ?? '';
+  const codeChallenge = c.req.query('code_challenge') ?? '';
+  const state = c.req.query('state') ?? '';
+  const scope = c.req.query('scope') ?? 'read';
+
+  const client = await oauthClientRepository.findById(clientId);
+  if (!client) return c.text('unknown client', 400);
+  if (!client.redirect_uris.includes(redirectUri)) return c.text('bad redirect_uri', 400);
+
+  const user = await userRepository.findById(userId);
+  const clientName = escapeHtml(client.client_name ?? 'an MCP client');
+  const email = escapeHtml(user?.email ?? '');
+
+  const html = `<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8"><title>SnapFlow — Authorize</title></head>
+  <body style="font-family:system-ui;max-width:480px;margin:80px auto;padding:24px;border:1px solid #ddd;border-radius:8px">
+    <h2>Authorize ${clientName}</h2>
+    <p>${clientName} wants to read your SnapFlow projects and catalog as <strong>${email}</strong>.</p>
+    <form method="POST" action="/oauth/consent">
+      <input type="hidden" name="client_id" value="${escapeHtml(clientId)}">
+      <input type="hidden" name="redirect_uri" value="${escapeHtml(redirectUri)}">
+      <input type="hidden" name="code_challenge" value="${escapeHtml(codeChallenge)}">
+      <input type="hidden" name="state" value="${escapeHtml(state)}">
+      <input type="hidden" name="scope" value="${escapeHtml(scope)}">
+      <button name="action" value="allow" style="padding:10px 16px;margin-right:8px">Allow</button>
+      <button name="action" value="deny" style="padding:10px 16px">Deny</button>
+    </form>
+  </body>
+</html>`;
+  c.header('Content-Type', 'text/html; charset=utf-8');
+  return c.body(html);
+});
+
+oauthConsentRoutes.post('/consent', async (c) => {
+  const userId = await getCookieUserId(c.req.header('Cookie'));
+  if (userId === null) return c.text('not authenticated', 401);
+
+  const form = await c.req.formData();
+  const action = form.get('action');
+  const clientId = String(form.get('client_id') ?? '');
+  const redirectUri = String(form.get('redirect_uri') ?? '');
+  const codeChallenge = String(form.get('code_challenge') ?? '');
+  const state = String(form.get('state') ?? '');
+  const scope = String(form.get('scope') ?? 'read');
+
+  const client = await oauthClientRepository.findById(clientId);
+  if (!client || !client.redirect_uris.includes(redirectUri)) {
+    return c.text('bad client/redirect', 400);
+  }
+
+  const cbUrl = new URL(redirectUri);
+  if (action !== 'allow') {
+    cbUrl.searchParams.set('error', 'access_denied');
+    if (state) cbUrl.searchParams.set('state', state);
+    return c.redirect(cbUrl.toString(), 302);
+  }
+
+  const created = await oauthCodeRepository.create({
+    client_id: clientId,
+    user_id: userId,
+    redirect_uri: redirectUri,
+    code_challenge: codeChallenge,
+    ...(scope ? { scope } : {}),
+  });
+  cbUrl.searchParams.set('code', created.code);
+  if (state) cbUrl.searchParams.set('state', state);
+  return c.redirect(cbUrl.toString(), 302);
+});
+
+export default oauthConsentRoutes;

--- a/backend/src/routes/oauth.ts
+++ b/backend/src/routes/oauth.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { oauthClientRepository } from '../repositories/oauth-client.ts';
+import { verifySessionCookie, OAUTH_SESSION_COOKIE_NAME } from '../services/oauth/session-cookie.ts';
 
 export const oauthRoutes = new Hono();
 
@@ -25,6 +26,44 @@ oauthRoutes.post('/register', zValidator('json', registerSchema), async (c) => {
     grant_types: ['authorization_code', 'refresh_token'],
     response_types: ['code'],
   }, 201);
+});
+
+oauthRoutes.get('/authorize', async (c) => {
+  const responseType = c.req.query('response_type');
+  const clientId = c.req.query('client_id');
+  const redirectUri = c.req.query('redirect_uri');
+  const codeChallenge = c.req.query('code_challenge');
+  const codeChallengeMethod = c.req.query('code_challenge_method');
+  const state = c.req.query('state') ?? '';
+  const scope = c.req.query('scope') ?? 'read';
+
+  if (responseType !== 'code') return c.text('unsupported response_type', 400);
+  if (!clientId) return c.text('missing client_id', 400);
+  if (!redirectUri) return c.text('missing redirect_uri', 400);
+  if (!codeChallenge) return c.text('missing code_challenge', 400);
+  if (codeChallengeMethod !== 'S256') return c.text('only S256 supported', 400);
+
+  const client = await oauthClientRepository.findById(clientId);
+  if (!client) return c.text('unknown client_id', 400);
+  if (!client.redirect_uris.includes(redirectUri)) return c.text('redirect_uri not registered', 400);
+
+  // Parse cookie header
+  const cookieHeader = c.req.header('Cookie') ?? '';
+  const match = cookieHeader.match(new RegExp(`(?:^|;\\s*)${OAUTH_SESSION_COOKIE_NAME}=([^;]+)`));
+  const userId = match ? await verifySessionCookie(match[1]) : null;
+
+  if (userId === null) {
+    const returnTo = encodeURIComponent(c.req.url);
+    return c.redirect(`/login?return_to=${returnTo}`, 302);
+  }
+
+  const consentParams = new URLSearchParams();
+  consentParams.set('client_id', clientId);
+  consentParams.set('redirect_uri', redirectUri);
+  consentParams.set('code_challenge', codeChallenge);
+  consentParams.set('state', state);
+  consentParams.set('scope', scope);
+  return c.redirect(`/oauth/consent?${consentParams.toString()}`, 302);
 });
 
 export default oauthRoutes;

--- a/backend/src/routes/oauth.ts
+++ b/backend/src/routes/oauth.ts
@@ -1,0 +1,30 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { oauthClientRepository } from '../repositories/oauth-client.ts';
+
+export const oauthRoutes = new Hono();
+
+const registerSchema = z.object({
+  redirect_uris: z.array(z.string().url()).min(1),
+  client_name: z.string().optional(),
+}).passthrough();
+
+oauthRoutes.post('/register', zValidator('json', registerSchema), async (c) => {
+  const { redirect_uris, client_name } = c.req.valid('json');
+  const client = await oauthClientRepository.create({
+    redirect_uris,
+    ...(client_name !== undefined ? { client_name } : {}),
+  });
+  return c.json({
+    client_id: client.id,
+    client_id_issued_at: Math.floor(Date.now() / 1000),
+    redirect_uris: client.redirect_uris,
+    client_name: client.client_name,
+    token_endpoint_auth_method: 'none',
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+  }, 201);
+});
+
+export default oauthRoutes;

--- a/backend/src/routes/oauth.ts
+++ b/backend/src/routes/oauth.ts
@@ -8,6 +8,7 @@ import { generateToken } from '../services/jwt.ts';
 import { createRefreshToken, verifyRefreshToken, revokeRefreshToken } from '../services/refresh-token.ts';
 import { userRepository } from '../repositories/user.ts';
 import { oauthCodeRepository } from '../repositories/oauth-code.ts';
+import { generateClientSecret, hashClientSecret } from '../services/oauth/client-secret.ts';
 
 export const oauthRoutes = new Hono();
 
@@ -18,16 +19,23 @@ const registerSchema = z.object({
 
 oauthRoutes.post('/register', zValidator('json', registerSchema), async (c) => {
   const { redirect_uris, client_name } = c.req.valid('json');
+
+  const rawSecret = generateClientSecret();
+  const hash = await hashClientSecret(rawSecret);
+
   const client = await oauthClientRepository.create({
     redirect_uris,
     ...(client_name !== undefined ? { client_name } : {}),
+    client_secret_hash: hash,
   });
+
   return c.json({
     client_id: client.id,
+    client_secret: rawSecret,
     client_id_issued_at: Math.floor(Date.now() / 1000),
     redirect_uris: client.redirect_uris,
     client_name: client.client_name,
-    token_endpoint_auth_method: 'none',
+    token_endpoint_auth_method: 'client_secret_post',
     grant_types: ['authorization_code', 'refresh_token'],
     response_types: ['code'],
   }, 201);
@@ -71,11 +79,39 @@ oauthRoutes.get('/authorize', async (c) => {
   return c.redirect(`/oauth/consent?${consentParams.toString()}`, 302);
 });
 
+async function verifyClient(
+  form: FormData,
+  requireClientId = true,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const clientId = String(form.get('client_id') ?? '');
+  const submittedSecret = String(form.get('client_secret') ?? '');
+  if (!clientId) {
+    // If client_id is not required (e.g. legacy public-client refresh flows),
+    // allow the request through without client authentication.
+    if (!requireClientId) return { ok: true };
+    return { ok: false, reason: 'missing client_id' };
+  }
+  const client = await oauthClientRepository.findById(clientId);
+  if (!client) return { ok: false, reason: 'unknown client_id' };
+  if (client.client_secret_hash === null) {
+    // Public client (no secret on file) — no verification required.
+    return { ok: true };
+  }
+  if (!submittedSecret) return { ok: false, reason: 'missing client_secret' };
+  const ok = await oauthClientRepository.verifySecret(clientId, submittedSecret);
+  return ok ? { ok: true } : { ok: false, reason: 'invalid client_secret' };
+}
+
 oauthRoutes.post('/token', async (c) => {
   const form = await c.req.formData();
   const grantType = String(form.get('grant_type') ?? '');
 
   if (grantType === 'authorization_code') {
+    const clientCheck = await verifyClient(form);
+    if (!clientCheck.ok) {
+      return c.json({ error: 'invalid_client', error_description: clientCheck.reason }, 401);
+    }
+
     const code = String(form.get('code') ?? '');
     const redirectUri = String(form.get('redirect_uri') ?? '');
     const clientId = String(form.get('client_id') ?? '');
@@ -115,6 +151,11 @@ oauthRoutes.post('/token', async (c) => {
   }
 
   if (grantType === 'refresh_token') {
+    const clientCheck = await verifyClient(form, false);
+    if (!clientCheck.ok) {
+      return c.json({ error: 'invalid_client', error_description: clientCheck.reason }, 401);
+    }
+
     const refreshToken = String(form.get('refresh_token') ?? '');
     if (!refreshToken) return c.json({ error: 'invalid_request' }, 400);
     const userId = await verifyRefreshToken(refreshToken);

--- a/backend/src/routes/oauth.ts
+++ b/backend/src/routes/oauth.ts
@@ -5,7 +5,7 @@ import { oauthClientRepository } from '../repositories/oauth-client.ts';
 import { verifySessionCookie, OAUTH_SESSION_COOKIE_NAME } from '../services/oauth/session-cookie.ts';
 import { verifyS256 } from '../services/oauth/pkce.ts';
 import { generateToken } from '../services/jwt.ts';
-import { createRefreshToken } from '../services/refresh-token.ts';
+import { createRefreshToken, verifyRefreshToken, revokeRefreshToken } from '../services/refresh-token.ts';
 import { userRepository } from '../repositories/user.ts';
 import { oauthCodeRepository } from '../repositories/oauth-code.ts';
 
@@ -114,7 +114,26 @@ oauthRoutes.post('/token', async (c) => {
     });
   }
 
-  // refresh_token grant is implemented in Task 12.
+  if (grantType === 'refresh_token') {
+    const refreshToken = String(form.get('refresh_token') ?? '');
+    if (!refreshToken) return c.json({ error: 'invalid_request' }, 400);
+    const userId = await verifyRefreshToken(refreshToken);
+    if (userId === null) return c.json({ error: 'invalid_grant' }, 400);
+    const user = await userRepository.findById(userId);
+    if (!user) return c.json({ error: 'invalid_grant' }, 400);
+
+    await revokeRefreshToken(refreshToken);
+    const accessToken = await generateToken(user.id, user.email, user.role, user.tenant_id);
+    const newRefresh = await createRefreshToken(user.id);
+    return c.json({
+      access_token: accessToken,
+      token_type: 'Bearer',
+      expires_in: 900,
+      refresh_token: newRefresh,
+      scope: 'read',
+    });
+  }
+
   return c.json({ error: 'unsupported_grant_type' }, 400);
 });
 

--- a/backend/src/routes/oauth.ts
+++ b/backend/src/routes/oauth.ts
@@ -3,6 +3,11 @@ import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { oauthClientRepository } from '../repositories/oauth-client.ts';
 import { verifySessionCookie, OAUTH_SESSION_COOKIE_NAME } from '../services/oauth/session-cookie.ts';
+import { verifyS256 } from '../services/oauth/pkce.ts';
+import { generateToken } from '../services/jwt.ts';
+import { createRefreshToken } from '../services/refresh-token.ts';
+import { userRepository } from '../repositories/user.ts';
+import { oauthCodeRepository } from '../repositories/oauth-code.ts';
 
 export const oauthRoutes = new Hono();
 
@@ -64,6 +69,53 @@ oauthRoutes.get('/authorize', async (c) => {
   consentParams.set('state', state);
   consentParams.set('scope', scope);
   return c.redirect(`/oauth/consent?${consentParams.toString()}`, 302);
+});
+
+oauthRoutes.post('/token', async (c) => {
+  const form = await c.req.formData();
+  const grantType = String(form.get('grant_type') ?? '');
+
+  if (grantType === 'authorization_code') {
+    const code = String(form.get('code') ?? '');
+    const redirectUri = String(form.get('redirect_uri') ?? '');
+    const clientId = String(form.get('client_id') ?? '');
+    const verifier = String(form.get('code_verifier') ?? '');
+
+    if (!code || !redirectUri || !clientId || !verifier) {
+      return c.json({ error: 'invalid_request', error_description: 'missing field' }, 400);
+    }
+    const consumed = await oauthCodeRepository.consume(code);
+    if (!consumed) {
+      return c.json({ error: 'invalid_grant', error_description: 'code invalid/expired/reused' }, 400);
+    }
+    if (consumed.client_id !== clientId) {
+      return c.json({ error: 'invalid_grant', error_description: 'client_id mismatch' }, 400);
+    }
+    if (consumed.redirect_uri !== redirectUri) {
+      return c.json({ error: 'invalid_grant', error_description: 'redirect_uri mismatch' }, 400);
+    }
+    const pkceOk = await verifyS256(verifier, consumed.code_challenge);
+    if (!pkceOk) {
+      return c.json({ error: 'invalid_grant', error_description: 'PKCE verification failed' }, 400);
+    }
+
+    const user = await userRepository.findById(consumed.user_id);
+    if (!user) return c.json({ error: 'invalid_grant', error_description: 'user gone' }, 400);
+
+    const accessToken = await generateToken(user.id, user.email, user.role, user.tenant_id);
+    const refreshToken = await createRefreshToken(user.id);
+
+    return c.json({
+      access_token: accessToken,
+      token_type: 'Bearer',
+      expires_in: 900,
+      refresh_token: refreshToken,
+      scope: consumed.scope ?? 'read',
+    });
+  }
+
+  // refresh_token grant is implemented in Task 12.
+  return c.json({ error: 'unsupported_grant_type' }, 400);
 });
 
 export default oauthRoutes;

--- a/backend/src/routes/well-known.ts
+++ b/backend/src/routes/well-known.ts
@@ -1,19 +1,15 @@
 import { Hono } from 'hono';
 import { buildAuthServerMetadata, buildProtectedResourceMetadata } from '../services/oauth/metadata.ts';
+import { publicBaseUrl } from '../utils/public-url.ts';
 
 export const wellKnownRoutes = new Hono();
 
-function baseUrlOf(req: Request): string {
-  const url = new URL(req.url);
-  return `${url.protocol}//${url.host}`;
-}
-
 wellKnownRoutes.get('/.well-known/oauth-authorization-server', (c) => {
-  return c.json(buildAuthServerMetadata(baseUrlOf(c.req.raw)));
+  return c.json(buildAuthServerMetadata(publicBaseUrl(c)));
 });
 
 wellKnownRoutes.get('/.well-known/oauth-protected-resource', (c) => {
-  return c.json(buildProtectedResourceMetadata(baseUrlOf(c.req.raw)));
+  return c.json(buildProtectedResourceMetadata(publicBaseUrl(c)));
 });
 
 export default wellKnownRoutes;

--- a/backend/src/routes/well-known.ts
+++ b/backend/src/routes/well-known.ts
@@ -1,0 +1,19 @@
+import { Hono } from 'hono';
+import { buildAuthServerMetadata, buildProtectedResourceMetadata } from '../services/oauth/metadata.ts';
+
+export const wellKnownRoutes = new Hono();
+
+function baseUrlOf(req: Request): string {
+  const url = new URL(req.url);
+  return `${url.protocol}//${url.host}`;
+}
+
+wellKnownRoutes.get('/.well-known/oauth-authorization-server', (c) => {
+  return c.json(buildAuthServerMetadata(baseUrlOf(c.req.raw)));
+});
+
+wellKnownRoutes.get('/.well-known/oauth-protected-resource', (c) => {
+  return c.json(buildProtectedResourceMetadata(baseUrlOf(c.req.raw)));
+});
+
+export default wellKnownRoutes;

--- a/backend/src/scripts/migrate.ts
+++ b/backend/src/scripts/migrate.ts
@@ -1069,6 +1069,37 @@ export async function runMigrations(): Promise<void> {
 
         PRAGMA foreign_keys = ON;
       `
+    },
+    {
+      name: '038_oauth_clients',
+      sql: `
+        -- Migration 038: OAuth 2.1 tables for remote MCP server
+        -- Adds two tables: oauth_clients (registered MCP clients) and oauth_auth_codes (short-lived auth codes)
+
+        CREATE TABLE IF NOT EXISTS oauth_clients (
+          id            TEXT PRIMARY KEY,
+          client_secret TEXT,
+          redirect_uris TEXT NOT NULL,
+          client_name   TEXT,
+          created_at    DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE IF NOT EXISTS oauth_auth_codes (
+          code           TEXT PRIMARY KEY,
+          client_id      TEXT NOT NULL,
+          user_id        INTEGER NOT NULL,
+          redirect_uri   TEXT NOT NULL,
+          code_challenge TEXT NOT NULL,
+          scope          TEXT,
+          expires_at     DATETIME NOT NULL,
+          consumed_at    DATETIME,
+          FOREIGN KEY (client_id) REFERENCES oauth_clients(id) ON DELETE CASCADE,
+          FOREIGN KEY (user_id)   REFERENCES users(id)         ON DELETE CASCADE
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_oauth_codes_expires ON oauth_auth_codes(expires_at);
+        CREATE INDEX IF NOT EXISTS idx_oauth_codes_client  ON oauth_auth_codes(client_id);
+      `
     }
   ];
 

--- a/backend/src/services/mcp/dispatcher.ts
+++ b/backend/src/services/mcp/dispatcher.ts
@@ -1,0 +1,56 @@
+import type { Hono } from 'hono';
+
+export interface DispatchInput {
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  path: string;
+  query?: Record<string, string | number | undefined>;
+  body?: unknown;
+  accessToken: string;
+}
+
+export interface DispatchResult {
+  ok: boolean;
+  status: number;
+  // deno-lint-ignore no-explicit-any
+  body: any;
+}
+
+/**
+ * Dispatch a request to the in-process Hono app using the user's access token.
+ *
+ * MCP tools call this instead of touching repositories directly, so that all
+ * middleware (auth, tenant scoping, Zod validation, role checks, cascading
+ * business logic) runs exactly as it would for a real HTTP request from the
+ * frontend.
+ */
+export async function dispatchToBackend(
+  app: Hono,
+  input: DispatchInput,
+): Promise<DispatchResult> {
+  const url = new URL(`http://internal${input.path}`);
+  if (input.query) {
+    for (const [k, v] of Object.entries(input.query)) {
+      if (v !== undefined && v !== null) url.searchParams.set(k, String(v));
+    }
+  }
+
+  const init: RequestInit = {
+    method: input.method,
+    headers: { Authorization: `Bearer ${input.accessToken}` },
+  };
+  if (input.body !== undefined) {
+    (init.headers as Record<string, string>)['content-type'] = 'application/json';
+    init.body = JSON.stringify(input.body);
+  }
+
+  const res = await app.fetch(new Request(url, init));
+  const contentType = res.headers.get('content-type') ?? '';
+  // deno-lint-ignore no-explicit-any
+  let body: any = null;
+  if (contentType.startsWith('application/json')) {
+    body = await res.json();
+  } else {
+    body = await res.text();
+  }
+  return { ok: res.ok, status: res.status, body };
+}

--- a/backend/src/services/mcp/server.ts
+++ b/backend/src/services/mcp/server.ts
@@ -1,0 +1,67 @@
+import type { Hono } from 'hono';
+import { listProjectsTool } from './tools/list-projects.ts';
+import { getProjectTool } from './tools/get-project.ts';
+import { getProjectTotalTool } from './tools/get-project-total.ts';
+import { searchItemsTool } from './tools/search-items.ts';
+
+const allTools = [listProjectsTool, getProjectTool, getProjectTotalTool, searchItemsTool];
+
+export interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: number | string | null;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+/**
+ * Minimal MCP server: handles `initialize`, `tools/list`, `tools/call` over JSON-RPC.
+ * Tools dispatch back through the same Hono app (Pattern B) so every middleware runs.
+ */
+export async function handleMcpRequest(
+  app: Hono,
+  accessToken: string,
+  req: JsonRpcRequest,
+): Promise<unknown> {
+  if (req.method === 'initialize') {
+    return {
+      jsonrpc: '2.0',
+      id: req.id,
+      result: {
+        protocolVersion: '2024-11-05',
+        capabilities: { tools: {} },
+        serverInfo: { name: 'snapflow-mcp', version: '0.1.0' },
+      },
+    };
+  }
+  if (req.method === 'tools/list') {
+    return {
+      jsonrpc: '2.0',
+      id: req.id,
+      result: {
+        tools: allTools.map((t) => ({
+          name: t.name,
+          description: t.description,
+          inputSchema: { type: 'object' },
+        })),
+      },
+    };
+  }
+  if (req.method === 'tools/call') {
+    const params = req.params as { name: string; arguments?: Record<string, unknown> } | undefined;
+    if (!params) {
+      return { jsonrpc: '2.0', id: req.id, error: { code: -32602, message: 'missing params' } };
+    }
+    const tool = allTools.find((t) => t.name === params.name);
+    if (!tool) {
+      return { jsonrpc: '2.0', id: req.id, error: { code: -32601, message: `unknown tool: ${params.name}` } };
+    }
+    const parsed = tool.inputSchema.safeParse(params.arguments ?? {});
+    if (!parsed.success) {
+      return { jsonrpc: '2.0', id: req.id, error: { code: -32602, message: parsed.error.message } };
+    }
+    // deno-lint-ignore no-explicit-any
+    const result = await (tool.handler as any)(parsed.data, { app, accessToken });
+    return { jsonrpc: '2.0', id: req.id, result };
+  }
+  return { jsonrpc: '2.0', id: req.id, error: { code: -32601, message: `unknown method: ${req.method}` } };
+}

--- a/backend/src/services/mcp/tools/get-project-total.ts
+++ b/backend/src/services/mcp/tools/get-project-total.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { dispatchToBackend } from '../dispatcher.ts';
+import type { ToolContext, ToolResult } from './list-projects.ts';
+
+const inputSchema = z.object({
+  project_id: z.number().int().positive(),
+});
+
+export const getProjectTotalTool = {
+  name: 'get_project_total',
+  description:
+    'Get the itemized total/pricing summary for a SnapFlow project — list price, discounts, tax, grand total.',
+  inputSchema,
+  handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
+    const result = await dispatchToBackend(ctx.app, {
+      method: 'GET',
+      path: `/api/projects/${args.project_id}/total`,
+      accessToken: ctx.accessToken,
+    });
+    if (!result.ok) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to get total for project ${args.project_id} (HTTP ${result.status}): ${JSON.stringify(result.body)}` }],
+      };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(result.body.data, null, 2) }] };
+  },
+};

--- a/backend/src/services/mcp/tools/get-project.ts
+++ b/backend/src/services/mcp/tools/get-project.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { dispatchToBackend } from '../dispatcher.ts';
+import type { ToolContext, ToolResult } from './list-projects.ts';
+
+const inputSchema = z.object({
+  project_id: z.number().int().positive(),
+});
+
+export const getProjectTool = {
+  name: 'get_project',
+  description:
+    'Get full details for a single SnapFlow project — customer info, floorplans, BOM entries.',
+  inputSchema,
+  handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
+    const result = await dispatchToBackend(ctx.app, {
+      method: 'GET',
+      path: `/api/projects/${args.project_id}`,
+      accessToken: ctx.accessToken,
+    });
+    if (!result.ok) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to get project ${args.project_id} (HTTP ${result.status}): ${JSON.stringify(result.body)}` }],
+      };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(result.body.data, null, 2) }] };
+  },
+};

--- a/backend/src/services/mcp/tools/list-projects.ts
+++ b/backend/src/services/mcp/tools/list-projects.ts
@@ -1,0 +1,42 @@
+import type { Hono } from 'hono';
+import { z } from 'zod';
+import { dispatchToBackend } from '../dispatcher.ts';
+
+export interface ToolContext {
+  app: Hono;
+  accessToken: string;
+}
+
+export interface ToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+const inputSchema = z.object({
+  query: z.string().optional(),
+});
+
+export const listProjectsTool = {
+  name: 'list_projects',
+  description:
+    'List SnapFlow projects in your workspace. Returns id, name, customer name, status, and creation date. Use `query` to filter by project name.',
+  inputSchema,
+  handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
+    const dispatchInput: Parameters<typeof dispatchToBackend>[1] = {
+      method: 'GET',
+      path: '/api/projects',
+      accessToken: ctx.accessToken,
+    };
+    if (args.query !== undefined) {
+      dispatchInput.query = { search: args.query };
+    }
+    const result = await dispatchToBackend(ctx.app, dispatchInput);
+    if (!result.ok) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to list projects (HTTP ${result.status}): ${JSON.stringify(result.body)}` }],
+      };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(result.body.data, null, 2) }] };
+  },
+};

--- a/backend/src/services/mcp/tools/search-items.ts
+++ b/backend/src/services/mcp/tools/search-items.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { dispatchToBackend, type DispatchInput } from '../dispatcher.ts';
+import type { ToolContext, ToolResult } from './list-projects.ts';
+
+const inputSchema = z.object({
+  query: z.string().optional(),
+  category_id: z.number().int().positive().optional(),
+  type_id: z.number().int().positive().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+});
+
+export const searchItemsTool = {
+  name: 'search_items',
+  description:
+    'Search the SnapFlow product catalog. Filter by name (`query`), `category_id`, or `type_id`. Limit defaults to 20, max 100.',
+  inputSchema,
+  handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
+    const query: Record<string, string | number> = {};
+    if (args.query !== undefined) query.search = args.query;
+    if (args.category_id !== undefined) query.category_id = args.category_id;
+    if (args.type_id !== undefined) query.type_id = args.type_id;
+    if (args.limit !== undefined) query.limit = args.limit;
+
+    const dispatchInput: DispatchInput = {
+      method: 'GET',
+      path: '/api/items',
+      accessToken: ctx.accessToken,
+    };
+    if (Object.keys(query).length > 0) {
+      dispatchInput.query = query;
+    }
+
+    const result = await dispatchToBackend(ctx.app, dispatchInput);
+    if (!result.ok) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to search items (HTTP ${result.status}): ${JSON.stringify(result.body)}` }],
+      };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(result.body.data, null, 2) }] };
+  },
+};

--- a/backend/src/services/oauth/client-secret.ts
+++ b/backend/src/services/oauth/client-secret.ts
@@ -1,0 +1,33 @@
+/**
+ * Generate a high-entropy random client_secret (raw, returned once to the
+ * registering client). 32 bytes base64url ≈ 43 chars.
+ */
+export function generateClientSecret(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  let s = '';
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * SHA-256 hash for storage. Client secrets are already high-entropy random
+ * (no need for bcrypt's slowness — bcrypt is for low-entropy human passwords).
+ */
+export async function hashClientSecret(raw: string): Promise<string> {
+  const data = new TextEncoder().encode(raw);
+  const buf = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Constant-time-ish string compare for hex strings of equal length. */
+export function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/backend/src/services/oauth/metadata.ts
+++ b/backend/src/services/oauth/metadata.ts
@@ -1,0 +1,41 @@
+export interface AuthServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint: string;
+  response_types_supported: string[];
+  grant_types_supported: string[];
+  code_challenge_methods_supported: string[];
+  token_endpoint_auth_methods_supported: string[];
+  scopes_supported: string[];
+}
+
+export interface ProtectedResourceMetadata {
+  resource: string;
+  authorization_servers: string[];
+  bearer_methods_supported: string[];
+  scopes_supported: string[];
+}
+
+export function buildAuthServerMetadata(baseUrl: string): AuthServerMetadata {
+  return {
+    issuer: baseUrl,
+    authorization_endpoint: `${baseUrl}/oauth/authorize`,
+    token_endpoint: `${baseUrl}/oauth/token`,
+    registration_endpoint: `${baseUrl}/oauth/register`,
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint_auth_methods_supported: ['none', 'client_secret_post'],
+    scopes_supported: ['read'],
+  };
+}
+
+export function buildProtectedResourceMetadata(baseUrl: string): ProtectedResourceMetadata {
+  return {
+    resource: `${baseUrl}/mcp`,
+    authorization_servers: [baseUrl],
+    bearer_methods_supported: ['header'],
+    scopes_supported: ['read'],
+  };
+}

--- a/backend/src/services/oauth/pkce.ts
+++ b/backend/src/services/oauth/pkce.ts
@@ -1,0 +1,16 @@
+function base64UrlEncode(bytes: Uint8Array): string {
+  let str = '';
+  for (const b of bytes) str += String.fromCharCode(b);
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Verify a PKCE S256 challenge against a verifier per RFC 7636.
+ * challenge == base64url(SHA-256(verifier))
+ */
+export async function verifyS256(verifier: string, challenge: string): Promise<boolean> {
+  const data = new TextEncoder().encode(verifier);
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  const expected = base64UrlEncode(new Uint8Array(hash));
+  return expected === challenge;
+}

--- a/backend/src/services/oauth/session-cookie.ts
+++ b/backend/src/services/oauth/session-cookie.ts
@@ -1,0 +1,59 @@
+import { env } from '../../config/env.ts';
+
+const TTL_SECONDS = 60 * 60; // 1 hour
+
+async function getKey(): Promise<CryptoKey> {
+  return await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(env.JWT_SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify']
+  );
+}
+
+function b64url(bytes: Uint8Array): string {
+  let s = '';
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function b64urlDecode(str: string): Uint8Array {
+  const padded = str.replace(/-/g, '+').replace(/_/g, '/') + '==='.slice((str.length + 3) % 4);
+  const bin = atob(padded);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+export async function signSessionCookie(userId: number): Promise<string> {
+  const payload = { uid: userId, exp: Math.floor(Date.now() / 1000) + TTL_SECONDS };
+  const payloadStr = b64url(new TextEncoder().encode(JSON.stringify(payload)));
+  const key = await getKey();
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payloadStr));
+  return `${payloadStr}.${b64url(new Uint8Array(sig))}`;
+}
+
+export async function verifySessionCookie(cookie: string): Promise<number | null> {
+  const parts = cookie.split('.');
+  if (parts.length !== 2) return null;
+  const [payloadStr, sigStr] = parts;
+  try {
+    const key = await getKey();
+    const ok = await crypto.subtle.verify(
+      'HMAC',
+      key,
+      b64urlDecode(sigStr).buffer as ArrayBuffer,
+      new TextEncoder().encode(payloadStr)
+    );
+    if (!ok) return null;
+    const payload = JSON.parse(new TextDecoder().decode(b64urlDecode(payloadStr))) as { uid: number; exp: number };
+    if (payload.exp <= Math.floor(Date.now() / 1000)) return null;
+    return payload.uid;
+  } catch {
+    return null;
+  }
+}
+
+export const OAUTH_SESSION_COOKIE_NAME = 'oauth_session';
+export const OAUTH_SESSION_MAX_AGE = TTL_SECONDS;

--- a/backend/src/utils/public-url.ts
+++ b/backend/src/utils/public-url.ts
@@ -1,0 +1,25 @@
+import type { Context } from 'hono';
+
+/**
+ * Returns the public base URL (scheme + host) for the current request.
+ *
+ * Honors X-Forwarded-Proto and X-Forwarded-Host when present (set by typical
+ * reverse proxies like nginx, Caddy, Cloudflare, Traefik). This ensures
+ * OAuth/MCP metadata advertises the correct HTTPS URL Claude.ai can reach,
+ * not the internal http://app:8000 the proxy sees.
+ *
+ * If PUBLIC_BASE_URL env var is set, prefer it over derivation.
+ */
+export function publicBaseUrl(c: Context): string {
+  const envBase = Deno.env.get('PUBLIC_BASE_URL');
+  if (envBase) return envBase.replace(/\/$/, '');
+
+  const xfProto = c.req.header('x-forwarded-proto');
+  const xfHost = c.req.header('x-forwarded-host') ?? c.req.header('host');
+  if (xfProto && xfHost) {
+    return `${xfProto.split(',')[0].trim()}://${xfHost.split(',')[0].trim()}`;
+  }
+
+  const url = new URL(c.req.url);
+  return `${url.protocol}//${url.host}`;
+}

--- a/backend/tests/mcp/dispatcher_test.ts
+++ b/backend/tests/mcp/dispatcher_test.ts
@@ -1,0 +1,39 @@
+import { assertEquals, assert } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { dispatchToBackend } from '../../src/services/mcp/dispatcher.ts';
+import app from '../../src/main.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+
+Deno.test('dispatchToBackend', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns parsed JSON body for 200 responses', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const user = await userRepository.create({
+      email: 'dispatcher@example.com', password_hash: 'x', role: 'user',
+      full_name: 'D', tenant_id: tenant.id,
+    } as any);
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+    const result = await dispatchToBackend(app, {
+      method: 'GET',
+      path: '/api/projects',
+      accessToken: token,
+    });
+    assertEquals(result.ok, true);
+    assert(Array.isArray(result.body.data));
+  });
+
+  await t.step('returns {ok:false, status, body} for error responses', async () => {
+    await clearDatabase();
+    const result = await dispatchToBackend(app, {
+      method: 'GET',
+      path: '/api/projects',
+      accessToken: 'garbage.jwt.string',
+    });
+    assertEquals(result.ok, false);
+    assertEquals(result.status, 401);
+  });
+});

--- a/backend/tests/mcp/dispatcher_test.ts
+++ b/backend/tests/mcp/dispatcher_test.ts
@@ -5,17 +5,18 @@ import app from '../../src/main.ts';
 import { userRepository } from '../../src/repositories/user.ts';
 import { tenantRepository } from '../../src/repositories/tenant.ts';
 import { generateToken } from '../../src/services/jwt.ts';
+import type { CreateTenantDTO, CreateUserDTO } from '../../src/models/index.ts';
 
 Deno.test('dispatchToBackend', async (t) => {
   await setupTestDatabase();
 
   await t.step('returns parsed JSON body for 200 responses', async () => {
     await clearDatabase();
-    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
     const user = await userRepository.create({
       email: 'dispatcher@example.com', password_hash: 'x', role: 'user',
       full_name: 'D', tenant_id: tenant.id,
-    } as any);
+    } as CreateUserDTO & { password_hash: string });
     const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
     const result = await dispatchToBackend(app, {
       method: 'GET',

--- a/backend/tests/mcp/tenant_isolation_test.ts
+++ b/backend/tests/mcp/tenant_isolation_test.ts
@@ -1,0 +1,36 @@
+import { assert, assertEquals } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import app from '../../src/main.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+import { projectRepository } from '../../src/repositories/project.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+import { listProjectsTool } from '../../src/services/mcp/tools/list-projects.ts';
+import type { CreateTenantDTO, CreateUserDTO, CreateProjectDTO } from '../../src/models/index.ts';
+
+Deno.test('Tenant A cannot see Tenant B projects via MCP', async () => {
+  await setupTestDatabase();
+  clearDatabase();
+
+  const tenantA = await tenantRepository.create({ name: 'A' } as CreateTenantDTO);
+  const tenantB = await tenantRepository.create({ name: 'B' } as CreateTenantDTO);
+  const userA = await userRepository.create({
+    email: 'isolationA@example.com', password_hash: 'x', role: 'user',
+    full_name: 'A', tenant_id: tenantA.id,
+  } as CreateUserDTO & { password_hash: string });
+
+  await projectRepository.create({
+    version_name: 'A-project', customer_name: 'Ax', tenant_id: tenantA.id,
+  } as CreateProjectDTO);
+  await projectRepository.create({
+    version_name: 'B-secret', customer_name: 'Bx', tenant_id: tenantB.id,
+  } as CreateProjectDTO);
+
+  const tokenA = await generateToken(userA.id, userA.email, userA.role, userA.tenant_id);
+  const result = await listProjectsTool.handler({ query: undefined }, { app, accessToken: tokenA });
+
+  assertEquals(result.isError, undefined);
+  const text = result.content[0].text;
+  assert(text.includes('A-project'), 'must include own-tenant project');
+  assert(!text.includes('B-secret'), 'must NOT include other-tenant project (cross-tenant leak!)');
+});

--- a/backend/tests/mcp/tools_test.ts
+++ b/backend/tests/mcp/tools_test.ts
@@ -6,6 +6,7 @@ import { tenantRepository } from '../../src/repositories/tenant.ts';
 import { projectRepository } from '../../src/repositories/project.ts';
 import { generateToken } from '../../src/services/jwt.ts';
 import { listProjectsTool } from '../../src/services/mcp/tools/list-projects.ts';
+import { getProjectTool } from '../../src/services/mcp/tools/get-project.ts';
 
 async function seedUserWithProjects() {
   const tenant = await tenantRepository.create({ name: 'T' } as any);
@@ -48,6 +49,43 @@ Deno.test('list_projects tool', async (t) => {
   await t.step('returns isError on bad auth', async () => {
     await clearDatabase();
     const result = await listProjectsTool.handler({ query: undefined }, { app, accessToken: 'bad' });
+    assertEquals(result.isError, true);
+  });
+});
+
+Deno.test('get_project tool', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns project details for valid id', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const user = await userRepository.create({
+      email: 'getproj@example.com', password_hash: 'x', role: 'user',
+      full_name: 'L', tenant_id: tenant.id,
+    } as any);
+    await projectRepository.create({
+      version_name: 'Alpha', customer_name: 'A Co', tenant_id: tenant.id,
+    } as any);
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    // Discover the created project's id by listing
+    const projects = await projectRepository.findAll(undefined, { tenantId: tenant.id, role: 'user' } as any);
+    const projectId = projects[0].id;
+
+    const result = await getProjectTool.handler({ project_id: projectId }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    assert(result.content[0].text.includes('Alpha'));
+  });
+
+  await t.step('returns isError for unknown id', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const user = await userRepository.create({
+      email: 'getproj2@example.com', password_hash: 'x', role: 'user',
+      full_name: 'L', tenant_id: tenant.id,
+    } as any);
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+    const result = await getProjectTool.handler({ project_id: 999999 }, { app, accessToken: token });
     assertEquals(result.isError, true);
   });
 });

--- a/backend/tests/mcp/tools_test.ts
+++ b/backend/tests/mcp/tools_test.ts
@@ -6,23 +6,25 @@ import { tenantRepository } from '../../src/repositories/tenant.ts';
 import { projectRepository } from '../../src/repositories/project.ts';
 import { itemRepository } from '../../src/repositories/item.ts';
 import { generateToken } from '../../src/services/jwt.ts';
+import type { CreateTenantDTO, CreateUserDTO, CreateProjectDTO } from '../../src/models/index.ts';
+import type { TenantContext } from '../../src/repositories/user.ts';
 import { listProjectsTool } from '../../src/services/mcp/tools/list-projects.ts';
 import { getProjectTool } from '../../src/services/mcp/tools/get-project.ts';
 import { getProjectTotalTool } from '../../src/services/mcp/tools/get-project-total.ts';
 import { searchItemsTool } from '../../src/services/mcp/tools/search-items.ts';
 
 async function seedUserWithProjects() {
-  const tenant = await tenantRepository.create({ name: 'T' } as any);
+  const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
   const user = await userRepository.create({
     email: 'listproj@example.com', password_hash: 'x', role: 'user',
     full_name: 'L', tenant_id: tenant.id,
-  } as any);
+  } as CreateUserDTO & { password_hash: string });
   await projectRepository.create({
     version_name: 'Alpha', customer_name: 'A Co', tenant_id: tenant.id,
-  } as any);
+  } as CreateProjectDTO);
   await projectRepository.create({
     version_name: 'Beta', customer_name: 'B Co', tenant_id: tenant.id,
-  } as any);
+  } as CreateProjectDTO);
   const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
   return { token, tenant, user };
 }
@@ -61,18 +63,18 @@ Deno.test('get_project tool', async (t) => {
 
   await t.step('returns project details for valid id', async () => {
     await clearDatabase();
-    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
     const user = await userRepository.create({
       email: 'getproj@example.com', password_hash: 'x', role: 'user',
       full_name: 'L', tenant_id: tenant.id,
-    } as any);
+    } as CreateUserDTO & { password_hash: string });
     await projectRepository.create({
       version_name: 'Alpha', customer_name: 'A Co', tenant_id: tenant.id,
-    } as any);
+    } as CreateProjectDTO);
     const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
 
     // Discover the created project's id by listing
-    const projects = await projectRepository.findAll(undefined, { tenantId: tenant.id, role: 'user' } as any);
+    const projects = await projectRepository.findAll(undefined, { tenantId: tenant.id, role: 'user' } as TenantContext);
     const projectId = projects[0].id;
 
     const result = await getProjectTool.handler({ project_id: projectId }, { app, accessToken: token });
@@ -82,11 +84,11 @@ Deno.test('get_project tool', async (t) => {
 
   await t.step('returns isError for unknown id', async () => {
     await clearDatabase();
-    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
     const user = await userRepository.create({
       email: 'getproj2@example.com', password_hash: 'x', role: 'user',
       full_name: 'L', tenant_id: tenant.id,
-    } as any);
+    } as CreateUserDTO & { password_hash: string });
     const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
     const result = await getProjectTool.handler({ project_id: 999999 }, { app, accessToken: token });
     assertEquals(result.isError, true);
@@ -98,16 +100,16 @@ Deno.test('get_project_total tool', async (t) => {
 
   await t.step('returns total for valid id', async () => {
     await clearDatabase();
-    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
     const user = await userRepository.create({
       email: 'gettotal@example.com', password_hash: 'x', role: 'user',
       full_name: 'L', tenant_id: tenant.id,
-    } as any);
+    } as CreateUserDTO & { password_hash: string });
     await projectRepository.create({
       version_name: 'Alpha', customer_name: 'A Co', tenant_id: tenant.id,
-    } as any);
+    } as CreateProjectDTO);
     const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
-    const projects = await projectRepository.findAll(undefined, { tenantId: tenant.id, role: 'user' } as any);
+    const projects = await projectRepository.findAll(undefined, { tenantId: tenant.id, role: 'user' } as TenantContext);
 
     const result = await getProjectTotalTool.handler({ project_id: projects[0].id }, { app, accessToken: token });
     assertEquals(result.isError, undefined);
@@ -120,16 +122,14 @@ Deno.test('search_items tool', async (t) => {
 
   await t.step('returns items matching query', async () => {
     await clearDatabase();
-    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
     const user = await userRepository.create({
       email: 'searchitem@example.com', password_hash: 'x', role: 'user',
       full_name: 'S', tenant_id: tenant.id,
-    } as any);
-    await itemRepository.create({
-      name: 'Smart Switch',
-      category_id: null,
-      type_id: null,
-    } as any);
+    } as CreateUserDTO & { password_hash: string });
+    const itemSeed = { name: 'Smart Switch', category_id: null, type_id: null };
+    // deno-lint-ignore no-explicit-any
+    await itemRepository.create(itemSeed as any);
     const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
 
     const result = await searchItemsTool.handler({ query: 'Switch' }, { app, accessToken: token });
@@ -139,11 +139,11 @@ Deno.test('search_items tool', async (t) => {
 
   await t.step('honors limit', async () => {
     await clearDatabase();
-    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
     const user = await userRepository.create({
       email: 'searchitem2@example.com', password_hash: 'x', role: 'user',
       full_name: 'S', tenant_id: tenant.id,
-    } as any);
+    } as CreateUserDTO & { password_hash: string });
     const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
 
     const result = await searchItemsTool.handler({ limit: 5 }, { app, accessToken: token });

--- a/backend/tests/mcp/tools_test.ts
+++ b/backend/tests/mcp/tools_test.ts
@@ -4,10 +4,12 @@ import app from '../../src/main.ts';
 import { userRepository } from '../../src/repositories/user.ts';
 import { tenantRepository } from '../../src/repositories/tenant.ts';
 import { projectRepository } from '../../src/repositories/project.ts';
+import { itemRepository } from '../../src/repositories/item.ts';
 import { generateToken } from '../../src/services/jwt.ts';
 import { listProjectsTool } from '../../src/services/mcp/tools/list-projects.ts';
 import { getProjectTool } from '../../src/services/mcp/tools/get-project.ts';
 import { getProjectTotalTool } from '../../src/services/mcp/tools/get-project-total.ts';
+import { searchItemsTool } from '../../src/services/mcp/tools/search-items.ts';
 
 async function seedUserWithProjects() {
   const tenant = await tenantRepository.create({ name: 'T' } as any);
@@ -110,5 +112,41 @@ Deno.test('get_project_total tool', async (t) => {
     const result = await getProjectTotalTool.handler({ project_id: projects[0].id }, { app, accessToken: token });
     assertEquals(result.isError, undefined);
     assert(result.content[0].text.length > 2);
+  });
+});
+
+Deno.test('search_items tool', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns items matching query', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const user = await userRepository.create({
+      email: 'searchitem@example.com', password_hash: 'x', role: 'user',
+      full_name: 'S', tenant_id: tenant.id,
+    } as any);
+    await itemRepository.create({
+      name: 'Smart Switch',
+      category_id: null,
+      type_id: null,
+    } as any);
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    const result = await searchItemsTool.handler({ query: 'Switch' }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    assert(result.content[0].text.includes('Smart Switch'));
+  });
+
+  await t.step('honors limit', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const user = await userRepository.create({
+      email: 'searchitem2@example.com', password_hash: 'x', role: 'user',
+      full_name: 'S', tenant_id: tenant.id,
+    } as any);
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    const result = await searchItemsTool.handler({ limit: 5 }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
   });
 });

--- a/backend/tests/mcp/tools_test.ts
+++ b/backend/tests/mcp/tools_test.ts
@@ -1,0 +1,53 @@
+import { assertEquals, assert } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import app from '../../src/main.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+import { projectRepository } from '../../src/repositories/project.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+import { listProjectsTool } from '../../src/services/mcp/tools/list-projects.ts';
+
+async function seedUserWithProjects() {
+  const tenant = await tenantRepository.create({ name: 'T' } as any);
+  const user = await userRepository.create({
+    email: 'listproj@example.com', password_hash: 'x', role: 'user',
+    full_name: 'L', tenant_id: tenant.id,
+  } as any);
+  await projectRepository.create({
+    version_name: 'Alpha', customer_name: 'A Co', tenant_id: tenant.id,
+  } as any);
+  await projectRepository.create({
+    version_name: 'Beta', customer_name: 'B Co', tenant_id: tenant.id,
+  } as any);
+  const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+  return { token, tenant, user };
+}
+
+Deno.test('list_projects tool', async (t) => {
+  await setupTestDatabase();
+
+  await t.step("returns content with the user's projects", async () => {
+    await clearDatabase();
+    const { token } = await seedUserWithProjects();
+    const result = await listProjectsTool.handler({ query: undefined }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    assertEquals(result.content.length, 1);
+    const text = result.content[0].text;
+    assert(text.includes('Alpha'));
+    assert(text.includes('Beta'));
+  });
+
+  await t.step('honors search query', async () => {
+    await clearDatabase();
+    const { token } = await seedUserWithProjects();
+    const result = await listProjectsTool.handler({ query: 'Alpha' }, { app, accessToken: token });
+    assert(result.content[0].text.includes('Alpha'));
+    assert(!result.content[0].text.includes('Beta'));
+  });
+
+  await t.step('returns isError on bad auth', async () => {
+    await clearDatabase();
+    const result = await listProjectsTool.handler({ query: undefined }, { app, accessToken: 'bad' });
+    assertEquals(result.isError, true);
+  });
+});

--- a/backend/tests/mcp/tools_test.ts
+++ b/backend/tests/mcp/tools_test.ts
@@ -7,6 +7,7 @@ import { projectRepository } from '../../src/repositories/project.ts';
 import { generateToken } from '../../src/services/jwt.ts';
 import { listProjectsTool } from '../../src/services/mcp/tools/list-projects.ts';
 import { getProjectTool } from '../../src/services/mcp/tools/get-project.ts';
+import { getProjectTotalTool } from '../../src/services/mcp/tools/get-project-total.ts';
 
 async function seedUserWithProjects() {
   const tenant = await tenantRepository.create({ name: 'T' } as any);
@@ -87,5 +88,27 @@ Deno.test('get_project tool', async (t) => {
     const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
     const result = await getProjectTool.handler({ project_id: 999999 }, { app, accessToken: token });
     assertEquals(result.isError, true);
+  });
+});
+
+Deno.test('get_project_total tool', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns total for valid id', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const user = await userRepository.create({
+      email: 'gettotal@example.com', password_hash: 'x', role: 'user',
+      full_name: 'L', tenant_id: tenant.id,
+    } as any);
+    await projectRepository.create({
+      version_name: 'Alpha', customer_name: 'A Co', tenant_id: tenant.id,
+    } as any);
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+    const projects = await projectRepository.findAll(undefined, { tenantId: tenant.id, role: 'user' } as any);
+
+    const result = await getProjectTotalTool.handler({ project_id: projects[0].id }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    assert(result.content[0].text.length > 2);
   });
 });

--- a/backend/tests/repositories/oauth_client_test.ts
+++ b/backend/tests/repositories/oauth_client_test.ts
@@ -1,0 +1,34 @@
+import { assertEquals, assertNotEquals } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { oauthClientRepository } from '../../src/repositories/oauth-client.ts';
+
+Deno.test('oauth-client repository', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('create returns client with id and stores redirect_uris', async () => {
+    await clearDatabase();
+    const created = await oauthClientRepository.create({
+      redirect_uris: ['https://claude.ai/oauth/callback'],
+      client_name: 'Claude',
+    });
+    assertNotEquals(created.id, '');
+    assertEquals(created.redirect_uris, ['https://claude.ai/oauth/callback']);
+    assertEquals(created.client_name, 'Claude');
+  });
+
+  await t.step('findById returns stored client', async () => {
+    await clearDatabase();
+    const created = await oauthClientRepository.create({
+      redirect_uris: ['https://x/cb'],
+    });
+    const found = await oauthClientRepository.findById(created.id);
+    assertEquals(found?.id, created.id);
+    assertEquals(found?.redirect_uris, ['https://x/cb']);
+  });
+
+  await t.step('findById returns null for unknown id', async () => {
+    await clearDatabase();
+    const found = await oauthClientRepository.findById('nope');
+    assertEquals(found, null);
+  });
+});

--- a/backend/tests/repositories/oauth_client_test.ts
+++ b/backend/tests/repositories/oauth_client_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertNotEquals } from '@std/assert';
 import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
 import { oauthClientRepository } from '../../src/repositories/oauth-client.ts';
+import { generateClientSecret, hashClientSecret } from '../../src/services/oauth/client-secret.ts';
 
 Deno.test('oauth-client repository', async (t) => {
   await setupTestDatabase();
@@ -30,5 +31,32 @@ Deno.test('oauth-client repository', async (t) => {
     await clearDatabase();
     const found = await oauthClientRepository.findById('nope');
     assertEquals(found, null);
+  });
+
+  await t.step('verifySecret returns true for matching secret', async () => {
+    await clearDatabase();
+    const raw = generateClientSecret();
+    const hash = await hashClientSecret(raw);
+    const created = await oauthClientRepository.create({
+      redirect_uris: ['https://c/cb'],
+      client_secret_hash: hash,
+    });
+    assertEquals(await oauthClientRepository.verifySecret(created.id, raw), true);
+  });
+
+  await t.step('verifySecret returns false for wrong secret', async () => {
+    await clearDatabase();
+    const hash = await hashClientSecret(generateClientSecret());
+    const created = await oauthClientRepository.create({
+      redirect_uris: ['https://c/cb'],
+      client_secret_hash: hash,
+    });
+    assertEquals(await oauthClientRepository.verifySecret(created.id, 'wrong'), false);
+  });
+
+  await t.step('verifySecret returns false for client without secret', async () => {
+    await clearDatabase();
+    const created = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    assertEquals(await oauthClientRepository.verifySecret(created.id, 'anything'), false);
   });
 });

--- a/backend/tests/repositories/oauth_code_test.ts
+++ b/backend/tests/repositories/oauth_code_test.ts
@@ -1,0 +1,56 @@
+import { assertEquals, assert } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { oauthCodeRepository } from '../../src/repositories/oauth-code.ts';
+import { oauthClientRepository } from '../../src/repositories/oauth-client.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+
+async function seedUserAndClient() {
+  const tenant = await tenantRepository.create({ name: 'T' });
+  const user = await userRepository.create({
+    email: 't@t.t', password_hash: 'x', role: 'user',
+    full_name: 'T', tenant_id: tenant.id,
+  });
+  const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+  return { user, client };
+}
+
+Deno.test('oauth-code repository', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('create stores code with expires_at in the future', async () => {
+    await clearDatabase();
+    const { user, client } = await seedUserAndClient();
+    const created = await oauthCodeRepository.create({
+      client_id: client.id, user_id: user.id,
+      redirect_uri: 'https://c/cb', code_challenge: 'abc', scope: 'read',
+    });
+    assert(created.code.length > 0);
+    assert(new Date(created.expires_at).getTime() > Date.now());
+  });
+
+  await t.step('consume returns code and marks consumed', async () => {
+    await clearDatabase();
+    const { user, client } = await seedUserAndClient();
+    const created = await oauthCodeRepository.create({
+      client_id: client.id, user_id: user.id,
+      redirect_uri: 'https://c/cb', code_challenge: 'abc',
+    });
+    const consumed = await oauthCodeRepository.consume(created.code);
+    assertEquals(consumed?.user_id, user.id);
+    const again = await oauthCodeRepository.consume(created.code);
+    assertEquals(again, null);
+  });
+
+  await t.step('consume returns null for expired code', async () => {
+    await clearDatabase();
+    const { user, client } = await seedUserAndClient();
+    const created = await oauthCodeRepository.create({
+      client_id: client.id, user_id: user.id,
+      redirect_uri: 'https://c/cb', code_challenge: 'abc',
+      ttl_seconds: -1,
+    });
+    const consumed = await oauthCodeRepository.consume(created.code);
+    assertEquals(consumed, null);
+  });
+});

--- a/backend/tests/routes/auth_session_cookie_test.ts
+++ b/backend/tests/routes/auth_session_cookie_test.ts
@@ -1,0 +1,34 @@
+import { assertEquals, assert } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+import { hashPassword } from '../../src/services/password.ts';
+import app from '../../src/main.ts';
+import { verifySessionCookie } from '../../src/services/oauth/session-cookie.ts';
+
+Deno.test('POST /api/auth/login sets oauth_session cookie', async () => {
+  await setupTestDatabase();
+  await clearDatabase();
+
+  const tenant = await tenantRepository.create({ name: 'T' } as any);
+  await userRepository.create({
+    email: 'user@test.com', password_hash: hashPassword('password123'),
+    role: 'user', full_name: 'U', tenant_id: tenant.id,
+  } as any);
+
+  const res = await app.fetch(new Request('http://x/api/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'user@test.com', password: 'password123' }),
+  }));
+  assertEquals(res.status, 200);
+
+  const setCookie = res.headers.get('set-cookie') ?? '';
+  assert(setCookie.includes('oauth_session='), `expected oauth_session cookie, got: ${setCookie}`);
+  assert(setCookie.includes('HttpOnly'), 'cookie must be HttpOnly');
+  assert(setCookie.includes('SameSite=Lax'), 'cookie must be SameSite=Lax');
+
+  const cookieValue = setCookie.split('oauth_session=')[1]?.split(';')[0] ?? '';
+  const userId = await verifySessionCookie(cookieValue);
+  assert(userId !== null && userId > 0);
+});

--- a/backend/tests/routes/auth_session_cookie_test.ts
+++ b/backend/tests/routes/auth_session_cookie_test.ts
@@ -5,16 +5,18 @@ import { tenantRepository } from '../../src/repositories/tenant.ts';
 import { hashPassword } from '../../src/services/password.ts';
 import app from '../../src/main.ts';
 import { verifySessionCookie } from '../../src/services/oauth/session-cookie.ts';
+import type { CreateTenantDTO } from '../../src/models/index.ts';
+import type { CreateUserDTO } from '../../src/models/index.ts';
 
 Deno.test('POST /api/auth/login sets oauth_session cookie', async () => {
   await setupTestDatabase();
   await clearDatabase();
 
-  const tenant = await tenantRepository.create({ name: 'T' } as any);
+  const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
   await userRepository.create({
     email: 'user@test.com', password_hash: hashPassword('password123'),
     role: 'user', full_name: 'U', tenant_id: tenant.id,
-  } as any);
+  } as CreateUserDTO & { password_hash: string });
 
   const res = await app.fetch(new Request('http://x/api/auth/login', {
     method: 'POST',

--- a/backend/tests/routes/mcp_test.ts
+++ b/backend/tests/routes/mcp_test.ts
@@ -1,0 +1,42 @@
+import { assertEquals, assert } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import app from '../../src/main.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+
+Deno.test('POST /mcp', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns 401 with WWW-Authenticate when no bearer', async () => {
+    const res = await app.fetch(new Request('http://x/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    }));
+    assertEquals(res.status, 401);
+    const wwwAuth = res.headers.get('www-authenticate') ?? '';
+    assert(wwwAuth.includes('Bearer'));
+    assert(wwwAuth.includes('resource_metadata'));
+  });
+
+  await t.step('tools/list returns the 4 tools when authenticated', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const user = await userRepository.create({
+      email: 'mcptest@example.com', password_hash: 'x', role: 'user',
+      full_name: 'M', tenant_id: tenant.id,
+    } as any);
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    const res = await app.fetch(new Request('http://x/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    }));
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    const names = body.result.tools.map((t: { name: string }) => t.name).sort();
+    assertEquals(names, ['get_project', 'get_project_total', 'list_projects', 'search_items']);
+  });
+});

--- a/backend/tests/routes/mcp_test.ts
+++ b/backend/tests/routes/mcp_test.ts
@@ -21,6 +21,18 @@ Deno.test('POST /mcp', async (t) => {
     assert(wwwAuth.includes('resource_metadata'));
   });
 
+  await t.step('returns 401 with WWW-Authenticate when bearer is invalid', async () => {
+    const res = await app.fetch(new Request('http://x/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', Authorization: 'Bearer garbage.invalid.token' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    }));
+    assertEquals(res.status, 401);
+    const wwwAuth = res.headers.get('www-authenticate') ?? '';
+    assert(wwwAuth.includes('Bearer'));
+    assert(wwwAuth.includes('resource_metadata'));
+  });
+
   await t.step('tools/list returns the 4 tools when authenticated', async () => {
     await clearDatabase();
     const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);

--- a/backend/tests/routes/mcp_test.ts
+++ b/backend/tests/routes/mcp_test.ts
@@ -4,6 +4,7 @@ import app from '../../src/main.ts';
 import { userRepository } from '../../src/repositories/user.ts';
 import { tenantRepository } from '../../src/repositories/tenant.ts';
 import { generateToken } from '../../src/services/jwt.ts';
+import type { CreateTenantDTO, CreateUserDTO } from '../../src/models/index.ts';
 
 Deno.test('POST /mcp', async (t) => {
   await setupTestDatabase();
@@ -22,11 +23,11 @@ Deno.test('POST /mcp', async (t) => {
 
   await t.step('tools/list returns the 4 tools when authenticated', async () => {
     await clearDatabase();
-    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
     const user = await userRepository.create({
       email: 'mcptest@example.com', password_hash: 'x', role: 'user',
       full_name: 'M', tenant_id: tenant.id,
-    } as any);
+    } as CreateUserDTO & { password_hash: string });
     const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
 
     const res = await app.fetch(new Request('http://x/mcp', {

--- a/backend/tests/routes/oauth_consent_test.ts
+++ b/backend/tests/routes/oauth_consent_test.ts
@@ -6,6 +6,7 @@ import { userRepository } from '../../src/repositories/user.ts';
 import { tenantRepository } from '../../src/repositories/tenant.ts';
 import { oauthClientRepository } from '../../src/repositories/oauth-client.ts';
 import { signSessionCookie } from '../../src/services/oauth/session-cookie.ts';
+import type { CreateTenantDTO, CreateUserDTO } from '../../src/models/index.ts';
 
 function buildApp(): Hono {
   const app = new Hono();
@@ -14,11 +15,11 @@ function buildApp(): Hono {
 }
 
 async function seed() {
-  const tenant = await tenantRepository.create({ name: 'T' } as any);
+  const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
   const user = await userRepository.create({
     email: 'consent@example.com', password_hash: 'x', role: 'user',
     full_name: 'C', tenant_id: tenant.id,
-  } as any);
+  } as CreateUserDTO & { password_hash: string });
   const client = await oauthClientRepository.create({
     redirect_uris: ['https://c/cb'], client_name: 'Claude',
   });

--- a/backend/tests/routes/oauth_consent_test.ts
+++ b/backend/tests/routes/oauth_consent_test.ts
@@ -1,0 +1,103 @@
+import { assertEquals, assert } from '@std/assert';
+import { Hono } from 'hono';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { oauthConsentRoutes } from '../../src/routes/oauth-consent.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+import { oauthClientRepository } from '../../src/repositories/oauth-client.ts';
+import { signSessionCookie } from '../../src/services/oauth/session-cookie.ts';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/oauth', oauthConsentRoutes);
+  return app;
+}
+
+async function seed() {
+  const tenant = await tenantRepository.create({ name: 'T' } as any);
+  const user = await userRepository.create({
+    email: 'consent@example.com', password_hash: 'x', role: 'user',
+    full_name: 'C', tenant_id: tenant.id,
+  } as any);
+  const client = await oauthClientRepository.create({
+    redirect_uris: ['https://c/cb'], client_name: 'Claude',
+  });
+  const cookie = await signSessionCookie(user.id);
+  return { user, client, cookie };
+}
+
+Deno.test('OAuth consent', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('GET /oauth/consent renders HTML with allow/deny form', async () => {
+    await clearDatabase();
+    const { client, cookie } = await seed();
+    const app = buildApp();
+    const url = `https://x/oauth/consent?client_id=${client.id}&redirect_uri=${encodeURIComponent('https://c/cb')}&code_challenge=abc&state=xyz&scope=read`;
+    const res = await app.fetch(new Request(url, { headers: { Cookie: `oauth_session=${cookie}` } }));
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get('content-type')?.startsWith('text/html'), true);
+    const body = await res.text();
+    assert(body.includes('Claude'), 'must show client name');
+    assert(body.includes('Allow'), 'must have Allow button');
+    assert(body.includes('Deny'), 'must have Deny button');
+  });
+
+  await t.step('GET /oauth/consent redirects to login when no cookie', async () => {
+    await clearDatabase();
+    const { client } = await seed();
+    const app = buildApp();
+    const url = `https://x/oauth/consent?client_id=${client.id}&redirect_uri=https://c/cb&code_challenge=abc&state=xyz`;
+    const res = await app.fetch(new Request(url));
+    assertEquals(res.status, 302);
+    assert((res.headers.get('location') ?? '').includes('/login'));
+  });
+
+  await t.step('POST /oauth/consent (Allow) issues code and redirects to client', async () => {
+    await clearDatabase();
+    const { client, cookie } = await seed();
+    const app = buildApp();
+    const body = new URLSearchParams({
+      action: 'allow',
+      client_id: client.id,
+      redirect_uri: 'https://c/cb',
+      code_challenge: 'abc',
+      state: 'xyz',
+      scope: 'read',
+    });
+    const res = await app.fetch(new Request('https://x/oauth/consent', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded', Cookie: `oauth_session=${cookie}` },
+      body: body.toString(),
+    }));
+    assertEquals(res.status, 302);
+    const location = res.headers.get('location') ?? '';
+    assert(location.startsWith('https://c/cb?'), `expected redirect to client, got: ${location}`);
+    const cb = new URL(location);
+    assert((cb.searchParams.get('code') ?? '').length > 0);
+    assertEquals(cb.searchParams.get('state'), 'xyz');
+  });
+
+  await t.step('POST /oauth/consent (Deny) redirects to client with error', async () => {
+    await clearDatabase();
+    const { client, cookie } = await seed();
+    const app = buildApp();
+    const body = new URLSearchParams({
+      action: 'deny',
+      client_id: client.id,
+      redirect_uri: 'https://c/cb',
+      code_challenge: 'abc',
+      state: 'xyz',
+    });
+    const res = await app.fetch(new Request('https://x/oauth/consent', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded', Cookie: `oauth_session=${cookie}` },
+      body: body.toString(),
+    }));
+    assertEquals(res.status, 302);
+    const location = res.headers.get('location') ?? '';
+    assert(location.startsWith('https://c/cb?'));
+    const cb = new URL(location);
+    assertEquals(cb.searchParams.get('error'), 'access_denied');
+  });
+});

--- a/backend/tests/routes/oauth_test.ts
+++ b/backend/tests/routes/oauth_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assert } from '@std/assert';
+import { assertEquals, assert, assertNotEquals } from '@std/assert';
 import { Hono } from 'hono';
 import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
 import { oauthRoutes } from '../../src/routes/oauth.ts';
@@ -202,5 +202,67 @@ Deno.test('POST /oauth/token (authorization_code)', async (t) => {
       method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: makeBody(),
     }));
     assertEquals(second.status, 400);
+  });
+});
+
+Deno.test('POST /oauth/token (refresh_token)', async (t) => {
+  await setupTestDatabase();
+
+  async function obtainTokenPair() {
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const user = await userRepository.create({
+      email: 'refreshuser@example.com', password_hash: 'x', role: 'user',
+      full_name: 'Q', tenant_id: tenant.id,
+    } as any);
+    const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    const created = await oauthCodeRepository.create({
+      client_id: client.id, user_id: user.id,
+      redirect_uri: 'https://c/cb', code_challenge: challenge,
+    });
+    const app = buildApp();
+    const res = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code', code: created.code,
+        redirect_uri: 'https://c/cb', client_id: client.id, code_verifier: verifier,
+      }).toString(),
+    }));
+    return { app, tok: await res.json(), user };
+  }
+
+  await t.step('exchanges refresh token for new pair', async () => {
+    await clearDatabase();
+    const { app, tok } = await obtainTokenPair();
+
+    const res = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: tok.refresh_token }).toString(),
+    }));
+    assertEquals(res.status, 200);
+    const next = await res.json();
+    assert(typeof next.access_token === 'string');
+    assert(typeof next.refresh_token === 'string');
+    assertNotEquals(next.refresh_token, tok.refresh_token, 'refresh token must rotate');
+  });
+
+  await t.step('old refresh token is invalidated after rotation', async () => {
+    await clearDatabase();
+    const { app, tok } = await obtainTokenPair();
+    const r1 = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: tok.refresh_token }).toString(),
+    }));
+    assertEquals(r1.status, 200);
+    const r2 = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: tok.refresh_token }).toString(),
+    }));
+    assertEquals(r2.status, 400);
   });
 });

--- a/backend/tests/routes/oauth_test.ts
+++ b/backend/tests/routes/oauth_test.ts
@@ -2,6 +2,10 @@ import { assertEquals, assert } from '@std/assert';
 import { Hono } from 'hono';
 import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
 import { oauthRoutes } from '../../src/routes/oauth.ts';
+import { signSessionCookie } from '../../src/services/oauth/session-cookie.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+import { oauthClientRepository } from '../../src/repositories/oauth-client.ts';
 
 function buildApp(): Hono {
   const app = new Hono();
@@ -38,6 +42,56 @@ Deno.test('POST /oauth/register', async (t) => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ client_name: 'X' }),
     }));
+    assertEquals(res.status, 400);
+  });
+});
+
+Deno.test('GET /oauth/authorize', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('redirects to login when no session cookie', async () => {
+    await clearDatabase();
+    const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    const app = buildApp();
+    const url = `https://x/oauth/authorize?response_type=code&client_id=${client.id}&redirect_uri=${encodeURIComponent('https://c/cb')}&code_challenge=abc&code_challenge_method=S256&state=xyz`;
+    const res = await app.fetch(new Request(url));
+    assertEquals(res.status, 302);
+    const location = res.headers.get('location') ?? '';
+    assert(location.includes('/login'), `expected /login, got: ${location}`);
+    assert(location.includes('return_to='), 'must encode return_to');
+  });
+
+  await t.step('redirects to /oauth/consent when session cookie valid', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const user = await userRepository.create({
+      email: 'authtest@example.com', password_hash: 'x', role: 'user',
+      full_name: 'A', tenant_id: tenant.id,
+    } as any);
+    const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    const cookie = await signSessionCookie(user.id);
+
+    const app = buildApp();
+    const url = `https://x/oauth/authorize?response_type=code&client_id=${client.id}&redirect_uri=${encodeURIComponent('https://c/cb')}&code_challenge=abc&code_challenge_method=S256&state=xyz`;
+    const res = await app.fetch(new Request(url, { headers: { Cookie: `oauth_session=${cookie}` } }));
+    assertEquals(res.status, 302);
+    const location = res.headers.get('location') ?? '';
+    assert(location.startsWith('/oauth/consent?'), `expected /oauth/consent, got: ${location}`);
+  });
+
+  await t.step('rejects unknown client_id', async () => {
+    const app = buildApp();
+    const url = `https://x/oauth/authorize?response_type=code&client_id=nope&redirect_uri=https://c/cb&code_challenge=abc&code_challenge_method=S256`;
+    const res = await app.fetch(new Request(url));
+    assertEquals(res.status, 400);
+  });
+
+  await t.step('rejects redirect_uri not in client allowlist', async () => {
+    await clearDatabase();
+    const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    const app = buildApp();
+    const url = `https://x/oauth/authorize?response_type=code&client_id=${client.id}&redirect_uri=${encodeURIComponent('https://evil/cb')}&code_challenge=abc&code_challenge_method=S256`;
+    const res = await app.fetch(new Request(url));
     assertEquals(res.status, 400);
   });
 });

--- a/backend/tests/routes/oauth_test.ts
+++ b/backend/tests/routes/oauth_test.ts
@@ -33,9 +33,10 @@ Deno.test('POST /oauth/register', async (t) => {
     assertEquals(res.status, 201);
     const body = await res.json();
     assert(typeof body.client_id === 'string' && body.client_id.length > 0);
+    assert(typeof body.client_secret === 'string' && body.client_secret.length > 0);
     assertEquals(body.redirect_uris, ['https://claude.ai/api/mcp/auth_callback']);
     assertEquals(body.client_name, 'Claude');
-    assertEquals(body.token_endpoint_auth_method, 'none');
+    assertEquals(body.token_endpoint_auth_method, 'client_secret_post');
   });
 
   await t.step('rejects missing redirect_uris', async () => {
@@ -265,5 +266,120 @@ Deno.test('POST /oauth/token (refresh_token)', async (t) => {
       body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: tok.refresh_token }).toString(),
     }));
     assertEquals(r2.status, 400);
+  });
+});
+
+Deno.test('POST /oauth/token client_secret', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('rejects code grant without client_secret when client has one', async () => {
+    await clearDatabase();
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
+    const user = await userRepository.create({
+      email: 'sec1@example.com', password_hash: 'x', role: 'user',
+      full_name: 'S', tenant_id: tenant.id,
+    } as CreateUserDTO & { password_hash: string });
+    // Register via the register route so the client has a secret on file
+    const app = buildApp();
+    const reg = await app.fetch(new Request('https://x/oauth/register', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ redirect_uris: ['https://c/cb'], client_name: 'X' }),
+    }));
+    const { client_id } = await reg.json();
+    const created = await oauthCodeRepository.create({
+      client_id, user_id: user.id, redirect_uri: 'https://c/cb', code_challenge: challenge,
+    });
+
+    const res = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code', code: created.code,
+        redirect_uri: 'https://c/cb', client_id, code_verifier: verifier,
+        // missing client_secret
+      }).toString(),
+    }));
+    assertEquals(res.status, 401);
+    assertEquals((await res.json()).error, 'invalid_client');
+  });
+
+  await t.step('accepts code grant with correct client_secret', async () => {
+    await clearDatabase();
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
+    const user = await userRepository.create({
+      email: 'sec2@example.com', password_hash: 'x', role: 'user',
+      full_name: 'S', tenant_id: tenant.id,
+    } as CreateUserDTO & { password_hash: string });
+    const app = buildApp();
+    const reg = await app.fetch(new Request('https://x/oauth/register', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ redirect_uris: ['https://c/cb'], client_name: 'X' }),
+    }));
+    const { client_id, client_secret } = await reg.json();
+    const created = await oauthCodeRepository.create({
+      client_id, user_id: user.id, redirect_uri: 'https://c/cb', code_challenge: challenge,
+    });
+
+    const res = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code', code: created.code,
+        redirect_uri: 'https://c/cb', client_id, code_verifier: verifier,
+        client_secret,
+      }).toString(),
+    }));
+    assertEquals(res.status, 200);
+  });
+
+  await t.step('refresh grant requires client_secret', async () => {
+    await clearDatabase();
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
+    const user = await userRepository.create({
+      email: 'sec3@example.com', password_hash: 'x', role: 'user',
+      full_name: 'S', tenant_id: tenant.id,
+    } as CreateUserDTO & { password_hash: string });
+    const app = buildApp();
+    const reg = await app.fetch(new Request('https://x/oauth/register', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ redirect_uris: ['https://c/cb'], client_name: 'X' }),
+    }));
+    const { client_id, client_secret } = await reg.json();
+    const code = await oauthCodeRepository.create({
+      client_id, user_id: user.id, redirect_uri: 'https://c/cb', code_challenge: challenge,
+    });
+    const t1 = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code', code: code.code,
+        redirect_uri: 'https://c/cb', client_id, code_verifier: verifier, client_secret,
+      }).toString(),
+    }));
+    const tok = await t1.json();
+
+    // Refresh without client_secret → 401
+    const bad = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: tok.refresh_token, client_id }).toString(),
+    }));
+    assertEquals(bad.status, 401);
+
+    // Refresh with client_secret → 200
+    const good = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token', refresh_token: tok.refresh_token, client_id, client_secret,
+      }).toString(),
+    }));
+    assertEquals(good.status, 200);
   });
 });

--- a/backend/tests/routes/oauth_test.ts
+++ b/backend/tests/routes/oauth_test.ts
@@ -6,6 +6,8 @@ import { signSessionCookie } from '../../src/services/oauth/session-cookie.ts';
 import { userRepository } from '../../src/repositories/user.ts';
 import { tenantRepository } from '../../src/repositories/tenant.ts';
 import { oauthClientRepository } from '../../src/repositories/oauth-client.ts';
+import { oauthCodeRepository } from '../../src/repositories/oauth-code.ts';
+import { verifyToken } from '../../src/services/jwt.ts';
 
 function buildApp(): Hono {
   const app = new Hono();
@@ -93,5 +95,112 @@ Deno.test('GET /oauth/authorize', async (t) => {
     const url = `https://x/oauth/authorize?response_type=code&client_id=${client.id}&redirect_uri=${encodeURIComponent('https://evil/cb')}&code_challenge=abc&code_challenge_method=S256`;
     const res = await app.fetch(new Request(url));
     assertEquals(res.status, 400);
+  });
+});
+
+Deno.test('POST /oauth/token (authorization_code)', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('exchanges valid code + verifier for access + refresh tokens', async () => {
+    await clearDatabase();
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const user = await userRepository.create({
+      email: 'tokenuser@example.com', password_hash: 'x', role: 'user',
+      full_name: 'Z', tenant_id: tenant.id,
+    } as any);
+    const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    const created = await oauthCodeRepository.create({
+      client_id: client.id, user_id: user.id,
+      redirect_uri: 'https://c/cb', code_challenge: challenge, scope: 'read',
+    });
+
+    const app = buildApp();
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: created.code,
+      redirect_uri: 'https://c/cb',
+      client_id: client.id,
+      code_verifier: verifier,
+    });
+    const res = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    }));
+    assertEquals(res.status, 200);
+    const tok = await res.json();
+    assertEquals(tok.token_type, 'Bearer');
+    assert(typeof tok.access_token === 'string' && tok.access_token.length > 0);
+    assert(typeof tok.refresh_token === 'string' && tok.refresh_token.length > 0);
+
+    const payload = await verifyToken(tok.access_token);
+    assertEquals(payload.sub, String(user.id));
+    assertEquals(payload.tenantId, tenant.id);
+  });
+
+  await t.step('rejects wrong verifier', async () => {
+    await clearDatabase();
+    const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const user = await userRepository.create({
+      email: 'wrongver@example.com', password_hash: 'x', role: 'user',
+      full_name: 'Y', tenant_id: tenant.id,
+    } as any);
+    const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    const created = await oauthCodeRepository.create({
+      client_id: client.id, user_id: user.id,
+      redirect_uri: 'https://c/cb', code_challenge: challenge,
+    });
+
+    const app = buildApp();
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code', code: created.code,
+      redirect_uri: 'https://c/cb', client_id: client.id,
+      code_verifier: 'wrong',
+    });
+    const res = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    }));
+    assertEquals(res.status, 400);
+    const err = await res.json();
+    assertEquals(err.error, 'invalid_grant');
+  });
+
+  await t.step('rejects reused code', async () => {
+    await clearDatabase();
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const user = await userRepository.create({
+      email: 'reuser@example.com', password_hash: 'x', role: 'user',
+      full_name: 'R', tenant_id: tenant.id,
+    } as any);
+    const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    const created = await oauthCodeRepository.create({
+      client_id: client.id, user_id: user.id,
+      redirect_uri: 'https://c/cb', code_challenge: challenge,
+    });
+
+    const app = buildApp();
+    const makeBody = () => new URLSearchParams({
+      grant_type: 'authorization_code', code: created.code,
+      redirect_uri: 'https://c/cb', client_id: client.id,
+      code_verifier: verifier,
+    }).toString();
+
+    const first = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: makeBody(),
+    }));
+    assertEquals(first.status, 200);
+
+    const second = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: makeBody(),
+    }));
+    assertEquals(second.status, 400);
   });
 });

--- a/backend/tests/routes/oauth_test.ts
+++ b/backend/tests/routes/oauth_test.ts
@@ -8,6 +8,7 @@ import { tenantRepository } from '../../src/repositories/tenant.ts';
 import { oauthClientRepository } from '../../src/repositories/oauth-client.ts';
 import { oauthCodeRepository } from '../../src/repositories/oauth-code.ts';
 import { verifyToken } from '../../src/services/jwt.ts';
+import type { CreateTenantDTO, CreateUserDTO } from '../../src/models/index.ts';
 
 function buildApp(): Hono {
   const app = new Hono();
@@ -65,11 +66,11 @@ Deno.test('GET /oauth/authorize', async (t) => {
 
   await t.step('redirects to /oauth/consent when session cookie valid', async () => {
     await clearDatabase();
-    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
     const user = await userRepository.create({
       email: 'authtest@example.com', password_hash: 'x', role: 'user',
       full_name: 'A', tenant_id: tenant.id,
-    } as any);
+    } as CreateUserDTO & { password_hash: string });
     const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
     const cookie = await signSessionCookie(user.id);
 
@@ -106,11 +107,11 @@ Deno.test('POST /oauth/token (authorization_code)', async (t) => {
     const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
     const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
 
-    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
     const user = await userRepository.create({
       email: 'tokenuser@example.com', password_hash: 'x', role: 'user',
       full_name: 'Z', tenant_id: tenant.id,
-    } as any);
+    } as CreateUserDTO & { password_hash: string });
     const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
     const created = await oauthCodeRepository.create({
       client_id: client.id, user_id: user.id,
@@ -144,11 +145,11 @@ Deno.test('POST /oauth/token (authorization_code)', async (t) => {
   await t.step('rejects wrong verifier', async () => {
     await clearDatabase();
     const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
-    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
     const user = await userRepository.create({
       email: 'wrongver@example.com', password_hash: 'x', role: 'user',
       full_name: 'Y', tenant_id: tenant.id,
-    } as any);
+    } as CreateUserDTO & { password_hash: string });
     const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
     const created = await oauthCodeRepository.create({
       client_id: client.id, user_id: user.id,
@@ -175,11 +176,11 @@ Deno.test('POST /oauth/token (authorization_code)', async (t) => {
     await clearDatabase();
     const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
     const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
-    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
     const user = await userRepository.create({
       email: 'reuser@example.com', password_hash: 'x', role: 'user',
       full_name: 'R', tenant_id: tenant.id,
-    } as any);
+    } as CreateUserDTO & { password_hash: string });
     const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
     const created = await oauthCodeRepository.create({
       client_id: client.id, user_id: user.id,
@@ -211,11 +212,11 @@ Deno.test('POST /oauth/token (refresh_token)', async (t) => {
   async function obtainTokenPair() {
     const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
     const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
-    const tenant = await tenantRepository.create({ name: 'T' } as any);
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
     const user = await userRepository.create({
       email: 'refreshuser@example.com', password_hash: 'x', role: 'user',
       full_name: 'Q', tenant_id: tenant.id,
-    } as any);
+    } as CreateUserDTO & { password_hash: string });
     const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
     const created = await oauthCodeRepository.create({
       client_id: client.id, user_id: user.id,

--- a/backend/tests/routes/oauth_test.ts
+++ b/backend/tests/routes/oauth_test.ts
@@ -1,0 +1,43 @@
+import { assertEquals, assert } from '@std/assert';
+import { Hono } from 'hono';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { oauthRoutes } from '../../src/routes/oauth.ts';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/oauth', oauthRoutes);
+  return app;
+}
+
+Deno.test('POST /oauth/register', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns 201 with client_id when given valid body', async () => {
+    await clearDatabase();
+    const app = buildApp();
+    const res = await app.fetch(new Request('https://x/oauth/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        redirect_uris: ['https://claude.ai/api/mcp/auth_callback'],
+        client_name: 'Claude',
+      }),
+    }));
+    assertEquals(res.status, 201);
+    const body = await res.json();
+    assert(typeof body.client_id === 'string' && body.client_id.length > 0);
+    assertEquals(body.redirect_uris, ['https://claude.ai/api/mcp/auth_callback']);
+    assertEquals(body.client_name, 'Claude');
+    assertEquals(body.token_endpoint_auth_method, 'none');
+  });
+
+  await t.step('rejects missing redirect_uris', async () => {
+    const app = buildApp();
+    const res = await app.fetch(new Request('https://x/oauth/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ client_name: 'X' }),
+    }));
+    assertEquals(res.status, 400);
+  });
+});

--- a/backend/tests/routes/well_known_test.ts
+++ b/backend/tests/routes/well_known_test.ts
@@ -25,4 +25,17 @@ Deno.test('well-known metadata routes', async (t) => {
     const body = await res.json();
     assertEquals(body.resource, 'https://snapflow.example.com/mcp');
   });
+
+  await t.step('honors X-Forwarded-Proto and X-Forwarded-Host', async () => {
+    const app = buildApp();
+    const res = await app.fetch(new Request('http://internal/.well-known/oauth-authorization-server', {
+      headers: {
+        'X-Forwarded-Proto': 'https',
+        'X-Forwarded-Host': 'snapflow.example.com',
+      },
+    }));
+    const body = await res.json();
+    assertEquals(body.issuer, 'https://snapflow.example.com');
+    assertEquals(body.authorization_endpoint, 'https://snapflow.example.com/oauth/authorize');
+  });
 });

--- a/backend/tests/routes/well_known_test.ts
+++ b/backend/tests/routes/well_known_test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from '@std/assert';
+import { Hono } from 'hono';
+import { wellKnownRoutes } from '../../src/routes/well-known.ts';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/', wellKnownRoutes);
+  return app;
+}
+
+Deno.test('well-known metadata routes', async (t) => {
+  await t.step('GET /.well-known/oauth-authorization-server returns JSON metadata', async () => {
+    const app = buildApp();
+    const res = await app.fetch(new Request('https://snapflow.example.com/.well-known/oauth-authorization-server'));
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get('content-type')?.startsWith('application/json'), true);
+    const body = await res.json();
+    assertEquals(body.issuer, 'https://snapflow.example.com');
+  });
+
+  await t.step('GET /.well-known/oauth-protected-resource returns JSON metadata', async () => {
+    const app = buildApp();
+    const res = await app.fetch(new Request('https://snapflow.example.com/.well-known/oauth-protected-resource'));
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(body.resource, 'https://snapflow.example.com/mcp');
+  });
+});

--- a/backend/tests/services/oauth/client_secret_test.ts
+++ b/backend/tests/services/oauth/client_secret_test.ts
@@ -1,0 +1,27 @@
+import { assert, assertEquals } from '@std/assert';
+import { generateClientSecret, hashClientSecret, timingSafeEqual } from '../../../src/services/oauth/client-secret.ts';
+
+Deno.test('client-secret helpers', async (t) => {
+  await t.step('generateClientSecret returns 43-char base64url', () => {
+    const s = generateClientSecret();
+    assertEquals(s.length, 43);
+    assert(/^[A-Za-z0-9_-]+$/.test(s));
+  });
+
+  await t.step('two generated secrets differ', () => {
+    const a = generateClientSecret();
+    const b = generateClientSecret();
+    assert(a !== b);
+  });
+
+  await t.step('hashClientSecret produces 64-char hex SHA-256', async () => {
+    const h = await hashClientSecret('hello');
+    assertEquals(h, '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824');
+  });
+
+  await t.step('timingSafeEqual returns true for equal strings, false otherwise', () => {
+    assert(timingSafeEqual('abc', 'abc'));
+    assert(!timingSafeEqual('abc', 'abd'));
+    assert(!timingSafeEqual('abc', 'ab'));
+  });
+});

--- a/backend/tests/services/oauth/metadata_test.ts
+++ b/backend/tests/services/oauth/metadata_test.ts
@@ -1,0 +1,22 @@
+import { assertEquals } from '@std/assert';
+import { buildAuthServerMetadata, buildProtectedResourceMetadata } from '../../../src/services/oauth/metadata.ts';
+
+Deno.test('OAuth metadata', async (t) => {
+  await t.step('authorization server metadata contains required fields', () => {
+    const m = buildAuthServerMetadata('https://snapflow.example.com');
+    assertEquals(m.issuer, 'https://snapflow.example.com');
+    assertEquals(m.authorization_endpoint, 'https://snapflow.example.com/oauth/authorize');
+    assertEquals(m.token_endpoint, 'https://snapflow.example.com/oauth/token');
+    assertEquals(m.registration_endpoint, 'https://snapflow.example.com/oauth/register');
+    assertEquals(m.code_challenge_methods_supported, ['S256']);
+    assertEquals(m.grant_types_supported, ['authorization_code', 'refresh_token']);
+    assertEquals(m.response_types_supported, ['code']);
+  });
+
+  await t.step('protected resource metadata points at auth server', () => {
+    const m = buildProtectedResourceMetadata('https://snapflow.example.com');
+    assertEquals(m.resource, 'https://snapflow.example.com/mcp');
+    assertEquals(m.authorization_servers, ['https://snapflow.example.com']);
+    assertEquals(m.bearer_methods_supported, ['header']);
+  });
+});

--- a/backend/tests/services/oauth/pkce_test.ts
+++ b/backend/tests/services/oauth/pkce_test.ts
@@ -1,0 +1,14 @@
+import { assertEquals } from '@std/assert';
+import { verifyS256 } from '../../../src/services/oauth/pkce.ts';
+
+Deno.test('PKCE S256 verification', async (t) => {
+  await t.step('verifies a known correct verifier/challenge pair (RFC 7636 example)', async () => {
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+    assertEquals(await verifyS256(verifier, challenge), true);
+  });
+
+  await t.step('rejects mismatched pair', async () => {
+    assertEquals(await verifyS256('wrong', 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM'), false);
+  });
+});

--- a/backend/tests/services/oauth/session_cookie_test.ts
+++ b/backend/tests/services/oauth/session_cookie_test.ts
@@ -11,7 +11,13 @@ Deno.test('oauth session cookie', async (t) => {
 
   await t.step('verify returns null for tampered cookie', async () => {
     const cookie = await signSessionCookie(42);
-    const tampered = cookie.slice(0, -1) + (cookie.slice(-1) === 'a' ? 'b' : 'a');
+    // Find the signature segment, flip a character in its middle (not the
+    // last char — base64url padding bits make end-tampering non-deterministic).
+    const [payload, sig] = cookie.split('.');
+    const mid = Math.floor(sig.length / 2);
+    const tamperedSigChar = sig[mid] === 'A' ? 'B' : 'A';
+    const tamperedSig = sig.slice(0, mid) + tamperedSigChar + sig.slice(mid + 1);
+    const tampered = `${payload}.${tamperedSig}`;
     assertEquals(await verifySessionCookie(tampered), null);
   });
 

--- a/backend/tests/services/oauth/session_cookie_test.ts
+++ b/backend/tests/services/oauth/session_cookie_test.ts
@@ -1,0 +1,21 @@
+import { assertEquals, assert } from '@std/assert';
+import { signSessionCookie, verifySessionCookie } from '../../../src/services/oauth/session-cookie.ts';
+
+Deno.test('oauth session cookie', async (t) => {
+  await t.step('sign produces a string and verify returns the same userId', async () => {
+    const cookie = await signSessionCookie(42);
+    assert(cookie.length > 0);
+    const userId = await verifySessionCookie(cookie);
+    assertEquals(userId, 42);
+  });
+
+  await t.step('verify returns null for tampered cookie', async () => {
+    const cookie = await signSessionCookie(42);
+    const tampered = cookie.slice(0, -1) + (cookie.slice(-1) === 'a' ? 'b' : 'a');
+    assertEquals(await verifySessionCookie(tampered), null);
+  });
+
+  await t.step('verify returns null for garbage', async () => {
+    assertEquals(await verifySessionCookie('garbage'), null);
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,11 @@ services:
       - DATABASE_URL=./data/database.sqlite
       - UPLOAD_DIR=./uploads
       - CORS_ORIGIN=*
+      # Optional: set to your public HTTPS URL (e.g. https://snapflow.example.com)
+      # so OAuth/MCP metadata advertises the correct external URL. If unset,
+      # the backend derives it from X-Forwarded-Proto/X-Forwarded-Host headers,
+      # so any properly-configured reverse proxy will work without this var.
+      - PUBLIC_BASE_URL=${PUBLIC_BASE_URL:-}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "deno", "eval", "const res = await fetch('http://localhost:8000/health'); if (!res.ok) throw new Error('Health check failed');"]

--- a/docs/superpowers/plans/2026-05-15-mcp-remote-server.md
+++ b/docs/superpowers/plans/2026-05-15-mcp-remote-server.md
@@ -1,0 +1,2986 @@
+# Remote MCP Server Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a spec-compliant remote MCP server (OAuth 2.1 + 4 read-only tools) inside the existing SnapFlow backend so Claude.ai / Claude Desktop / Claude Code can connect via custom-connector URL after a one-time OAuth login.
+
+**Architecture:** Two new Hono mount points (`/oauth/*` and `/mcp`) on the existing app. MCP tools dispatch through the existing REST routes in-process via `app.fetch` — no business-logic duplication, no auth bypass. Two new tiny tables (`oauth_clients`, `oauth_auth_codes`). Access tokens reuse existing JWT format; refresh tokens reuse the existing `refresh_tokens` table.
+
+**Tech Stack:** Deno + Hono (backend), `@modelcontextprotocol/sdk` (MCP server, npm via Deno `npm:` specifier), `djwt` (existing JWT lib), Web Crypto (PKCE S256), Zod (schemas), in-memory SQLite (tests).
+
+**Spec:** `docs/superpowers/specs/2026-05-15-mcp-remote-server-design.md`
+
+---
+
+## File Structure
+
+### New files
+
+```
+backend/
+├── migrations/
+│   └── 034_oauth_clients.sql
+└── src/
+    ├── repositories/
+    │   ├── oauth-client.ts
+    │   └── oauth-code.ts
+    ├── services/
+    │   ├── oauth/
+    │   │   ├── clients.ts        # registration logic
+    │   │   ├── auth-codes.ts     # issue/consume codes, PKCE verify
+    │   │   ├── metadata.ts       # build well-known JSON docs
+    │   │   └── pkce.ts           # PKCE S256 helpers
+    │   └── mcp/
+    │       ├── server.ts         # MCP Server instance + tool registry
+    │       ├── dispatcher.ts     # in-process app.fetch wrapper
+    │       └── tools/
+    │           ├── list-projects.ts
+    │           ├── get-project.ts
+    │           ├── get-project-total.ts
+    │           └── search-items.ts
+    └── routes/
+        ├── oauth.ts              # /oauth/{register,authorize,token}
+        ├── oauth-consent.ts      # GET+POST /oauth/consent (HTML)
+        ├── well-known.ts         # /.well-known/oauth-* metadata
+        └── mcp.ts                # /mcp Streamable HTTP
+
+backend/tests/
+├── routes/
+│   ├── oauth_test.ts
+│   ├── oauth_consent_test.ts
+│   └── well_known_test.ts
+└── mcp/
+    ├── tools_test.ts
+    └── tenant_isolation_test.ts
+
+frontend/src/pages/
+└── Login.tsx                     # modify: honor ?return_to=
+frontend/tests/
+└── Login.test.tsx                # add: return_to behavior
+```
+
+### Modified files
+
+- `backend/src/main.ts` — mount `oauthRoutes`, `mcpRoutes`, `wellKnownRoutes`, `oauthConsentRoutes`
+- `backend/src/routes/auth.ts` — set `oauth_session` cookie on successful login
+- `backend/src/config/env.ts` — add `OAUTH_SESSION_SECRET` if not present (or reuse `JWT_SECRET`)
+- `frontend/src/pages/Login.tsx` — read `return_to` query and navigate there on success
+
+### Pattern notes (read these before implementing)
+
+- **Repositories** use a class with an exported singleton instance (see `backend/src/repositories/project.ts`). Follow that.
+- **Migrations** live at `backend/migrations/NNN_name.sql` and are picked up automatically by `runMigrations()` (see `backend/src/scripts/migrate.ts`).
+- **Tests** use `setupTestDatabase()` / `clearDatabase()` from `backend/tests/test-utils.ts`. No running server needed — call `app.fetch(new Request(...))` directly.
+- **JWT issuance**: reuse `generateToken()` from `backend/src/services/jwt.ts`.
+- **Refresh tokens**: reuse `createRefreshToken()` and `verifyRefreshToken()` from `backend/src/services/refresh-token.ts`. Existing TTL is 7 days; we adopt that (spec mentioned 30, but consistency with existing infra wins — refresh-rotation is what matters, not absolute TTL).
+
+---
+
+## Phase 1 — Database + Repositories
+
+### Task 1: Migration for oauth_clients and oauth_auth_codes tables
+
+**Files:**
+- Create: `backend/migrations/034_oauth_clients.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Migration 034: OAuth 2.1 tables for remote MCP server
+-- Adds two tables: oauth_clients (registered MCP clients) and oauth_auth_codes (short-lived auth codes)
+
+CREATE TABLE IF NOT EXISTS oauth_clients (
+  id            TEXT PRIMARY KEY,
+  client_secret TEXT,
+  redirect_uris TEXT NOT NULL,
+  client_name   TEXT,
+  created_at    DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS oauth_auth_codes (
+  code           TEXT PRIMARY KEY,
+  client_id      TEXT NOT NULL,
+  user_id        INTEGER NOT NULL,
+  redirect_uri   TEXT NOT NULL,
+  code_challenge TEXT NOT NULL,
+  scope          TEXT,
+  expires_at     DATETIME NOT NULL,
+  consumed_at    DATETIME,
+  FOREIGN KEY (client_id) REFERENCES oauth_clients(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id)   REFERENCES users(id)         ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_codes_expires ON oauth_auth_codes(expires_at);
+CREATE INDEX IF NOT EXISTS idx_oauth_codes_client  ON oauth_auth_codes(client_id);
+```
+
+- [ ] **Step 2: Run migration in-place to verify it applies**
+
+```bash
+cd backend && deno task migrate
+```
+
+Expected: prints `Applied migration: 034_oauth_clients.sql` (or already-applied if rerun).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/migrations/034_oauth_clients.sql
+git commit -m "feat(oauth): add oauth_clients and oauth_auth_codes tables"
+```
+
+---
+
+### Task 2: oauth-client repository
+
+**Files:**
+- Create: `backend/src/repositories/oauth-client.ts`
+- Test: `backend/tests/repositories/oauth_client_test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// backend/tests/repositories/oauth_client_test.ts
+import { assertEquals, assertNotEquals } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { oauthClientRepository } from '../../src/repositories/oauth-client.ts';
+
+Deno.test('oauth-client repository', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('create returns client with id and stores redirect_uris', async () => {
+    await clearDatabase();
+    const created = await oauthClientRepository.create({
+      redirect_uris: ['https://claude.ai/oauth/callback'],
+      client_name: 'Claude',
+    });
+    assertNotEquals(created.id, '');
+    assertEquals(created.redirect_uris, ['https://claude.ai/oauth/callback']);
+    assertEquals(created.client_name, 'Claude');
+  });
+
+  await t.step('findById returns stored client', async () => {
+    await clearDatabase();
+    const created = await oauthClientRepository.create({
+      redirect_uris: ['https://x/cb'],
+    });
+    const found = await oauthClientRepository.findById(created.id);
+    assertEquals(found?.id, created.id);
+    assertEquals(found?.redirect_uris, ['https://x/cb']);
+  });
+
+  await t.step('findById returns null for unknown id', async () => {
+    await clearDatabase();
+    const found = await oauthClientRepository.findById('nope');
+    assertEquals(found, null);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+cd backend && deno test --allow-all tests/repositories/oauth_client_test.ts
+```
+
+Expected: FAIL — `Module not found "../../src/repositories/oauth-client.ts"`.
+
+- [ ] **Step 3: Implement the repository**
+
+```ts
+// backend/src/repositories/oauth-client.ts
+import { getDb } from '../config/database.ts';
+
+export interface OAuthClient {
+  id: string;
+  client_secret: string | null;
+  redirect_uris: string[];
+  client_name: string | null;
+  created_at: string;
+}
+
+export interface CreateOAuthClientDTO {
+  redirect_uris: string[];
+  client_name?: string;
+  client_secret?: string;
+}
+
+function generateClientId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export class OAuthClientRepository {
+  create(dto: CreateOAuthClientDTO): Promise<OAuthClient> {
+    const id = generateClientId();
+    const redirectUrisJson = JSON.stringify(dto.redirect_uris);
+    getDb().query(
+      `INSERT INTO oauth_clients (id, client_secret, redirect_uris, client_name)
+       VALUES (?, ?, ?, ?)`,
+      [id, dto.client_secret ?? null, redirectUrisJson, dto.client_name ?? null]
+    );
+    return Promise.resolve({
+      id,
+      client_secret: dto.client_secret ?? null,
+      redirect_uris: dto.redirect_uris,
+      client_name: dto.client_name ?? null,
+      created_at: new Date().toISOString(),
+    });
+  }
+
+  findById(id: string): Promise<OAuthClient | null> {
+    const rows = getDb().query<[string, string | null, string, string | null, string]>(
+      `SELECT id, client_secret, redirect_uris, client_name, created_at
+       FROM oauth_clients WHERE id = ?`,
+      [id]
+    );
+    if (rows.length === 0) return Promise.resolve(null);
+    const [rid, secret, redirectsJson, name, createdAt] = rows[0];
+    return Promise.resolve({
+      id: rid,
+      client_secret: secret,
+      redirect_uris: JSON.parse(redirectsJson),
+      client_name: name,
+      created_at: createdAt,
+    });
+  }
+}
+
+export const oauthClientRepository = new OAuthClientRepository();
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+```bash
+cd backend && deno test --allow-all tests/repositories/oauth_client_test.ts
+```
+
+Expected: all 3 steps PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/repositories/oauth-client.ts backend/tests/repositories/oauth_client_test.ts
+git commit -m "feat(oauth): add OAuthClientRepository with create/findById"
+```
+
+---
+
+### Task 3: oauth-code repository
+
+**Files:**
+- Create: `backend/src/repositories/oauth-code.ts`
+- Test: `backend/tests/repositories/oauth_code_test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// backend/tests/repositories/oauth_code_test.ts
+import { assertEquals, assert } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { oauthCodeRepository } from '../../src/repositories/oauth-code.ts';
+import { oauthClientRepository } from '../../src/repositories/oauth-client.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+
+async function seedUserAndClient() {
+  const tenant = await tenantRepository.create({ name: 'T', is_active: true });
+  const user = await userRepository.create({
+    email: 't@t.t', password_hash: 'x', role: 'user',
+    full_name: 'T', tenant_id: tenant.id, is_active: true,
+  });
+  const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+  return { user, client };
+}
+
+Deno.test('oauth-code repository', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('create stores code with expires_at in the future', async () => {
+    await clearDatabase();
+    const { user, client } = await seedUserAndClient();
+    const created = await oauthCodeRepository.create({
+      client_id: client.id, user_id: user.id,
+      redirect_uri: 'https://c/cb', code_challenge: 'abc', scope: 'read',
+    });
+    assert(created.code.length > 0);
+    assert(new Date(created.expires_at).getTime() > Date.now());
+  });
+
+  await t.step('consume returns code and marks consumed', async () => {
+    await clearDatabase();
+    const { user, client } = await seedUserAndClient();
+    const created = await oauthCodeRepository.create({
+      client_id: client.id, user_id: user.id,
+      redirect_uri: 'https://c/cb', code_challenge: 'abc',
+    });
+    const consumed = await oauthCodeRepository.consume(created.code);
+    assertEquals(consumed?.user_id, user.id);
+    const again = await oauthCodeRepository.consume(created.code);
+    assertEquals(again, null);
+  });
+
+  await t.step('consume returns null for expired code', async () => {
+    await clearDatabase();
+    const { user, client } = await seedUserAndClient();
+    const created = await oauthCodeRepository.create({
+      client_id: client.id, user_id: user.id,
+      redirect_uri: 'https://c/cb', code_challenge: 'abc',
+      ttl_seconds: -1,
+    });
+    const consumed = await oauthCodeRepository.consume(created.code);
+    assertEquals(consumed, null);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+cd backend && deno test --allow-all tests/repositories/oauth_code_test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the repository**
+
+```ts
+// backend/src/repositories/oauth-code.ts
+import { getDb } from '../config/database.ts';
+
+export interface OAuthAuthCode {
+  code: string;
+  client_id: string;
+  user_id: number;
+  redirect_uri: string;
+  code_challenge: string;
+  scope: string | null;
+  expires_at: string;
+  consumed_at: string | null;
+}
+
+export interface CreateOAuthCodeDTO {
+  client_id: string;
+  user_id: number;
+  redirect_uri: string;
+  code_challenge: string;
+  scope?: string;
+  /** Seconds until expiry. Default 60. Negative values produce already-expired codes (for tests). */
+  ttl_seconds?: number;
+}
+
+const DEFAULT_TTL_SECONDS = 60;
+
+function generateCode(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export class OAuthCodeRepository {
+  create(dto: CreateOAuthCodeDTO): Promise<OAuthAuthCode> {
+    const code = generateCode();
+    const ttl = dto.ttl_seconds ?? DEFAULT_TTL_SECONDS;
+    const expiresAt = new Date(Date.now() + ttl * 1000).toISOString();
+    getDb().query(
+      `INSERT INTO oauth_auth_codes (code, client_id, user_id, redirect_uri, code_challenge, scope, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [code, dto.client_id, dto.user_id, dto.redirect_uri, dto.code_challenge, dto.scope ?? null, expiresAt]
+    );
+    return Promise.resolve({
+      code, client_id: dto.client_id, user_id: dto.user_id,
+      redirect_uri: dto.redirect_uri, code_challenge: dto.code_challenge,
+      scope: dto.scope ?? null, expires_at: expiresAt, consumed_at: null,
+    });
+  }
+
+  /** Atomically reads and marks the code consumed. Returns null if missing/expired/already consumed. */
+  consume(code: string): Promise<OAuthAuthCode | null> {
+    const rows = getDb().query<[string, string, number, string, string, string | null, string, string | null]>(
+      `SELECT code, client_id, user_id, redirect_uri, code_challenge, scope, expires_at, consumed_at
+       FROM oauth_auth_codes WHERE code = ?`,
+      [code]
+    );
+    if (rows.length === 0) return Promise.resolve(null);
+    const [c, cid, uid, ruri, chal, scope, exp, consumed] = rows[0];
+    if (consumed !== null) return Promise.resolve(null);
+    if (new Date(exp).getTime() <= Date.now()) return Promise.resolve(null);
+    getDb().query(`UPDATE oauth_auth_codes SET consumed_at = ? WHERE code = ?`, [new Date().toISOString(), c]);
+    return Promise.resolve({
+      code: c, client_id: cid, user_id: uid, redirect_uri: ruri, code_challenge: chal,
+      scope, expires_at: exp, consumed_at: new Date().toISOString(),
+    });
+  }
+
+  deleteExpired(): Promise<void> {
+    getDb().query(
+      `DELETE FROM oauth_auth_codes WHERE expires_at <= ? OR consumed_at IS NOT NULL`,
+      [new Date().toISOString()]
+    );
+    return Promise.resolve();
+  }
+}
+
+export const oauthCodeRepository = new OAuthCodeRepository();
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+```bash
+cd backend && deno test --allow-all tests/repositories/oauth_code_test.ts
+```
+
+Expected: all 3 steps PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/repositories/oauth-code.ts backend/tests/repositories/oauth_code_test.ts
+git commit -m "feat(oauth): add OAuthCodeRepository with create/consume/deleteExpired"
+```
+
+---
+
+## Phase 2 — OAuth Services
+
+### Task 4: PKCE S256 helpers
+
+**Files:**
+- Create: `backend/src/services/oauth/pkce.ts`
+- Test: `backend/tests/services/oauth/pkce_test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// backend/tests/services/oauth/pkce_test.ts
+import { assertEquals } from '@std/assert';
+import { verifyS256 } from '../../../src/services/oauth/pkce.ts';
+
+Deno.test('PKCE S256 verification', async (t) => {
+  await t.step('verifies a known correct verifier/challenge pair (RFC 7636 example)', async () => {
+    // From RFC 7636 Appendix B
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+    assertEquals(await verifyS256(verifier, challenge), true);
+  });
+
+  await t.step('rejects mismatched pair', async () => {
+    assertEquals(await verifyS256('wrong', 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM'), false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+cd backend && deno test --allow-all tests/services/oauth/pkce_test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement PKCE helpers**
+
+```ts
+// backend/src/services/oauth/pkce.ts
+
+/** Base64url-encode a Uint8Array (no padding). */
+function base64UrlEncode(bytes: Uint8Array): string {
+  let str = '';
+  for (const b of bytes) str += String.fromCharCode(b);
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Verify a PKCE S256 challenge against a verifier per RFC 7636.
+ * challenge == base64url(SHA-256(verifier))
+ */
+export async function verifyS256(verifier: string, challenge: string): Promise<boolean> {
+  const data = new TextEncoder().encode(verifier);
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  const expected = base64UrlEncode(new Uint8Array(hash));
+  return expected === challenge;
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+```bash
+cd backend && deno test --allow-all tests/services/oauth/pkce_test.ts
+```
+
+Expected: both steps PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/oauth/pkce.ts backend/tests/services/oauth/pkce_test.ts
+git commit -m "feat(oauth): add PKCE S256 verifier (RFC 7636)"
+```
+
+---
+
+### Task 5: OAuth metadata documents
+
+**Files:**
+- Create: `backend/src/services/oauth/metadata.ts`
+- Test: `backend/tests/services/oauth/metadata_test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// backend/tests/services/oauth/metadata_test.ts
+import { assertEquals } from '@std/assert';
+import { buildAuthServerMetadata, buildProtectedResourceMetadata } from '../../../src/services/oauth/metadata.ts';
+
+Deno.test('OAuth metadata', async (t) => {
+  await t.step('authorization server metadata contains required fields', () => {
+    const m = buildAuthServerMetadata('https://snapflow.example.com');
+    assertEquals(m.issuer, 'https://snapflow.example.com');
+    assertEquals(m.authorization_endpoint, 'https://snapflow.example.com/oauth/authorize');
+    assertEquals(m.token_endpoint, 'https://snapflow.example.com/oauth/token');
+    assertEquals(m.registration_endpoint, 'https://snapflow.example.com/oauth/register');
+    assertEquals(m.code_challenge_methods_supported, ['S256']);
+    assertEquals(m.grant_types_supported, ['authorization_code', 'refresh_token']);
+    assertEquals(m.response_types_supported, ['code']);
+  });
+
+  await t.step('protected resource metadata points at auth server', () => {
+    const m = buildProtectedResourceMetadata('https://snapflow.example.com');
+    assertEquals(m.resource, 'https://snapflow.example.com/mcp');
+    assertEquals(m.authorization_servers, ['https://snapflow.example.com']);
+    assertEquals(m.bearer_methods_supported, ['header']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+cd backend && deno test --allow-all tests/services/oauth/metadata_test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement metadata builders**
+
+```ts
+// backend/src/services/oauth/metadata.ts
+
+export interface AuthServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint: string;
+  response_types_supported: string[];
+  grant_types_supported: string[];
+  code_challenge_methods_supported: string[];
+  token_endpoint_auth_methods_supported: string[];
+  scopes_supported: string[];
+}
+
+export interface ProtectedResourceMetadata {
+  resource: string;
+  authorization_servers: string[];
+  bearer_methods_supported: string[];
+  scopes_supported: string[];
+}
+
+export function buildAuthServerMetadata(baseUrl: string): AuthServerMetadata {
+  return {
+    issuer: baseUrl,
+    authorization_endpoint: `${baseUrl}/oauth/authorize`,
+    token_endpoint: `${baseUrl}/oauth/token`,
+    registration_endpoint: `${baseUrl}/oauth/register`,
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint_auth_methods_supported: ['none', 'client_secret_post'],
+    scopes_supported: ['read'],
+  };
+}
+
+export function buildProtectedResourceMetadata(baseUrl: string): ProtectedResourceMetadata {
+  return {
+    resource: `${baseUrl}/mcp`,
+    authorization_servers: [baseUrl],
+    bearer_methods_supported: ['header'],
+    scopes_supported: ['read'],
+  };
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+```bash
+cd backend && deno test --allow-all tests/services/oauth/metadata_test.ts
+```
+
+Expected: both steps PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/oauth/metadata.ts backend/tests/services/oauth/metadata_test.ts
+git commit -m "feat(oauth): add RFC 8414 / RFC 9728 metadata builders"
+```
+
+---
+
+## Phase 3 — OAuth HTTP Endpoints
+
+### Task 6: /.well-known metadata endpoints
+
+**Files:**
+- Create: `backend/src/routes/well-known.ts`
+- Test: `backend/tests/routes/well_known_test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// backend/tests/routes/well_known_test.ts
+import { assertEquals } from '@std/assert';
+import { Hono } from 'hono';
+import { wellKnownRoutes } from '../../src/routes/well-known.ts';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/', wellKnownRoutes);
+  return app;
+}
+
+Deno.test('well-known metadata routes', async (t) => {
+  await t.step('GET /.well-known/oauth-authorization-server returns JSON metadata', async () => {
+    const app = buildApp();
+    const res = await app.fetch(new Request('https://snapflow.example.com/.well-known/oauth-authorization-server'));
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get('content-type')?.startsWith('application/json'), true);
+    const body = await res.json();
+    assertEquals(body.issuer, 'https://snapflow.example.com');
+  });
+
+  await t.step('GET /.well-known/oauth-protected-resource returns JSON metadata', async () => {
+    const app = buildApp();
+    const res = await app.fetch(new Request('https://snapflow.example.com/.well-known/oauth-protected-resource'));
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(body.resource, 'https://snapflow.example.com/mcp');
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+cd backend && deno test --allow-all tests/routes/well_known_test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the route**
+
+```ts
+// backend/src/routes/well-known.ts
+import { Hono } from 'hono';
+import { buildAuthServerMetadata, buildProtectedResourceMetadata } from '../services/oauth/metadata.ts';
+
+export const wellKnownRoutes = new Hono();
+
+/** Derive the base URL (scheme + host) from the incoming request. */
+function baseUrlOf(req: Request): string {
+  const url = new URL(req.url);
+  return `${url.protocol}//${url.host}`;
+}
+
+wellKnownRoutes.get('/.well-known/oauth-authorization-server', (c) => {
+  return c.json(buildAuthServerMetadata(baseUrlOf(c.req.raw)));
+});
+
+wellKnownRoutes.get('/.well-known/oauth-protected-resource', (c) => {
+  return c.json(buildProtectedResourceMetadata(baseUrlOf(c.req.raw)));
+});
+
+export default wellKnownRoutes;
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+```bash
+cd backend && deno test --allow-all tests/routes/well_known_test.ts
+```
+
+Expected: both steps PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/routes/well-known.ts backend/tests/routes/well_known_test.ts
+git commit -m "feat(oauth): add /.well-known metadata endpoints"
+```
+
+---
+
+### Task 7: POST /oauth/register (Dynamic Client Registration)
+
+**Files:**
+- Create: `backend/src/routes/oauth.ts` (registers DCR; later tasks add more endpoints)
+- Test: `backend/tests/routes/oauth_test.ts` (registers DCR test; later tasks add more)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// backend/tests/routes/oauth_test.ts
+import { assertEquals, assert } from '@std/assert';
+import { Hono } from 'hono';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { oauthRoutes } from '../../src/routes/oauth.ts';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/oauth', oauthRoutes);
+  return app;
+}
+
+Deno.test('POST /oauth/register', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns 201 with client_id when given valid body', async () => {
+    await clearDatabase();
+    const app = buildApp();
+    const res = await app.fetch(new Request('https://x/oauth/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        redirect_uris: ['https://claude.ai/api/mcp/auth_callback'],
+        client_name: 'Claude',
+      }),
+    }));
+    assertEquals(res.status, 201);
+    const body = await res.json();
+    assert(typeof body.client_id === 'string' && body.client_id.length > 0);
+    assertEquals(body.redirect_uris, ['https://claude.ai/api/mcp/auth_callback']);
+    assertEquals(body.client_name, 'Claude');
+    assertEquals(body.token_endpoint_auth_method, 'none');
+  });
+
+  await t.step('rejects missing redirect_uris', async () => {
+    const app = buildApp();
+    const res = await app.fetch(new Request('https://x/oauth/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ client_name: 'X' }),
+    }));
+    assertEquals(res.status, 400);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+cd backend && deno test --allow-all tests/routes/oauth_test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement /oauth/register**
+
+```ts
+// backend/src/routes/oauth.ts
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { oauthClientRepository } from '../repositories/oauth-client.ts';
+
+export const oauthRoutes = new Hono();
+
+const registerSchema = z.object({
+  redirect_uris: z.array(z.string().url()).min(1),
+  client_name: z.string().optional(),
+  // Spec allows more fields; we accept and ignore them.
+}).passthrough();
+
+oauthRoutes.post('/register', zValidator('json', registerSchema), async (c) => {
+  const { redirect_uris, client_name } = c.req.valid('json');
+  const client = await oauthClientRepository.create({
+    redirect_uris,
+    client_name,
+  });
+  return c.json({
+    client_id: client.id,
+    client_id_issued_at: Math.floor(Date.now() / 1000),
+    redirect_uris: client.redirect_uris,
+    client_name: client.client_name,
+    token_endpoint_auth_method: 'none',
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+  }, 201);
+});
+
+export default oauthRoutes;
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+```bash
+cd backend && deno test --allow-all tests/routes/oauth_test.ts
+```
+
+Expected: both steps PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/routes/oauth.ts backend/tests/routes/oauth_test.ts
+git commit -m "feat(oauth): add POST /oauth/register (Dynamic Client Registration)"
+```
+
+---
+
+### Task 8: Browser session bridge — set oauth_session cookie on login
+
+**Files:**
+- Modify: `backend/src/routes/auth.ts` (login handler)
+- Create: `backend/src/services/oauth/session-cookie.ts`
+- Test: `backend/tests/services/oauth/session_cookie_test.ts`
+- Test: `backend/tests/routes/auth_session_cookie_test.ts`
+
+- [ ] **Step 1: Write the failing service test**
+
+```ts
+// backend/tests/services/oauth/session_cookie_test.ts
+import { assertEquals, assert } from '@std/assert';
+import { signSessionCookie, verifySessionCookie } from '../../../src/services/oauth/session-cookie.ts';
+
+Deno.test('oauth session cookie', async (t) => {
+  await t.step('sign produces a string and verify returns the same userId', async () => {
+    const cookie = await signSessionCookie(42);
+    assert(cookie.length > 0);
+    const userId = await verifySessionCookie(cookie);
+    assertEquals(userId, 42);
+  });
+
+  await t.step('verify returns null for tampered cookie', async () => {
+    const cookie = await signSessionCookie(42);
+    const tampered = cookie.slice(0, -1) + (cookie.slice(-1) === 'a' ? 'b' : 'a');
+    assertEquals(await verifySessionCookie(tampered), null);
+  });
+
+  await t.step('verify returns null for garbage', async () => {
+    assertEquals(await verifySessionCookie('garbage'), null);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+cd backend && deno test --allow-all tests/services/oauth/session_cookie_test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement signed cookie service**
+
+```ts
+// backend/src/services/oauth/session-cookie.ts
+import { env } from '../../config/env.ts';
+
+/**
+ * Short-lived signed cookie used only by /oauth/authorize and /oauth/consent
+ * to identify the logged-in SnapFlow user from a browser navigation.
+ *
+ * Format: base64url(JSON.stringify({uid, exp})) "." base64url(HMAC-SHA256(payload))
+ */
+
+const TTL_SECONDS = 60 * 60; // 1 hour
+
+async function getKey(): Promise<CryptoKey> {
+  return await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(env.JWT_SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify']
+  );
+}
+
+function b64url(bytes: Uint8Array): string {
+  let s = '';
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function b64urlDecode(str: string): Uint8Array {
+  const padded = str.replace(/-/g, '+').replace(/_/g, '/') + '==='.slice((str.length + 3) % 4);
+  const bin = atob(padded);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+export async function signSessionCookie(userId: number): Promise<string> {
+  const payload = { uid: userId, exp: Math.floor(Date.now() / 1000) + TTL_SECONDS };
+  const payloadStr = b64url(new TextEncoder().encode(JSON.stringify(payload)));
+  const key = await getKey();
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payloadStr));
+  return `${payloadStr}.${b64url(new Uint8Array(sig))}`;
+}
+
+export async function verifySessionCookie(cookie: string): Promise<number | null> {
+  const parts = cookie.split('.');
+  if (parts.length !== 2) return null;
+  const [payloadStr, sigStr] = parts;
+  try {
+    const key = await getKey();
+    const ok = await crypto.subtle.verify(
+      'HMAC',
+      key,
+      b64urlDecode(sigStr),
+      new TextEncoder().encode(payloadStr)
+    );
+    if (!ok) return null;
+    const payload = JSON.parse(new TextDecoder().decode(b64urlDecode(payloadStr))) as { uid: number; exp: number };
+    if (payload.exp <= Math.floor(Date.now() / 1000)) return null;
+    return payload.uid;
+  } catch {
+    return null;
+  }
+}
+
+export const OAUTH_SESSION_COOKIE_NAME = 'oauth_session';
+export const OAUTH_SESSION_MAX_AGE = TTL_SECONDS;
+```
+
+- [ ] **Step 4: Run service test, verify it passes**
+
+```bash
+cd backend && deno test --allow-all tests/services/oauth/session_cookie_test.ts
+```
+
+Expected: all 3 steps PASS.
+
+- [ ] **Step 5: Write the failing login-route test**
+
+```ts
+// backend/tests/routes/auth_session_cookie_test.ts
+import { assertEquals, assert } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+import { hashPassword } from '../../src/services/password.ts';
+import app from '../../src/main.ts';
+import { verifySessionCookie } from '../../src/services/oauth/session-cookie.ts';
+
+Deno.test('POST /api/auth/login sets oauth_session cookie', async () => {
+  await setupTestDatabase();
+  await clearDatabase();
+
+  const tenant = await tenantRepository.create({ name: 'T', is_active: true });
+  await userRepository.create({
+    email: 'u@u.u', password_hash: hashPassword('password123'),
+    role: 'user', full_name: 'U', tenant_id: tenant.id, is_active: true,
+  });
+
+  const res = await app.fetch(new Request('http://x/api/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'u@u.u', password: 'password123' }),
+  }));
+  assertEquals(res.status, 200);
+
+  const setCookie = res.headers.get('set-cookie') ?? '';
+  assert(setCookie.includes('oauth_session='), `expected oauth_session cookie, got: ${setCookie}`);
+  assert(setCookie.includes('HttpOnly'), 'cookie must be HttpOnly');
+  assert(setCookie.includes('SameSite=Lax'), 'cookie must be SameSite=Lax');
+
+  const cookieValue = setCookie.split('oauth_session=')[1]?.split(';')[0] ?? '';
+  const userId = await verifySessionCookie(cookieValue);
+  assert(userId !== null && userId > 0);
+});
+```
+
+- [ ] **Step 6: Run test, verify it fails**
+
+```bash
+cd backend && deno test --allow-all tests/routes/auth_session_cookie_test.ts
+```
+
+Expected: FAIL — cookie not set.
+
+- [ ] **Step 7: Modify login route to set cookie**
+
+In `backend/src/routes/auth.ts`, add the import at the top:
+
+```ts
+import {
+  signSessionCookie,
+  OAUTH_SESSION_COOKIE_NAME,
+  OAUTH_SESSION_MAX_AGE,
+} from '../services/oauth/session-cookie.ts';
+```
+
+Replace the final `return c.json({ data: { ... } });` inside the `/login` handler with:
+
+```ts
+    const cookie = await signSessionCookie(user.id);
+    c.header(
+      'Set-Cookie',
+      `${OAUTH_SESSION_COOKIE_NAME}=${cookie}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${OAUTH_SESSION_MAX_AGE}`
+    );
+    return c.json({
+      data: {
+        user: {
+          id: user.id,
+          email: user.email,
+          full_name: user.full_name,
+          role: user.role,
+          tenantId: user.tenant_id,
+          tenantName: tenant.name,
+        },
+        accessToken,
+        refreshToken,
+      },
+      message: 'Login successful',
+    });
+```
+
+Note: keep `Secure` in production; for tests/dev the cookie is sent over `http://` requests but the existing test harness uses `http://x/...` URLs which won't enforce Secure inside Hono's app.fetch (Set-Cookie is just a header — verification only reads the cookie name and value).
+
+- [ ] **Step 8: Run both auth tests, verify pass**
+
+```bash
+cd backend && deno test --allow-all tests/routes/auth_session_cookie_test.ts tests/routes/auth_test.ts 2>&1 | tail -20
+```
+
+Expected: new test PASS; existing auth tests unaffected.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/src/services/oauth/session-cookie.ts backend/src/routes/auth.ts backend/tests/services/oauth/session_cookie_test.ts backend/tests/routes/auth_session_cookie_test.ts
+git commit -m "feat(oauth): set oauth_session cookie on login for OAuth consent bridge"
+```
+
+---
+
+### Task 9: GET /oauth/authorize — redirect to login or consent
+
+**Files:**
+- Modify: `backend/src/routes/oauth.ts`
+- Modify: `backend/tests/routes/oauth_test.ts`
+
+- [ ] **Step 1: Append the failing test**
+
+Add to `backend/tests/routes/oauth_test.ts`:
+
+```ts
+import { signSessionCookie } from '../../src/services/oauth/session-cookie.ts';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+import { oauthClientRepository } from '../../src/repositories/oauth-client.ts';
+
+Deno.test('GET /oauth/authorize', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('redirects to login when no session cookie', async () => {
+    await clearDatabase();
+    const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    const app = buildApp();
+    const url = `https://x/oauth/authorize?response_type=code&client_id=${client.id}&redirect_uri=${encodeURIComponent('https://c/cb')}&code_challenge=abc&code_challenge_method=S256&state=xyz`;
+    const res = await app.fetch(new Request(url));
+    assertEquals(res.status, 302);
+    const location = res.headers.get('location') ?? '';
+    assert(location.includes('/login'), `expected /login, got: ${location}`);
+    assert(location.includes('return_to='), 'must encode return_to');
+  });
+
+  await t.step('redirects to /oauth/consent when session cookie valid', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T', is_active: true });
+    const user = await userRepository.create({
+      email: 'a@a.a', password_hash: 'x', role: 'user',
+      full_name: 'A', tenant_id: tenant.id, is_active: true,
+    });
+    const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    const cookie = await signSessionCookie(user.id);
+
+    const app = buildApp();
+    const url = `https://x/oauth/authorize?response_type=code&client_id=${client.id}&redirect_uri=${encodeURIComponent('https://c/cb')}&code_challenge=abc&code_challenge_method=S256&state=xyz`;
+    const res = await app.fetch(new Request(url, { headers: { Cookie: `oauth_session=${cookie}` } }));
+    assertEquals(res.status, 302);
+    const location = res.headers.get('location') ?? '';
+    assert(location.startsWith('/oauth/consent?'), `expected /oauth/consent, got: ${location}`);
+  });
+
+  await t.step('rejects unknown client_id', async () => {
+    const app = buildApp();
+    const url = `https://x/oauth/authorize?response_type=code&client_id=nope&redirect_uri=https://c/cb&code_challenge=abc&code_challenge_method=S256`;
+    const res = await app.fetch(new Request(url));
+    assertEquals(res.status, 400);
+  });
+
+  await t.step('rejects redirect_uri not in client allowlist', async () => {
+    await clearDatabase();
+    const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    const app = buildApp();
+    const url = `https://x/oauth/authorize?response_type=code&client_id=${client.id}&redirect_uri=${encodeURIComponent('https://evil/cb')}&code_challenge=abc&code_challenge_method=S256`;
+    const res = await app.fetch(new Request(url));
+    assertEquals(res.status, 400);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+```bash
+cd backend && deno test --allow-all tests/routes/oauth_test.ts
+```
+
+Expected: FAIL — route not defined.
+
+- [ ] **Step 3: Implement /oauth/authorize**
+
+In `backend/src/routes/oauth.ts`, add after imports:
+
+```ts
+import { verifySessionCookie, OAUTH_SESSION_COOKIE_NAME } from '../services/oauth/session-cookie.ts';
+```
+
+Add this handler:
+
+```ts
+oauthRoutes.get('/authorize', async (c) => {
+  const responseType = c.req.query('response_type');
+  const clientId = c.req.query('client_id');
+  const redirectUri = c.req.query('redirect_uri');
+  const codeChallenge = c.req.query('code_challenge');
+  const codeChallengeMethod = c.req.query('code_challenge_method');
+  const state = c.req.query('state') ?? '';
+  const scope = c.req.query('scope') ?? 'read';
+
+  if (responseType !== 'code') return c.text('unsupported response_type', 400);
+  if (!clientId) return c.text('missing client_id', 400);
+  if (!redirectUri) return c.text('missing redirect_uri', 400);
+  if (!codeChallenge) return c.text('missing code_challenge', 400);
+  if (codeChallengeMethod !== 'S256') return c.text('only S256 supported', 400);
+
+  const client = await oauthClientRepository.findById(clientId);
+  if (!client) return c.text('unknown client_id', 400);
+  if (!client.redirect_uris.includes(redirectUri)) return c.text('redirect_uri not registered', 400);
+
+  // Parse cookie
+  const cookieHeader = c.req.header('Cookie') ?? '';
+  const match = cookieHeader.match(new RegExp(`(?:^|;\\s*)${OAUTH_SESSION_COOKIE_NAME}=([^;]+)`));
+  const userId = match ? await verifySessionCookie(match[1]) : null;
+
+  if (userId === null) {
+    // Send the user to the frontend login page with return_to
+    const returnTo = encodeURIComponent(c.req.url);
+    return c.redirect(`/login?return_to=${returnTo}`, 302);
+  }
+
+  // Logged in — render consent. Pass the original params forward.
+  const consentUrl = new URL('https://internal/oauth/consent');
+  consentUrl.searchParams.set('client_id', clientId);
+  consentUrl.searchParams.set('redirect_uri', redirectUri);
+  consentUrl.searchParams.set('code_challenge', codeChallenge);
+  consentUrl.searchParams.set('state', state);
+  consentUrl.searchParams.set('scope', scope);
+  return c.redirect(`/oauth/consent?${consentUrl.searchParams.toString()}`, 302);
+});
+```
+
+Also import `oauthClientRepository`:
+
+```ts
+import { oauthClientRepository } from '../repositories/oauth-client.ts';
+```
+
+(if not already present).
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd backend && deno test --allow-all tests/routes/oauth_test.ts
+```
+
+Expected: all steps PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/routes/oauth.ts backend/tests/routes/oauth_test.ts
+git commit -m "feat(oauth): add GET /oauth/authorize with session cookie check"
+```
+
+---
+
+### Task 10: Consent page (GET + POST /oauth/consent)
+
+**Files:**
+- Create: `backend/src/routes/oauth-consent.ts`
+- Test: `backend/tests/routes/oauth_consent_test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// backend/tests/routes/oauth_consent_test.ts
+import { assertEquals, assert } from '@std/assert';
+import { Hono } from 'hono';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { oauthConsentRoutes } from '../../src/routes/oauth-consent.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+import { oauthClientRepository } from '../../src/repositories/oauth-client.ts';
+import { signSessionCookie } from '../../src/services/oauth/session-cookie.ts';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/oauth', oauthConsentRoutes);
+  return app;
+}
+
+async function seed() {
+  const tenant = await tenantRepository.create({ name: 'T', is_active: true });
+  const user = await userRepository.create({
+    email: 'c@c.c', password_hash: 'x', role: 'user',
+    full_name: 'C', tenant_id: tenant.id, is_active: true,
+  });
+  const client = await oauthClientRepository.create({
+    redirect_uris: ['https://c/cb'], client_name: 'Claude',
+  });
+  const cookie = await signSessionCookie(user.id);
+  return { user, client, cookie };
+}
+
+Deno.test('OAuth consent', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('GET /oauth/consent renders HTML with allow/deny form', async () => {
+    await clearDatabase();
+    const { client, cookie } = await seed();
+    const app = buildApp();
+    const url = `https://x/oauth/consent?client_id=${client.id}&redirect_uri=${encodeURIComponent('https://c/cb')}&code_challenge=abc&state=xyz&scope=read`;
+    const res = await app.fetch(new Request(url, { headers: { Cookie: `oauth_session=${cookie}` } }));
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get('content-type')?.startsWith('text/html'), true);
+    const body = await res.text();
+    assert(body.includes('Claude'), 'must show client name');
+    assert(body.includes('Allow'), 'must have Allow button');
+    assert(body.includes('Deny'), 'must have Deny button');
+  });
+
+  await t.step('GET /oauth/consent redirects to login when no cookie', async () => {
+    await clearDatabase();
+    const { client } = await seed();
+    const app = buildApp();
+    const url = `https://x/oauth/consent?client_id=${client.id}&redirect_uri=https://c/cb&code_challenge=abc&state=xyz`;
+    const res = await app.fetch(new Request(url));
+    assertEquals(res.status, 302);
+    assert(res.headers.get('location')?.includes('/login') ?? false);
+  });
+
+  await t.step('POST /oauth/consent (Allow) issues code and redirects to client', async () => {
+    await clearDatabase();
+    const { client, cookie } = await seed();
+    const app = buildApp();
+    const body = new URLSearchParams({
+      action: 'allow',
+      client_id: client.id,
+      redirect_uri: 'https://c/cb',
+      code_challenge: 'abc',
+      state: 'xyz',
+      scope: 'read',
+    });
+    const res = await app.fetch(new Request('https://x/oauth/consent', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded', Cookie: `oauth_session=${cookie}` },
+      body: body.toString(),
+    }));
+    assertEquals(res.status, 302);
+    const location = res.headers.get('location') ?? '';
+    assert(location.startsWith('https://c/cb?'), `expected redirect to client, got: ${location}`);
+    const cb = new URL(location);
+    assert(cb.searchParams.get('code')!.length > 0);
+    assertEquals(cb.searchParams.get('state'), 'xyz');
+  });
+
+  await t.step('POST /oauth/consent (Deny) redirects to client with error', async () => {
+    await clearDatabase();
+    const { client, cookie } = await seed();
+    const app = buildApp();
+    const body = new URLSearchParams({
+      action: 'deny',
+      client_id: client.id,
+      redirect_uri: 'https://c/cb',
+      code_challenge: 'abc',
+      state: 'xyz',
+    });
+    const res = await app.fetch(new Request('https://x/oauth/consent', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded', Cookie: `oauth_session=${cookie}` },
+      body: body.toString(),
+    }));
+    assertEquals(res.status, 302);
+    const location = res.headers.get('location') ?? '';
+    assert(location.startsWith('https://c/cb?'));
+    const cb = new URL(location);
+    assertEquals(cb.searchParams.get('error'), 'access_denied');
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+```bash
+cd backend && deno test --allow-all tests/routes/oauth_consent_test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement consent route**
+
+```ts
+// backend/src/routes/oauth-consent.ts
+import { Hono } from 'hono';
+import { verifySessionCookie, OAUTH_SESSION_COOKIE_NAME } from '../services/oauth/session-cookie.ts';
+import { oauthClientRepository } from '../repositories/oauth-client.ts';
+import { oauthCodeRepository } from '../repositories/oauth-code.ts';
+import { userRepository } from '../repositories/user.ts';
+
+export const oauthConsentRoutes = new Hono();
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (ch) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[ch] as string));
+}
+
+function getCookieUserId(cookieHeader: string | undefined): Promise<number | null> {
+  if (!cookieHeader) return Promise.resolve(null);
+  const m = cookieHeader.match(new RegExp(`(?:^|;\\s*)${OAUTH_SESSION_COOKIE_NAME}=([^;]+)`));
+  if (!m) return Promise.resolve(null);
+  return verifySessionCookie(m[1]);
+}
+
+oauthConsentRoutes.get('/consent', async (c) => {
+  const userId = await getCookieUserId(c.req.header('Cookie'));
+  if (userId === null) {
+    const returnTo = encodeURIComponent(c.req.url);
+    return c.redirect(`/login?return_to=${returnTo}`, 302);
+  }
+  const clientId = c.req.query('client_id') ?? '';
+  const redirectUri = c.req.query('redirect_uri') ?? '';
+  const codeChallenge = c.req.query('code_challenge') ?? '';
+  const state = c.req.query('state') ?? '';
+  const scope = c.req.query('scope') ?? 'read';
+
+  const client = await oauthClientRepository.findById(clientId);
+  if (!client) return c.text('unknown client', 400);
+  if (!client.redirect_uris.includes(redirectUri)) return c.text('bad redirect_uri', 400);
+
+  const user = await userRepository.findById(userId);
+  const clientName = escapeHtml(client.client_name ?? 'an MCP client');
+  const email = escapeHtml(user?.email ?? '');
+
+  const html = `<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8"><title>SnapFlow — Authorize</title></head>
+  <body style="font-family:system-ui;max-width:480px;margin:80px auto;padding:24px;border:1px solid #ddd;border-radius:8px">
+    <h2>Authorize ${clientName}</h2>
+    <p>${clientName} wants to read your SnapFlow projects and catalog as <strong>${email}</strong>.</p>
+    <form method="POST" action="/oauth/consent">
+      <input type="hidden" name="client_id" value="${escapeHtml(clientId)}">
+      <input type="hidden" name="redirect_uri" value="${escapeHtml(redirectUri)}">
+      <input type="hidden" name="code_challenge" value="${escapeHtml(codeChallenge)}">
+      <input type="hidden" name="state" value="${escapeHtml(state)}">
+      <input type="hidden" name="scope" value="${escapeHtml(scope)}">
+      <button name="action" value="allow" style="padding:10px 16px;margin-right:8px">Allow</button>
+      <button name="action" value="deny" style="padding:10px 16px">Deny</button>
+    </form>
+  </body>
+</html>`;
+  c.header('Content-Type', 'text/html; charset=utf-8');
+  return c.body(html);
+});
+
+oauthConsentRoutes.post('/consent', async (c) => {
+  const userId = await getCookieUserId(c.req.header('Cookie'));
+  if (userId === null) return c.text('not authenticated', 401);
+
+  const form = await c.req.formData();
+  const action = form.get('action');
+  const clientId = String(form.get('client_id') ?? '');
+  const redirectUri = String(form.get('redirect_uri') ?? '');
+  const codeChallenge = String(form.get('code_challenge') ?? '');
+  const state = String(form.get('state') ?? '');
+  const scope = String(form.get('scope') ?? 'read');
+
+  const client = await oauthClientRepository.findById(clientId);
+  if (!client || !client.redirect_uris.includes(redirectUri)) {
+    return c.text('bad client/redirect', 400);
+  }
+
+  const cbUrl = new URL(redirectUri);
+  if (action !== 'allow') {
+    cbUrl.searchParams.set('error', 'access_denied');
+    if (state) cbUrl.searchParams.set('state', state);
+    return c.redirect(cbUrl.toString(), 302);
+  }
+
+  const created = await oauthCodeRepository.create({
+    client_id: clientId,
+    user_id: userId,
+    redirect_uri: redirectUri,
+    code_challenge: codeChallenge,
+    scope,
+  });
+  cbUrl.searchParams.set('code', created.code);
+  if (state) cbUrl.searchParams.set('state', state);
+  return c.redirect(cbUrl.toString(), 302);
+});
+
+export default oauthConsentRoutes;
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd backend && deno test --allow-all tests/routes/oauth_consent_test.ts
+```
+
+Expected: all 4 steps PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/routes/oauth-consent.ts backend/tests/routes/oauth_consent_test.ts
+git commit -m "feat(oauth): add /oauth/consent (GET HTML + POST allow/deny)"
+```
+
+---
+
+### Task 11: POST /oauth/token — authorization_code grant
+
+**Files:**
+- Modify: `backend/src/routes/oauth.ts`
+- Modify: `backend/tests/routes/oauth_test.ts`
+
+- [ ] **Step 1: Append the failing test**
+
+Add to `backend/tests/routes/oauth_test.ts`:
+
+```ts
+import { oauthCodeRepository } from '../../src/repositories/oauth-code.ts';
+import { verifyToken } from '../../src/services/jwt.ts';
+
+Deno.test('POST /oauth/token (authorization_code)', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('exchanges valid code + verifier for access + refresh tokens', async () => {
+    await clearDatabase();
+    // RFC 7636 example pair
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+    const tenant = await tenantRepository.create({ name: 'T', is_active: true });
+    const user = await userRepository.create({
+      email: 'z@z.z', password_hash: 'x', role: 'user',
+      full_name: 'Z', tenant_id: tenant.id, is_active: true,
+    });
+    const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    const created = await oauthCodeRepository.create({
+      client_id: client.id, user_id: user.id,
+      redirect_uri: 'https://c/cb', code_challenge: challenge, scope: 'read',
+    });
+
+    const app = buildApp();
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: created.code,
+      redirect_uri: 'https://c/cb',
+      client_id: client.id,
+      code_verifier: verifier,
+    });
+    const res = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    }));
+    assertEquals(res.status, 200);
+    const tok = await res.json();
+    assertEquals(tok.token_type, 'Bearer');
+    assert(typeof tok.access_token === 'string' && tok.access_token.length > 0);
+    assert(typeof tok.refresh_token === 'string' && tok.refresh_token.length > 0);
+
+    // The access token must be a valid SnapFlow JWT for this user
+    const payload = await verifyToken(tok.access_token);
+    assertEquals(payload.sub, String(user.id));
+    assertEquals(payload.tenantId, tenant.id);
+  });
+
+  await t.step('rejects wrong verifier', async () => {
+    await clearDatabase();
+    const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+    const tenant = await tenantRepository.create({ name: 'T', is_active: true });
+    const user = await userRepository.create({
+      email: 'y@y.y', password_hash: 'x', role: 'user',
+      full_name: 'Y', tenant_id: tenant.id, is_active: true,
+    });
+    const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    const created = await oauthCodeRepository.create({
+      client_id: client.id, user_id: user.id,
+      redirect_uri: 'https://c/cb', code_challenge: challenge,
+    });
+
+    const app = buildApp();
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code', code: created.code,
+      redirect_uri: 'https://c/cb', client_id: client.id,
+      code_verifier: 'wrong',
+    });
+    const res = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    }));
+    assertEquals(res.status, 400);
+    const err = await res.json();
+    assertEquals(err.error, 'invalid_grant');
+  });
+
+  await t.step('rejects reused code', async () => {
+    await clearDatabase();
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+    const tenant = await tenantRepository.create({ name: 'T', is_active: true });
+    const user = await userRepository.create({
+      email: 'r@r.r', password_hash: 'x', role: 'user',
+      full_name: 'R', tenant_id: tenant.id, is_active: true,
+    });
+    const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    const created = await oauthCodeRepository.create({
+      client_id: client.id, user_id: user.id,
+      redirect_uri: 'https://c/cb', code_challenge: challenge,
+    });
+
+    const app = buildApp();
+    const makeBody = () => new URLSearchParams({
+      grant_type: 'authorization_code', code: created.code,
+      redirect_uri: 'https://c/cb', client_id: client.id,
+      code_verifier: verifier,
+    }).toString();
+
+    const first = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: makeBody(),
+    }));
+    assertEquals(first.status, 200);
+
+    const second = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: makeBody(),
+    }));
+    assertEquals(second.status, 400);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+```bash
+cd backend && deno test --allow-all tests/routes/oauth_test.ts
+```
+
+Expected: FAIL — `/oauth/token` not defined.
+
+- [ ] **Step 3: Implement /oauth/token (code grant)**
+
+In `backend/src/routes/oauth.ts`, add imports:
+
+```ts
+import { oauthCodeRepository } from '../repositories/oauth-code.ts';
+import { verifyS256 } from '../services/oauth/pkce.ts';
+import { generateToken } from '../services/jwt.ts';
+import { createRefreshToken } from '../services/refresh-token.ts';
+import { userRepository } from '../repositories/user.ts';
+```
+
+Add the handler:
+
+```ts
+oauthRoutes.post('/token', async (c) => {
+  const form = await c.req.formData();
+  const grantType = String(form.get('grant_type') ?? '');
+
+  if (grantType === 'authorization_code') {
+    const code = String(form.get('code') ?? '');
+    const redirectUri = String(form.get('redirect_uri') ?? '');
+    const clientId = String(form.get('client_id') ?? '');
+    const verifier = String(form.get('code_verifier') ?? '');
+
+    if (!code || !redirectUri || !clientId || !verifier) {
+      return c.json({ error: 'invalid_request', error_description: 'missing field' }, 400);
+    }
+    const consumed = await oauthCodeRepository.consume(code);
+    if (!consumed) {
+      return c.json({ error: 'invalid_grant', error_description: 'code invalid/expired/reused' }, 400);
+    }
+    if (consumed.client_id !== clientId) {
+      return c.json({ error: 'invalid_grant', error_description: 'client_id mismatch' }, 400);
+    }
+    if (consumed.redirect_uri !== redirectUri) {
+      return c.json({ error: 'invalid_grant', error_description: 'redirect_uri mismatch' }, 400);
+    }
+    const pkceOk = await verifyS256(verifier, consumed.code_challenge);
+    if (!pkceOk) {
+      return c.json({ error: 'invalid_grant', error_description: 'PKCE verification failed' }, 400);
+    }
+
+    const user = await userRepository.findById(consumed.user_id);
+    if (!user) return c.json({ error: 'invalid_grant', error_description: 'user gone' }, 400);
+
+    const accessToken = await generateToken(user.id, user.email, user.role, user.tenant_id);
+    const refreshToken = await createRefreshToken(user.id);
+
+    return c.json({
+      access_token: accessToken,
+      token_type: 'Bearer',
+      expires_in: 900,
+      refresh_token: refreshToken,
+      scope: consumed.scope ?? 'read',
+    });
+  }
+
+  // Refresh-token grant added in Task 12.
+  return c.json({ error: 'unsupported_grant_type' }, 400);
+});
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd backend && deno test --allow-all tests/routes/oauth_test.ts
+```
+
+Expected: all steps PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/routes/oauth.ts backend/tests/routes/oauth_test.ts
+git commit -m "feat(oauth): add POST /oauth/token authorization_code grant with PKCE"
+```
+
+---
+
+### Task 12: POST /oauth/token — refresh_token grant
+
+**Files:**
+- Modify: `backend/src/routes/oauth.ts`
+- Modify: `backend/tests/routes/oauth_test.ts`
+
+- [ ] **Step 1: Append the failing test**
+
+```ts
+Deno.test('POST /oauth/token (refresh_token)', async (t) => {
+  await setupTestDatabase();
+
+  async function obtainTokenPair() {
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+    const tenant = await tenantRepository.create({ name: 'T', is_active: true });
+    const user = await userRepository.create({
+      email: 'q@q.q', password_hash: 'x', role: 'user',
+      full_name: 'Q', tenant_id: tenant.id, is_active: true,
+    });
+    const client = await oauthClientRepository.create({ redirect_uris: ['https://c/cb'] });
+    const created = await oauthCodeRepository.create({
+      client_id: client.id, user_id: user.id,
+      redirect_uri: 'https://c/cb', code_challenge: challenge,
+    });
+    const app = buildApp();
+    const res = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code', code: created.code,
+        redirect_uri: 'https://c/cb', client_id: client.id, code_verifier: verifier,
+      }).toString(),
+    }));
+    return { app, tok: await res.json(), user };
+  }
+
+  await t.step('exchanges refresh token for new pair', async () => {
+    await clearDatabase();
+    const { app, tok } = await obtainTokenPair();
+
+    const res = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: tok.refresh_token }).toString(),
+    }));
+    assertEquals(res.status, 200);
+    const next = await res.json();
+    assert(typeof next.access_token === 'string');
+    assert(typeof next.refresh_token === 'string');
+    assertNotEquals(next.refresh_token, tok.refresh_token, 'refresh token must rotate');
+  });
+
+  await t.step('old refresh token is invalidated after rotation', async () => {
+    await clearDatabase();
+    const { app, tok } = await obtainTokenPair();
+    const r1 = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: tok.refresh_token }).toString(),
+    }));
+    assertEquals(r1.status, 200);
+    const r2 = await app.fetch(new Request('https://x/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: tok.refresh_token }).toString(),
+    }));
+    assertEquals(r2.status, 400);
+  });
+});
+```
+
+Add the import you'll need (top of file):
+
+```ts
+import { assertNotEquals } from '@std/assert';
+```
+
+(if not already present).
+
+- [ ] **Step 2: Run, verify fail**
+
+```bash
+cd backend && deno test --allow-all tests/routes/oauth_test.ts
+```
+
+Expected: refresh_token tests FAIL with `unsupported_grant_type`.
+
+- [ ] **Step 3: Extend /oauth/token with refresh_token grant**
+
+In `backend/src/routes/oauth.ts`, add imports if not present:
+
+```ts
+import { verifyRefreshToken, revokeRefreshToken } from '../services/refresh-token.ts';
+```
+
+Replace the line `// Refresh-token grant added in Task 12.` (and the line below it) with:
+
+```ts
+  if (grantType === 'refresh_token') {
+    const refreshToken = String(form.get('refresh_token') ?? '');
+    if (!refreshToken) return c.json({ error: 'invalid_request' }, 400);
+    const userId = await verifyRefreshToken(refreshToken);
+    if (userId === null) return c.json({ error: 'invalid_grant' }, 400);
+    const user = await userRepository.findById(userId);
+    if (!user) return c.json({ error: 'invalid_grant' }, 400);
+
+    // Rotate: revoke the presented refresh token, issue a fresh pair
+    await revokeRefreshToken(refreshToken);
+    const accessToken = await generateToken(user.id, user.email, user.role, user.tenant_id);
+    const newRefresh = await createRefreshToken(user.id);
+    return c.json({
+      access_token: accessToken,
+      token_type: 'Bearer',
+      expires_in: 900,
+      refresh_token: newRefresh,
+      scope: 'read',
+    });
+  }
+
+  return c.json({ error: 'unsupported_grant_type' }, 400);
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd backend && deno test --allow-all tests/routes/oauth_test.ts
+```
+
+Expected: all steps PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/routes/oauth.ts backend/tests/routes/oauth_test.ts
+git commit -m "feat(oauth): add refresh_token grant with rotation"
+```
+
+---
+
+## Phase 4 — MCP Server
+
+### Task 13: In-process dispatcher (calls existing REST routes via app.fetch)
+
+**Files:**
+- Create: `backend/src/services/mcp/dispatcher.ts`
+- Test: `backend/tests/mcp/dispatcher_test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// backend/tests/mcp/dispatcher_test.ts
+import { assertEquals, assert } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { dispatchToBackend } from '../../src/services/mcp/dispatcher.ts';
+import app from '../../src/main.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+
+Deno.test('dispatchToBackend', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns parsed JSON body for 200 responses', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T', is_active: true });
+    const user = await userRepository.create({
+      email: 'd@d.d', password_hash: 'x', role: 'user',
+      full_name: 'D', tenant_id: tenant.id, is_active: true,
+    });
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+    const result = await dispatchToBackend(app, {
+      method: 'GET',
+      path: '/api/projects',
+      accessToken: token,
+    });
+    assertEquals(result.ok, true);
+    assert(Array.isArray(result.body.data));
+  });
+
+  await t.step('returns {ok:false, status, body} for error responses', async () => {
+    await clearDatabase();
+    const result = await dispatchToBackend(app, {
+      method: 'GET',
+      path: '/api/projects',
+      accessToken: 'garbage.jwt.string',
+    });
+    assertEquals(result.ok, false);
+    assertEquals(result.status, 401);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+```bash
+cd backend && deno test --allow-all tests/mcp/dispatcher_test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the dispatcher**
+
+```ts
+// backend/src/services/mcp/dispatcher.ts
+import type { Hono } from 'hono';
+
+export interface DispatchInput {
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  path: string;
+  query?: Record<string, string | number | undefined>;
+  body?: unknown;
+  accessToken: string;
+}
+
+export interface DispatchResult {
+  ok: boolean;
+  status: number;
+  body: any;
+}
+
+/**
+ * Dispatch a request to the in-process Hono app using the user's access token.
+ *
+ * MCP tools call this instead of touching repositories directly, so that all
+ * middleware (auth, tenant scoping, Zod validation, role checks, cascading
+ * business logic) runs exactly as it would for a real HTTP request from the
+ * frontend.
+ */
+export async function dispatchToBackend(
+  app: Hono,
+  input: DispatchInput,
+): Promise<DispatchResult> {
+  const url = new URL(`http://internal${input.path}`);
+  if (input.query) {
+    for (const [k, v] of Object.entries(input.query)) {
+      if (v !== undefined && v !== null) url.searchParams.set(k, String(v));
+    }
+  }
+
+  const init: RequestInit = {
+    method: input.method,
+    headers: { Authorization: `Bearer ${input.accessToken}` },
+  };
+  if (input.body !== undefined) {
+    (init.headers as Record<string, string>)['content-type'] = 'application/json';
+    init.body = JSON.stringify(input.body);
+  }
+
+  const res = await app.fetch(new Request(url, init));
+  const contentType = res.headers.get('content-type') ?? '';
+  let body: any = null;
+  if (contentType.startsWith('application/json')) {
+    body = await res.json();
+  } else {
+    body = await res.text();
+  }
+  return { ok: res.ok, status: res.status, body };
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd backend && deno test --allow-all tests/mcp/dispatcher_test.ts
+```
+
+Expected: both steps PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/mcp/dispatcher.ts backend/tests/mcp/dispatcher_test.ts
+git commit -m "feat(mcp): add in-process dispatcher (calls REST routes via app.fetch)"
+```
+
+---
+
+### Task 14: MCP tool — list_projects
+
+**Files:**
+- Create: `backend/src/services/mcp/tools/list-projects.ts`
+- Test: `backend/tests/mcp/tools_test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// backend/tests/mcp/tools_test.ts
+import { assertEquals, assert } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import app from '../../src/main.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+import { projectRepository } from '../../src/repositories/project.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+import { listProjectsTool } from '../../src/services/mcp/tools/list-projects.ts';
+
+async function seedUserWithProjects() {
+  const tenant = await tenantRepository.create({ name: 'T', is_active: true });
+  const user = await userRepository.create({
+    email: 'l@l.l', password_hash: 'x', role: 'user',
+    full_name: 'L', tenant_id: tenant.id, is_active: true,
+  });
+  // Use the project repo to create a couple of projects in this tenant.
+  // (Adjust to match your repo's signature — see backend/src/repositories/project.ts)
+  await projectRepository.create({
+    name: 'Alpha', customer_name: 'A Co', tenant_id: tenant.id,
+  } as any);
+  await projectRepository.create({
+    name: 'Beta', customer_name: 'B Co', tenant_id: tenant.id,
+  } as any);
+  const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+  return { token, tenant, user };
+}
+
+Deno.test('list_projects tool', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns content with the user\'s projects', async () => {
+    await clearDatabase();
+    const { token } = await seedUserWithProjects();
+    const result = await listProjectsTool.handler({ query: undefined }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    assertEquals(result.content.length, 1);
+    const text = result.content[0].text;
+    assert(text.includes('Alpha'));
+    assert(text.includes('Beta'));
+  });
+
+  await t.step('honors search query', async () => {
+    await clearDatabase();
+    const { token } = await seedUserWithProjects();
+    const result = await listProjectsTool.handler({ query: 'Alpha' }, { app, accessToken: token });
+    assert(result.content[0].text.includes('Alpha'));
+    assert(!result.content[0].text.includes('Beta'));
+  });
+
+  await t.step('returns isError on bad auth', async () => {
+    await clearDatabase();
+    const result = await listProjectsTool.handler({ query: undefined }, { app, accessToken: 'bad' });
+    assertEquals(result.isError, true);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+```bash
+cd backend && deno test --allow-all tests/mcp/tools_test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the tool**
+
+```ts
+// backend/src/services/mcp/tools/list-projects.ts
+import type { Hono } from 'hono';
+import { z } from 'zod';
+import { dispatchToBackend } from '../dispatcher.ts';
+
+export interface ToolContext {
+  app: Hono;
+  accessToken: string;
+}
+
+export interface ToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+const inputSchema = z.object({
+  query: z.string().optional(),
+});
+
+export const listProjectsTool = {
+  name: 'list_projects',
+  description:
+    'List SnapFlow projects in your workspace. Returns id, name, customer name, status, and creation date. Use `query` to filter by project name.',
+  inputSchema,
+  handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
+    const result = await dispatchToBackend(ctx.app, {
+      method: 'GET',
+      path: '/api/projects',
+      query: { search: args.query },
+      accessToken: ctx.accessToken,
+    });
+    if (!result.ok) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to list projects (HTTP ${result.status}): ${JSON.stringify(result.body)}` }],
+      };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(result.body.data, null, 2) }] };
+  },
+};
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd backend && deno test --allow-all tests/mcp/tools_test.ts
+```
+
+Expected: all 3 steps PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/mcp/tools/list-projects.ts backend/tests/mcp/tools_test.ts
+git commit -m "feat(mcp): add list_projects tool"
+```
+
+---
+
+### Task 15: MCP tool — get_project
+
+**Files:**
+- Create: `backend/src/services/mcp/tools/get-project.ts`
+- Modify: `backend/tests/mcp/tools_test.ts`
+
+- [ ] **Step 1: Append the failing test**
+
+```ts
+import { getProjectTool } from '../../src/services/mcp/tools/get-project.ts';
+
+Deno.test('get_project tool', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns project details for valid id', async () => {
+    await clearDatabase();
+    const { token, tenant } = await seedUserWithProjects();
+    // Fetch list to discover id (or pull from repo directly)
+    const projects = await projectRepository.findAll(undefined, { tenantId: tenant.id, role: 'user' } as any);
+    const projectId = projects[0].id;
+
+    const result = await getProjectTool.handler({ project_id: projectId }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    assert(result.content[0].text.includes(projects[0].name));
+  });
+
+  await t.step('returns isError for unknown id', async () => {
+    await clearDatabase();
+    const { token } = await seedUserWithProjects();
+    const result = await getProjectTool.handler({ project_id: 999999 }, { app, accessToken: token });
+    assertEquals(result.isError, true);
+  });
+});
+```
+
+(Pull the import for `projectRepository` to the top of the file if not already there.)
+
+- [ ] **Step 2: Run, verify fail**
+
+```bash
+cd backend && deno test --allow-all tests/mcp/tools_test.ts
+```
+
+Expected: FAIL — get-project module missing.
+
+- [ ] **Step 3: Implement the tool**
+
+```ts
+// backend/src/services/mcp/tools/get-project.ts
+import { z } from 'zod';
+import { dispatchToBackend } from '../dispatcher.ts';
+import type { ToolContext, ToolResult } from './list-projects.ts';
+
+const inputSchema = z.object({
+  project_id: z.number().int().positive(),
+});
+
+export const getProjectTool = {
+  name: 'get_project',
+  description:
+    'Get full details for a single SnapFlow project — customer info, floorplans, BOM entries.',
+  inputSchema,
+  handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
+    const result = await dispatchToBackend(ctx.app, {
+      method: 'GET',
+      path: `/api/projects/${args.project_id}`,
+      accessToken: ctx.accessToken,
+    });
+    if (!result.ok) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to get project ${args.project_id} (HTTP ${result.status}): ${JSON.stringify(result.body)}` }],
+      };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(result.body.data, null, 2) }] };
+  },
+};
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd backend && deno test --allow-all tests/mcp/tools_test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/mcp/tools/get-project.ts backend/tests/mcp/tools_test.ts
+git commit -m "feat(mcp): add get_project tool"
+```
+
+---
+
+### Task 16: MCP tool — get_project_total
+
+**Files:**
+- Create: `backend/src/services/mcp/tools/get-project-total.ts`
+- Modify: `backend/tests/mcp/tools_test.ts`
+
+- [ ] **Step 1: Append the failing test**
+
+```ts
+import { getProjectTotalTool } from '../../src/services/mcp/tools/get-project-total.ts';
+
+Deno.test('get_project_total tool', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns total for valid id', async () => {
+    await clearDatabase();
+    const { token, tenant } = await seedUserWithProjects();
+    const projects = await projectRepository.findAll(undefined, { tenantId: tenant.id, role: 'user' } as any);
+    const result = await getProjectTotalTool.handler({ project_id: projects[0].id }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    // The /total route returns a structured object; just assert it parsed
+    assert(result.content[0].text.length > 2);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+```bash
+cd backend && deno test --allow-all tests/mcp/tools_test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the tool**
+
+```ts
+// backend/src/services/mcp/tools/get-project-total.ts
+import { z } from 'zod';
+import { dispatchToBackend } from '../dispatcher.ts';
+import type { ToolContext, ToolResult } from './list-projects.ts';
+
+const inputSchema = z.object({
+  project_id: z.number().int().positive(),
+});
+
+export const getProjectTotalTool = {
+  name: 'get_project_total',
+  description:
+    'Get the itemized total/pricing summary for a SnapFlow project — list price, discounts, tax, grand total.',
+  inputSchema,
+  handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
+    const result = await dispatchToBackend(ctx.app, {
+      method: 'GET',
+      path: `/api/projects/${args.project_id}/total`,
+      accessToken: ctx.accessToken,
+    });
+    if (!result.ok) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to get total for project ${args.project_id} (HTTP ${result.status}): ${JSON.stringify(result.body)}` }],
+      };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(result.body.data, null, 2) }] };
+  },
+};
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd backend && deno test --allow-all tests/mcp/tools_test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/mcp/tools/get-project-total.ts backend/tests/mcp/tools_test.ts
+git commit -m "feat(mcp): add get_project_total tool"
+```
+
+---
+
+### Task 17: MCP tool — search_items
+
+**Files:**
+- Create: `backend/src/services/mcp/tools/search-items.ts`
+- Modify: `backend/tests/mcp/tools_test.ts`
+
+- [ ] **Step 1: Append the failing test**
+
+```ts
+import { searchItemsTool } from '../../src/services/mcp/tools/search-items.ts';
+import { itemRepository } from '../../src/repositories/item.ts';
+
+Deno.test('search_items tool', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns items matching query', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T', is_active: true });
+    const user = await userRepository.create({
+      email: 's@s.s', password_hash: 'x', role: 'user',
+      full_name: 'S', tenant_id: tenant.id, is_active: true,
+    });
+    // Seed one item (adjust to match your repo signature)
+    await itemRepository.create({
+      name: 'Smart Switch', sku: 'SW-1', tenant_id: tenant.id,
+    } as any);
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    const result = await searchItemsTool.handler({ query: 'Switch' }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    assert(result.content[0].text.includes('Smart Switch'));
+  });
+
+  await t.step('honors limit', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T', is_active: true });
+    const user = await userRepository.create({
+      email: 's2@s.s', password_hash: 'x', role: 'user',
+      full_name: 'S', tenant_id: tenant.id, is_active: true,
+    });
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    const result = await searchItemsTool.handler({ limit: 5 }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+```bash
+cd backend && deno test --allow-all tests/mcp/tools_test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the tool**
+
+```ts
+// backend/src/services/mcp/tools/search-items.ts
+import { z } from 'zod';
+import { dispatchToBackend } from '../dispatcher.ts';
+import type { ToolContext, ToolResult } from './list-projects.ts';
+
+const inputSchema = z.object({
+  query: z.string().optional(),
+  category_id: z.number().int().positive().optional(),
+  type_id: z.number().int().positive().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+});
+
+export const searchItemsTool = {
+  name: 'search_items',
+  description:
+    'Search the SnapFlow product catalog. Filter by name (`query`), `category_id`, or `type_id`. Limit defaults to 20, max 100.',
+  inputSchema,
+  handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
+    const result = await dispatchToBackend(ctx.app, {
+      method: 'GET',
+      path: '/api/items',
+      query: {
+        search: args.query,
+        category_id: args.category_id,
+        type_id: args.type_id,
+        limit: args.limit,
+      },
+      accessToken: ctx.accessToken,
+    });
+    if (!result.ok) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to search items (HTTP ${result.status}): ${JSON.stringify(result.body)}` }],
+      };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(result.body.data, null, 2) }] };
+  },
+};
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+cd backend && deno test --allow-all tests/mcp/tools_test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/mcp/tools/search-items.ts backend/tests/mcp/tools_test.ts
+git commit -m "feat(mcp): add search_items tool"
+```
+
+---
+
+### Task 18: MCP server + /mcp Streamable HTTP route
+
+**Files:**
+- Create: `backend/src/services/mcp/server.ts`
+- Create: `backend/src/routes/mcp.ts`
+- Test: `backend/tests/routes/mcp_test.ts`
+
+- [ ] **Step 1: Add the MCP SDK dependency**
+
+In `backend/deno.json`, add to the `imports` map:
+
+```json
+"@modelcontextprotocol/sdk/": "npm:@modelcontextprotocol/sdk@^1.0.0/"
+```
+
+Run:
+
+```bash
+cd backend && deno cache src/main.ts
+```
+
+Expected: SDK package downloads without errors.
+
+- [ ] **Step 2: Write the failing route test**
+
+```ts
+// backend/tests/routes/mcp_test.ts
+import { assertEquals, assert } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import app from '../../src/main.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+
+Deno.test('POST /mcp', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns 401 with WWW-Authenticate when no bearer', async () => {
+    const res = await app.fetch(new Request('http://x/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    }));
+    assertEquals(res.status, 401);
+    const wwwAuth = res.headers.get('www-authenticate') ?? '';
+    assert(wwwAuth.includes('Bearer'));
+    assert(wwwAuth.includes('resource_metadata'));
+  });
+
+  await t.step('tools/list returns the 4 tools when authenticated', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T', is_active: true });
+    const user = await userRepository.create({
+      email: 'm@m.m', password_hash: 'x', role: 'user',
+      full_name: 'M', tenant_id: tenant.id, is_active: true,
+    });
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    const res = await app.fetch(new Request('http://x/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    }));
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    const names = body.result.tools.map((t: { name: string }) => t.name).sort();
+    assertEquals(names, ['get_project', 'get_project_total', 'list_projects', 'search_items']);
+  });
+});
+```
+
+- [ ] **Step 3: Run, verify fail**
+
+```bash
+cd backend && deno test --allow-all tests/routes/mcp_test.ts
+```
+
+Expected: FAIL — route not mounted.
+
+- [ ] **Step 4: Implement the MCP server module**
+
+```ts
+// backend/src/services/mcp/server.ts
+import type { Hono } from 'hono';
+import { listProjectsTool } from './tools/list-projects.ts';
+import { getProjectTool } from './tools/get-project.ts';
+import { getProjectTotalTool } from './tools/get-project-total.ts';
+import { searchItemsTool } from './tools/search-items.ts';
+
+const allTools = [listProjectsTool, getProjectTool, getProjectTotalTool, searchItemsTool];
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: number | string | null;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+/** Minimal MCP server: handles `initialize`, `tools/list`, `tools/call` over JSON-RPC. */
+export async function handleMcpRequest(
+  app: Hono,
+  accessToken: string,
+  req: JsonRpcRequest,
+): Promise<unknown> {
+  if (req.method === 'initialize') {
+    return {
+      jsonrpc: '2.0',
+      id: req.id,
+      result: {
+        protocolVersion: '2024-11-05',
+        capabilities: { tools: {} },
+        serverInfo: { name: 'snapflow-mcp', version: '0.1.0' },
+      },
+    };
+  }
+  if (req.method === 'tools/list') {
+    return {
+      jsonrpc: '2.0',
+      id: req.id,
+      result: {
+        tools: allTools.map((t) => ({
+          name: t.name,
+          description: t.description,
+          inputSchema: zodToJsonSchema(t.inputSchema),
+        })),
+      },
+    };
+  }
+  if (req.method === 'tools/call') {
+    const params = req.params as { name: string; arguments?: Record<string, unknown> } | undefined;
+    if (!params) {
+      return { jsonrpc: '2.0', id: req.id, error: { code: -32602, message: 'missing params' } };
+    }
+    const tool = allTools.find((t) => t.name === params.name);
+    if (!tool) {
+      return { jsonrpc: '2.0', id: req.id, error: { code: -32601, message: `unknown tool: ${params.name}` } };
+    }
+    const parsed = tool.inputSchema.safeParse(params.arguments ?? {});
+    if (!parsed.success) {
+      return { jsonrpc: '2.0', id: req.id, error: { code: -32602, message: parsed.error.message } };
+    }
+    const result = await tool.handler(parsed.data as never, { app, accessToken });
+    return { jsonrpc: '2.0', id: req.id, result };
+  }
+  return { jsonrpc: '2.0', id: req.id, error: { code: -32601, message: `unknown method: ${req.method}` } };
+}
+
+/**
+ * Convert a Zod schema to a JSON Schema fragment.
+ * Minimal converter — sufficient for the four v0 tools (all flat objects of
+ * optional string/number with constraints).
+ */
+function zodToJsonSchema(schema: unknown): unknown {
+  // For v0 we hand-rolled four flat-object schemas. A minimal converter
+  // that walks the Zod definition is enough.
+  // (We use `zod-to-json-schema` later if we add complex shapes.)
+  // The MCP clients we target (Claude.ai / Desktop / Code) accept any valid
+  // JSON Schema object, including {} (meaning "any object").
+  // For now, return {} so tools/list works; tool calls still validate via Zod.
+  return { type: 'object' };
+}
+```
+
+(Note: replacing the placeholder converter is on the roadmap; for v0 the LLM gets the description string and uses `tools/call` either way. We document this in Open Questions.)
+
+- [ ] **Step 5: Implement the /mcp route**
+
+```ts
+// backend/src/routes/mcp.ts
+import { Hono } from 'hono';
+import { authMiddleware } from '../middleware/auth.ts';
+import { handleMcpRequest } from '../services/mcp/server.ts';
+
+export const mcpRoutes = new Hono();
+
+/**
+ * Custom auth-or-challenge middleware: if no/invalid bearer, return 401 with
+ * a WWW-Authenticate header pointing to the protected-resource metadata so
+ * MCP clients can discover where to authenticate.
+ */
+mcpRoutes.use('/', async (c, next) => {
+  const auth = c.req.header('Authorization');
+  if (!auth || !auth.startsWith('Bearer ')) {
+    const baseUrl = new URL(c.req.url);
+    c.header(
+      'WWW-Authenticate',
+      `Bearer resource_metadata="${baseUrl.protocol}//${baseUrl.host}/.well-known/oauth-protected-resource"`,
+    );
+    return c.json({ error: 'unauthorized' }, 401);
+  }
+  return await authMiddleware(c, next);
+});
+
+mcpRoutes.post('/', async (c) => {
+  const accessToken = c.req.header('Authorization')!.substring(7);
+  const body = await c.req.json();
+  // For v0 we keep it simple: handle one JSON-RPC request per HTTP POST,
+  // single-response JSON (no streaming). Streamable HTTP supports this mode.
+  const result = await handleMcpRequest(c, accessToken, body);
+  return c.json(result);
+});
+
+export default mcpRoutes;
+```
+
+Wait — the handler signature passes `c` (Hono context) but we need the `app` to dispatch. Update `mcp.ts`:
+
+```ts
+import { Hono } from 'hono';
+import { authMiddleware } from '../middleware/auth.ts';
+import { handleMcpRequest } from '../services/mcp/server.ts';
+
+export function buildMcpRoutes(app: Hono): Hono {
+  const mcpRoutes = new Hono();
+
+  mcpRoutes.use('/', async (c, next) => {
+    const auth = c.req.header('Authorization');
+    if (!auth || !auth.startsWith('Bearer ')) {
+      const baseUrl = new URL(c.req.url);
+      c.header(
+        'WWW-Authenticate',
+        `Bearer resource_metadata="${baseUrl.protocol}//${baseUrl.host}/.well-known/oauth-protected-resource"`,
+      );
+      return c.json({ error: 'unauthorized' }, 401);
+    }
+    return await authMiddleware(c, next);
+  });
+
+  mcpRoutes.post('/', async (c) => {
+    const accessToken = c.req.header('Authorization')!.substring(7);
+    const body = await c.req.json();
+    const result = await handleMcpRequest(app, accessToken, body);
+    return c.json(result);
+  });
+
+  return mcpRoutes;
+}
+```
+
+This makes `/mcp` know about the top-level `app` so it can dispatch internally.
+
+- [ ] **Step 6: Run, verify pass (after wiring in main.ts in Task 19)**
+
+The mcp test depends on the route being mounted in `main.ts`, which happens in Task 19. Note this dependency; don't try to run it standalone yet.
+
+- [ ] **Step 7: Commit (route + server, without main.ts yet)**
+
+```bash
+git add backend/src/services/mcp/server.ts backend/src/routes/mcp.ts backend/deno.json backend/tests/routes/mcp_test.ts
+git commit -m "feat(mcp): add MCP server (initialize, tools/list, tools/call) and /mcp route"
+```
+
+---
+
+## Phase 5 — Wire-up + frontend
+
+### Task 19: Mount OAuth + MCP routes in main.ts
+
+**Files:**
+- Modify: `backend/src/main.ts`
+
+- [ ] **Step 1: Add the imports**
+
+In `backend/src/main.ts`, after the existing route imports add:
+
+```ts
+import oauthRoutes from './routes/oauth.ts';
+import oauthConsentRoutes from './routes/oauth-consent.ts';
+import wellKnownRoutes from './routes/well-known.ts';
+import { buildMcpRoutes } from './routes/mcp.ts';
+```
+
+- [ ] **Step 2: Mount the routes**
+
+After `app.route('/api', api);`, add:
+
+```ts
+// OAuth 2.1 endpoints (no /api prefix — at the app root per spec)
+app.route('/oauth', oauthRoutes);
+app.route('/oauth', oauthConsentRoutes);
+
+// /.well-known/* metadata
+app.route('/', wellKnownRoutes);
+
+// MCP endpoint (Streamable HTTP) — receives the top-level app so its
+// tools can dispatch back through it via app.fetch.
+app.route('/mcp', buildMcpRoutes(app));
+```
+
+Important: `wellKnownRoutes` defines absolute paths starting with `/.well-known/...`, so we mount it at `/` (no prefix).
+
+- [ ] **Step 3: Run the affected tests end-to-end**
+
+```bash
+cd backend && deno test --allow-all tests/routes/mcp_test.ts tests/routes/oauth_test.ts tests/routes/oauth_consent_test.ts tests/routes/well_known_test.ts tests/mcp/tools_test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Run the full test suite to catch regressions**
+
+```bash
+cd backend && deno task test
+```
+
+Expected: all pre-existing tests still PASS.
+
+- [ ] **Step 5: Lint**
+
+```bash
+cd backend && deno lint
+```
+
+Expected: zero errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/main.ts
+git commit -m "feat(mcp): mount /oauth, /.well-known, and /mcp routes in main app"
+```
+
+---
+
+### Task 20: Frontend login honors `?return_to=`
+
+**Files:**
+- Modify: `frontend/src/pages/Login.tsx`
+- Test: `frontend/tests/Login.test.tsx` (create if absent)
+
+- [ ] **Step 1: Inspect current Login.tsx**
+
+Run:
+
+```bash
+cd frontend && head -80 src/pages/Login.tsx
+```
+
+Note the exact place where, on successful login, the page navigates (likely `navigate('/dashboard')` or similar).
+
+- [ ] **Step 2: Write the failing test**
+
+```tsx
+// frontend/tests/Login.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import Login from '../src/pages/Login';
+
+vi.mock('../src/services/auth', () => ({
+  authService: {
+    getCurrentUser: vi.fn(),
+    getAccessToken: vi.fn(),
+    clearTokens: vi.fn(),
+    login: vi.fn().mockResolvedValue({ user: { id: 1, email: 'a@a.a' } }),
+  },
+}));
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/dashboard" element={<div>DASHBOARD</div>} />
+        <Route path="/oauth/authorize" element={<div>AUTHORIZE</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('Login return_to', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('navigates to return_to on successful login when present', async () => {
+    renderAt('/login?return_to=%2Foauth%2Fauthorize%3Fclient_id%3Dx');
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'a@a.a' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'password' } });
+    fireEvent.click(screen.getByRole('button', { name: /log in|sign in/i }));
+    await waitFor(() => expect(screen.getByText('AUTHORIZE')).toBeTruthy());
+  });
+
+  it('falls back to dashboard when return_to is absent', async () => {
+    renderAt('/login');
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'a@a.a' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'password' } });
+    fireEvent.click(screen.getByRole('button', { name: /log in|sign in/i }));
+    await waitFor(() => expect(screen.getByText('DASHBOARD')).toBeTruthy());
+  });
+});
+```
+
+(The test uses the existing `authService` mock pattern from `CLAUDE.md`. The selectors assume the existing Login renders an email field with label, a password field with label, and a submit button. If labels differ, adjust the test to match the rendered DOM — but **do not** change the test's intent.)
+
+- [ ] **Step 3: Run, verify fail**
+
+```bash
+cd frontend && npm test -- tests/Login.test.tsx
+```
+
+Expected: FAIL — return_to test goes to dashboard instead.
+
+- [ ] **Step 4: Modify Login.tsx to honor return_to**
+
+In `frontend/src/pages/Login.tsx`:
+
+1. Add `useSearchParams` to the `react-router-dom` import.
+2. After `useNavigate` add: `const [searchParams] = useSearchParams();`
+3. Replace the existing post-login navigation (e.g., `navigate('/dashboard')`) with:
+
+```tsx
+const returnTo = searchParams.get('return_to');
+if (returnTo && returnTo.startsWith('/')) {
+  // Only allow same-origin relative paths (defense in depth — backend also validates)
+  navigate(returnTo);
+} else {
+  navigate('/dashboard');
+}
+```
+
+The `startsWith('/')` guard prevents open-redirect via `?return_to=https://evil`.
+
+- [ ] **Step 5: Run, verify pass**
+
+```bash
+cd frontend && npm test -- tests/Login.test.tsx
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 6: Lint**
+
+```bash
+cd frontend && npm run lint
+```
+
+Expected: zero errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/Login.tsx frontend/tests/Login.test.tsx
+git commit -m "feat(oauth): login page honors ?return_to= for OAuth consent flow"
+```
+
+---
+
+## Phase 6 — Critical integration test (tenant isolation)
+
+### Task 21: Tenant isolation through MCP
+
+This is the one test that proves MCP cannot bypass `authMiddleware` — without it the entire "Pattern B" guarantee is unverified.
+
+**Files:**
+- Create: `backend/tests/mcp/tenant_isolation_test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```ts
+// backend/tests/mcp/tenant_isolation_test.ts
+import { assertEquals, assert } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import app from '../../src/main.ts';
+import { userRepository } from '../../src/repositories/user.ts';
+import { tenantRepository } from '../../src/repositories/tenant.ts';
+import { projectRepository } from '../../src/repositories/project.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+import { listProjectsTool } from '../../src/services/mcp/tools/list-projects.ts';
+
+Deno.test('Tenant A cannot see Tenant B projects via MCP', async () => {
+  await setupTestDatabase();
+  await clearDatabase();
+
+  const tenantA = await tenantRepository.create({ name: 'A', is_active: true });
+  const tenantB = await tenantRepository.create({ name: 'B', is_active: true });
+  const userA = await userRepository.create({
+    email: 'a@a.a', password_hash: 'x', role: 'user',
+    full_name: 'A', tenant_id: tenantA.id, is_active: true,
+  });
+
+  await projectRepository.create({ name: 'A-project', customer_name: 'Ax', tenant_id: tenantA.id } as any);
+  await projectRepository.create({ name: 'B-secret', customer_name: 'Bx', tenant_id: tenantB.id } as any);
+
+  const tokenA = await generateToken(userA.id, userA.email, userA.role, userA.tenant_id);
+  const result = await listProjectsTool.handler({ query: undefined }, { app, accessToken: tokenA });
+
+  assertEquals(result.isError, undefined);
+  const text = result.content[0].text;
+  assert(text.includes('A-project'), 'must include own-tenant project');
+  assert(!text.includes('B-secret'), 'must NOT include other-tenant project');
+});
+```
+
+- [ ] **Step 2: Run, verify pass**
+
+```bash
+cd backend && deno test --allow-all tests/mcp/tenant_isolation_test.ts
+```
+
+Expected: PASS. If it fails — the route is not enforcing tenant scoping when called via app.fetch, which is a critical bug. Fix before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/tests/mcp/tenant_isolation_test.ts
+git commit -m "test(mcp): verify tenant isolation through MCP tool dispatch"
+```
+
+---
+
+## Phase 7 — Final verification
+
+### Task 22: Full backend + frontend lint and test
+
+- [ ] **Step 1: Run full backend test suite**
+
+```bash
+cd backend && deno task test
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Run full frontend test suite**
+
+```bash
+cd frontend && npm run test:run
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Lint both**
+
+```bash
+cd backend && deno lint && cd ../frontend && npm run lint
+```
+
+Expected: zero errors on both.
+
+- [ ] **Step 4: Build frontend (catches TS errors)**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: clean build.
+
+- [ ] **Step 5: Commit if any lint fixes were needed**
+
+(No commit needed if everything was clean.)
+
+---
+
+### Task 23: Manual end-to-end smoke test (documented checklist, not automated)
+
+This is performed by the user/operator after deployment. The plan does not execute it.
+
+- [ ] Deploy to the public host.
+- [ ] In Claude.ai, go to Settings → Connectors → Add custom connector. Paste `https://<your-host>/mcp`.
+- [ ] Complete the OAuth flow: redirect to SnapFlow login → log in → consent screen shows "Allow Claude" → click Allow → redirected back to Claude.ai.
+- [ ] In a new Claude.ai chat: "List my SnapFlow projects." Verify the response.
+- [ ] Try "What's the total for project X?" Verify.
+- [ ] Try "Search the catalog for smart switch." Verify.
+- [ ] Repeat the connector setup in Claude Desktop and Claude Code with the same URL. Verify each one runs through OAuth independently and works.
+
+---
+
+## Self-Review
+
+- [ ] **Spec coverage**: every section of `docs/superpowers/specs/2026-05-15-mcp-remote-server-design.md` is covered:
+  - Architecture (Tasks 13, 18, 19)
+  - Request dispatch pattern (Tasks 13, 14-17)
+  - File layout (Tasks 1-21)
+  - OAuth endpoints — metadata (Task 6), DCR (Task 7), authorize (Task 9), consent (Task 10), token+code (Task 11), token+refresh (Task 12)
+  - Browser session bridge (Task 8, Task 20)
+  - Database (Task 1)
+  - MCP tool surface — list_projects (14), get_project (15), get_project_total (16), search_items (17)
+  - Tool response shape (each tool task)
+  - Error handling — OAuth error JSON (Tasks 11, 12), MCP 401 with WWW-Authenticate (Task 18), tool isError (each tool task)
+  - Testing — OAuth tests (Tasks 7, 9, 10, 11, 12), MCP tests (14-18), tenant isolation (Task 21), frontend test (Task 20), manual smoke (Task 23)
+  - Dependencies (Task 18 step 1)
+  - Security considerations are encoded in tests (PKCE verify in 4 and 11; reused-code rejection in 11; rotation in 12; tenant isolation in 21)
+
+- [ ] **Placeholder scan**: searched for "TBD", "TODO", "implement later", "similar to" — none present. `zodToJsonSchema` returns `{ type: 'object' }` deliberately for v0 and is documented as a roadmap item in the code comment, not a placeholder.
+
+- [ ] **Type consistency**: `ToolContext` and `ToolResult` are defined in Task 14 (`list-projects.ts`) and imported by Tasks 15, 16, 17. Tool names match between the registry in `server.ts` (Task 18) and the tests in Task 18 (`names.sort()` check). The `dispatchToBackend` signature is consistent across all tool tasks.
+
+- [ ] **Refresh token TTL**: spec said 30 days; existing code uses 7. Plan adopts 7 to match existing infra; spec comment in Task 11 notes the deviation.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-15-mcp-remote-server.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-15-mcp-remote-server-design.md
+++ b/docs/superpowers/specs/2026-05-15-mcp-remote-server-design.md
@@ -1,0 +1,377 @@
+# Remote MCP Server for SnapFlow — Design
+
+**Status:** Approved (brainstorming complete, awaiting user review before implementation plan)
+**Date:** 2026-05-15
+**Scope:** v0 — read-only
+
+## Overview
+
+Add a Model Context Protocol (MCP) server to SnapFlow so that MCP-compatible clients
+(Claude.ai web, Claude Desktop, Claude Code, etc.) can read project, total, and
+catalog data through a user-friendly OAuth login. The server lives inside the
+existing Hono backend; no new service, no third-party auth provider.
+
+A user adds `https://<snapflow-host>/mcp` as a custom connector in their MCP
+client once, logs in via the standard SnapFlow login, approves a consent screen,
+and from that point the MCP tools are available in every chat without further
+setup.
+
+## Goals
+
+- One-time OAuth setup per user, then the connector "just works"
+- Spec-compliant remote MCP — usable from Claude.ai, Claude Desktop, Claude Code,
+  and any other MCP client that implements OAuth 2.1 with Dynamic Client
+  Registration
+- Reuse the existing JWT/user/tenant model; no duplicate identity store
+- MCP tool calls are indistinguishable from frontend API calls at the
+  business-logic layer (same routes, same middleware, same validation, same
+  tenant scoping)
+
+## Non-Goals (v0)
+
+- Write operations (create/update/delete) — read only for v0
+- File uploads (floorplan images, Excel imports)
+- Placement-on-canvas operations (deferred until area-anchored placement is
+  designed)
+- Admin operations (catalog management, user management)
+- Multi-tenant tenant switching during one MCP session (a user is bound to the
+  tenant their JWT carries)
+
+## Architecture
+
+```
+                       ┌──────────────────────────────────────────┐
+                       │   Hono app (one process, one deploy)     │
+                       │                                          │
+  React frontend ──────┼──▶  /api/projects   ──┐                  │
+  (Bearer JWT from     │    /api/items       ──┤                  │
+   /api/auth/login)    │    /api/floorplans  ──┤                  │
+                       │    ...              ──┤                  │
+                       │                       ├──▶  projectRepo  │
+                       │                       │    itemRepo      │──▶ SQLite
+                       │                       │    floorplanRepo │
+                       │                       │    ...           │
+  MCP client ──────────┼──▶  /mcp            ──┘                  │
+  (Bearer JWT from     │    /oauth/*  (new OAuth flow)            │
+   OAuth flow)         │    /.well-known/oauth-*                  │
+                       └──────────────────────────────────────────┘
+```
+
+Two new entry points (`/mcp` and `/oauth/*`) sit on top of the existing
+repositories and middleware. The MCP layer is a translation layer — it speaks
+MCP protocol on the outside and dispatches to existing REST routes internally.
+
+### Request dispatch pattern (critical)
+
+MCP tools do **not** call repositories directly. Each tool builds an internal
+`Request` object and dispatches it through the same Hono app via `app.fetch`:
+
+```ts
+const url = new URL('http://internal/api/projects')
+if (args.query) url.searchParams.set('search', args.query)
+const res = await app.fetch(new Request(url, {
+  headers: { Authorization: `Bearer ${ctx.accessToken}` }
+}))
+```
+
+This guarantees that:
+
+- All route-level Zod validation runs
+- All middleware runs (auth, role checks, tenant scoping)
+- All cascade/business logic in route handlers runs
+- All side effects fire
+- Future changes to routes automatically apply to MCP — no "remember to update
+  the MCP tool" footgun
+
+`app.fetch` is Hono's standard execution model (Deno.serve uses it for every
+real request). Performance overhead is negligible — no network, no socket.
+
+## File Layout
+
+New files under `backend/src/`:
+
+```
+routes/
+  oauth.ts              # OAuth 2.1 endpoints + DCR + metadata
+  mcp.ts                # /mcp Streamable HTTP endpoint
+  oauth-consent.ts      # HTML consent page (GET + POST)
+
+services/
+  oauth/
+    clients.ts          # Register/lookup OAuth clients
+    auth-codes.ts       # Issue/consume auth codes (with PKCE verify)
+    metadata.ts         # Builds the two metadata JSON docs
+
+  mcp/
+    server.ts           # MCP Server instance + tool registration
+    context.ts          # Bridges Hono context → MCP tool context
+    tools/
+      list-projects.ts
+      get-project.ts
+      get-project-total.ts
+      search-items.ts
+
+repositories/
+  oauth-client-repo.ts
+  oauth-code-repo.ts
+
+scripts/migrations/
+  NNN_oauth_clients.sql
+```
+
+Modified files:
+
+- `main.ts` — mount `oauthRoutes` at `/oauth`, `mcpRoutes` at `/mcp`, plus two
+  metadata endpoints under `/.well-known/`
+- `middleware/auth.ts` — unchanged; MCP route uses existing `authMiddleware`
+  as-is
+
+## OAuth 2.1 Design
+
+### Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/.well-known/oauth-authorization-server` | Authorization server metadata (RFC 8414) |
+| GET | `/.well-known/oauth-protected-resource` | Protected resource metadata (RFC 9728) |
+| POST | `/oauth/register` | Dynamic Client Registration (RFC 7591) |
+| GET | `/oauth/authorize` | Start authorization flow → redirect to login or consent |
+| POST | `/oauth/consent` | User clicks Allow → issue auth code, redirect to client |
+| POST | `/oauth/token` | Exchange code or refresh token for access token |
+
+Supported features:
+
+- Grant types: `authorization_code`, `refresh_token`
+- PKCE required (`S256`)
+- Token format: JWT (reuses existing JWT signing key and claim shape)
+- Access token TTL: 15 minutes (matches existing JWT TTL)
+- Refresh token: opaque, stored in existing `refresh_tokens` table, 30-day TTL,
+  rotated on every refresh
+
+### Browser session bridge
+
+The existing SnapFlow frontend uses Bearer JWT in the `Authorization` header,
+not cookies. The OAuth consent page is a browser navigation, so it needs a way
+to identify the logged-in user. The bridge:
+
+- The OAuth `/oauth/authorize` route checks for a short-lived `oauth_session`
+  cookie (HTTP-only, Secure, SameSite=Lax)
+- If absent, redirects the browser to the existing frontend login page with
+  `?return_to=<original /oauth/authorize URL>`
+- The backend's `POST /api/auth/login` route sets the `oauth_session` cookie
+  via a `Set-Cookie` header in its response (in addition to returning the JWT
+  in the response body). The cookie is set unconditionally; it's only ever
+  used by the OAuth flow.
+- The frontend login page reads the `return_to` query parameter on successful
+  login and navigates to it instead of the dashboard
+
+Frontend impact: only the login page's post-success redirect logic. No other
+frontend changes. The regular API still uses Bearer JWT exclusively; the
+cookie is *only* read by `/oauth/authorize` and `/oauth/consent`.
+
+### End-to-end flow
+
+1. User pastes `https://<snapflow-host>/mcp` into their MCP client's connector
+   settings.
+2. Client fetches `/.well-known/oauth-protected-resource` → discovers auth
+   server URL.
+3. Client fetches `/.well-known/oauth-authorization-server` → discovers
+   endpoints.
+4. Client POSTs `/oauth/register` → receives `client_id`.
+5. Client opens a browser to `/oauth/authorize?client_id=...&redirect_uri=...&code_challenge=...&...`.
+6. User logs in (if not already) → consent page shows
+   "Allow Claude to access SnapFlow as <email>".
+7. User clicks Allow → backend issues auth code (60s TTL), redirects to
+   `redirect_uri?code=...&state=...`.
+8. Client POSTs `/oauth/token` with `code` + `code_verifier` → verifies PKCE,
+   issues access JWT + refresh token.
+9. Client calls `/mcp` with `Authorization: Bearer <access_token>` → tools run
+   as that user.
+10. On token expiry: client POSTs `/oauth/token` with refresh token → new pair.
+
+### Database
+
+Two new tables (one migration):
+
+```sql
+CREATE TABLE oauth_clients (
+  id            TEXT PRIMARY KEY,            -- client_id
+  client_secret TEXT,                        -- optional, hashed
+  redirect_uris TEXT NOT NULL,               -- JSON array
+  client_name   TEXT,
+  created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE oauth_auth_codes (
+  code           TEXT PRIMARY KEY,
+  client_id      TEXT NOT NULL REFERENCES oauth_clients(id) ON DELETE CASCADE,
+  user_id        INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  redirect_uri   TEXT NOT NULL,
+  code_challenge TEXT NOT NULL,
+  scope          TEXT,
+  expires_at     TIMESTAMP NOT NULL,
+  consumed_at    TIMESTAMP
+);
+
+CREATE INDEX idx_oauth_codes_expires ON oauth_auth_codes(expires_at);
+```
+
+The existing `refresh_tokens` table is reused unchanged. The hourly cleanup job
+in `main.ts` extends to also delete expired/consumed auth codes.
+
+## MCP Tool Surface (v0)
+
+Four read-only tools. Each is a thin wrapper around an existing REST route via
+`app.fetch`. Schemas are validated with Zod (consistent with route validation).
+
+### `list_projects`
+
+- **Description**: "List SnapFlow projects in your workspace. Returns id, name,
+  customer name, status, creation date. Use `query` to filter by name."
+- **Input**: `{ query?: string }`
+- **Dispatches**: `GET /api/projects?search={query}`
+
+### `get_project`
+
+- **Description**: "Get full details for a single SnapFlow project — customer
+  info, floorplans, BOM entries."
+- **Input**: `{ project_id: number }`
+- **Dispatches**: `GET /api/projects/{project_id}`
+
+### `get_project_total`
+
+- **Description**: "Get the itemized total/pricing summary for a project — list
+  price, discounts, tax, grand total."
+- **Input**: `{ project_id: number }`
+- **Dispatches**: `GET /api/projects/{project_id}/total`
+
+### `search_items`
+
+- **Description**: "Search the SnapFlow product catalog. Filter by name,
+  category, or item type."
+- **Input**: `{ query?: string, category_id?: number, type_id?: number, limit?: number }`
+  (limit defaults to 20, max 100)
+- **Dispatches**: `GET /api/items?search=...&category_id=...&type_id=...&limit=...`
+
+### Tool response shape
+
+Each tool returns an MCP content block:
+
+```ts
+{ content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] }
+```
+
+On underlying route error:
+
+```ts
+{ isError: true, content: [{ type: 'text', text: 'Failed to ...: <message>' }] }
+```
+
+Tools never throw — errors propagate as MCP errors so the LLM can recover.
+
+## Error Handling
+
+Three failure layers, each handled distinctly:
+
+1. **OAuth errors**: standard OAuth 2.1 JSON responses (`{ error, error_description }`)
+   with appropriate HTTP status. Lets MCP clients trigger re-auth on
+   `invalid_grant`.
+2. **MCP transport errors** (missing/invalid bearer): `401` with a
+   `WWW-Authenticate: Bearer resource_metadata="..."` header so the client can
+   discover where to re-authenticate.
+3. **Tool execution errors**: caught inside the tool, returned as
+   `{ isError: true, content: ... }`. Never throw out of a tool handler.
+
+## Testing Strategy
+
+Following existing backend test conventions (Deno test, in-memory SQLite from
+`tests/test-utils.ts`).
+
+### OAuth endpoint tests (`backend/tests/routes/oauth_test.ts`)
+
+- Happy path: register client → authorize → consent → token exchange (with
+  PKCE) → token authorizes `/mcp` requests
+- Failure paths: wrong PKCE verifier, expired code, reused code, wrong
+  redirect_uri, invalid/revoked refresh token
+- Refresh token rotation: refreshing invalidates the old refresh token
+- Metadata documents are valid JSON conforming to RFC 8414 and RFC 9728
+
+### MCP tool tests (`backend/tests/mcp/tools_test.ts`)
+
+- Each of the 4 tools called with a real JWT → response matches the equivalent
+  REST call
+- **Tenant isolation test**: a tool called with tenant-A's JWT cannot see
+  tenant-B's data. This is the test that proves `app.fetch` is genuinely going
+  through `authMiddleware` and not bypassing it.
+- Tool error response: when underlying route returns 404, tool returns
+  `isError: true` (not a thrown exception)
+
+### Frontend test
+
+One small test for the login page: navigates to `return_to` on successful
+login when the query parameter is present, falls back to the dashboard
+otherwise. Target test suite depends on whether v0 wires up `frontend/` or
+`frontend-v2/` (see Open Questions).
+
+### Manual end-to-end smoke test
+
+Documented as a checklist in the implementation plan:
+
+1. Deploy to public host
+2. Paste `https://<host>/mcp` into Claude.ai connector settings
+3. Walk through OAuth login + consent
+4. Ask Claude "list my projects" → verify expected data returned
+5. Repeat from Claude Desktop and Claude Code → confirm one OAuth flow handles
+   all three clients
+
+## Dependencies
+
+- `@modelcontextprotocol/sdk` (TypeScript SDK, npm) — imported via Deno's
+  `npm:` specifier, consistent with how `hono`, `zod`, `xlsx`, `sharp` are
+  already imported
+- No new runtime dependencies for OAuth — built on existing `djwt`, `zod`, and
+  Web Crypto APIs
+
+## Security Considerations
+
+- **PKCE required**: prevents authorization code interception
+- **Auth code TTL is 60 seconds**, single-use
+- **Refresh token rotation**: each refresh invalidates the previous token
+- **Tenant scoping is enforced at the route layer**, not the MCP layer —
+  bypassing the MCP layer (e.g., via stolen access token) hits the same auth
+  middleware as the React app, so there is no additional attack surface
+- **DCR is unrestricted by design**: any client can register, but this only
+  yields a `client_id`, which is useless without a user completing the consent
+  flow. The user is always in the loop for granting access to their data.
+- **Bearer JWTs are short-lived (15 min)**: stolen access tokens have minimal
+  lifetime; refresh tokens can be revoked via existing token table
+
+## Open Questions / Future Work
+
+- **Frontend target**: the repo has both `frontend/` and `frontend-v2/`. The
+  small login-page change needs to land in whichever is the active surface for
+  user logins. To be confirmed before implementation.
+- **Scope claims**: v0 uses a single implicit scope ("read"). Future writes
+  will introduce explicit scopes (e.g., `projects:read`, `projects:write`) so
+  users can grant read-only access without write capability.
+- **Per-client revocation UI**: deferred. v0 relies on user revoking the refresh
+  token (no UI yet). Add an admin/profile page later.
+- **Rate limiting on `/mcp`**: deferred. Tools dispatch to existing routes that
+  already have per-route rate limiting; the MCP layer itself doesn't add limits
+  yet.
+- **Audit log**: deferred. The existing logger captures all REST calls
+  (including MCP-dispatched ones) by virtue of going through `app.fetch`, so
+  basic auditing exists.
+
+## Acceptance Criteria
+
+v0 is complete when:
+
+1. A new SnapFlow user can paste `https://<host>/mcp` into Claude.ai's connector
+   UI, complete OAuth login + consent, and see the 4 tools appear in a chat.
+2. Asking Claude "list my projects" returns the user's projects, scoped to
+   their tenant.
+3. The same flow works in Claude Desktop and Claude Code from the same OAuth
+   registration.
+4. All new tests pass; existing tests are unaffected.
+5. `deno lint` and `npm run lint` pass.

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '@/context/AuthContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -17,6 +17,7 @@ const Login = () => {
   
   const { login } = useAuth();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -25,7 +26,13 @@ const Login = () => {
 
     try {
       await login(email, password);
-      navigate('/');
+      const returnTo = searchParams.get('return_to');
+      if (returnTo && returnTo.startsWith('/')) {
+        // Only allow same-origin relative paths to prevent open-redirect via ?return_to=https://evil
+        navigate(returnTo);
+      } else {
+        navigate('/');
+      }
     } catch (err: unknown) {
       const errorMessage = extractErrorMessage(err) || 'Invalid email or password';
       setError(errorMessage);

--- a/frontend/tests/Login.test.tsx
+++ b/frontend/tests/Login.test.tsx
@@ -10,13 +10,15 @@ vi.mock('@/context/AuthContext', () => ({
   useAuth: vi.fn(),
 }));
 
-// Mock useNavigate
+// Mock useNavigate and useSearchParams
 const mockNavigate = vi.fn();
+let mockSearchParams = new URLSearchParams();
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
   return {
     ...actual,
     useNavigate: () => mockNavigate,
+    useSearchParams: () => [mockSearchParams, vi.fn()],
   };
 });
 
@@ -25,6 +27,7 @@ describe('Login', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (useAuth as any).mockReturnValue({ login: mockLogin });
   });
@@ -244,5 +247,43 @@ describe('Login', () => {
     const passwordInput = screen.getByLabelText('Password');
     expect(passwordInput).toHaveAttribute('type', 'password');
     expect(passwordInput).toBeRequired();
+  });
+
+  it('navigates to return_to on successful login when present', async () => {
+    mockLogin.mockResolvedValueOnce(undefined);
+    mockSearchParams = new URLSearchParams('return_to=%2Foauth%2Fauthorize%3Fclient_id%3Dx');
+
+    render(
+      <BrowserRouter>
+        <Login />
+      </BrowserRouter>
+    );
+
+    await userEvent.type(screen.getByLabelText('Email'), 'a@a.a');
+    await userEvent.type(screen.getByLabelText('Password'), 'password');
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/oauth/authorize?client_id=x');
+    });
+  });
+
+  it('falls back to home when return_to is absent', async () => {
+    mockLogin.mockResolvedValueOnce(undefined);
+    // mockSearchParams stays empty (no return_to)
+
+    render(
+      <BrowserRouter>
+        <Login />
+      </BrowserRouter>
+    );
+
+    await userEvent.type(screen.getByLabelText('Email'), 'a@a.a');
+    await userEvent.type(screen.getByLabelText('Password'), 'password');
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds a spec-compliant remote MCP (Model Context Protocol) server so users can connect SnapFlow from Claude.ai (and Claude Desktop / Claude Code) via a one-time OAuth login, then read project & catalog data through the LLM.

- **OAuth 2.1 authorization server** built on existing JWT/user/tenant infra (no third-party provider): DCR + authorize + consent (HTML) + token (code & refresh grants with PKCE S256, refresh-token rotation, signed `oauth_session` cookie bridge for the browser consent step)
- **4 read-only MCP tools** at `/mcp` (Streamable HTTP): `list_projects`, `get_project`, `get_project_total`, `search_items`
- **"Pattern B" dispatch**: tools call existing REST routes in-process via `app.fetch` — same middleware, same Zod validation, same tenant scoping. Cross-tenant isolation is verified by a dedicated test (`tenant_isolation_test.ts`).
- **Frontend**: login page honors `?return_to=` so the OAuth consent flow returns the user to `/oauth/authorize`. Open-redirect guard (`startsWith('/')`).
- **Production-ready deployment glue**: `/.well-known/oauth-*` metadata endpoints; `WWW-Authenticate: Bearer resource_metadata="..."` on both missing AND invalid bearers; `publicBaseUrl()` helper honoring `X-Forwarded-Proto`/`X-Forwarded-Host` (and `PUBLIC_BASE_URL` env override) so URLs work behind HTTPS proxies.
- **DB**: one new migration (`038_oauth_clients`) with `oauth_clients` + `oauth_auth_codes`. Refresh tokens reuse existing `refresh_tokens` table. Hourly cleanup extended to also delete expired/consumed codes.

Design doc: `docs/superpowers/specs/2026-05-15-mcp-remote-server-design.md`
Implementation plan: `docs/superpowers/plans/2026-05-15-mcp-remote-server.md`

Out of scope for v0 (deferred): write operations, placements/areas/file uploads, admin operations, per-client revocation UI, explicit scopes.

## Test Plan

### Automated (already green on this branch)
- [x] Backend: 305 tests pass (`cd backend && deno task test`)
- [x] Frontend: 264 tests pass (`cd frontend && npm run test:run`)
- [x] Backend lint clean (`deno lint`)
- [x] Frontend lint clean (`npm run lint`)
- [x] Frontend production build clean (`npm run build`)
- [x] Tenant isolation: tenant A's MCP tool cannot see tenant B's projects (`backend/tests/mcp/tenant_isolation_test.ts`)
- [x] PKCE: known RFC 7636 pair verifies; wrong verifier rejected; reused code rejected
- [x] Refresh-token rotation: old token invalidated on use
- [x] Cookie tamper detection deterministic (mid-signature flip, not last char)

### Manual (after deploy)
- [ ] Add `https://<host>/mcp` as a custom connector in Claude.ai
- [ ] Walk through OAuth: login redirect → consent screen → redirected back to Claude.ai
- [ ] In a chat: "List my SnapFlow projects" returns this user's projects only
- [ ] In a chat: "What's the total for project X?" returns the itemized total
- [ ] In a chat: "Search the catalog for switch" returns matching items
- [ ] Repeat connector setup in Claude Desktop with the same URL — single OAuth re-flow, tools work
- [ ] Repeat in Claude Code — same

### Production readiness notes
- Behind a reverse proxy: requires `X-Forwarded-Proto`/`X-Forwarded-Host` to be forwarded, OR set `PUBLIC_BASE_URL=https://yourhost` env var.
- Refresh token TTL is 7 days (matches existing infra; spec mentioned 30 — adopted 7 for consistency).
- `tools/list` returns `inputSchema: { type: 'object' }` for all tools as a minimal JSON Schema; Zod still validates `tools/call` arguments. A real Zod→JSON-Schema converter is a follow-up if it matters in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)