### PR TITLE
feat(mcp): cluster A — deeper read tools (floorplans, BOM, areas, invoice)

### DIFF
--- a/backend/src/services/mcp/server.ts
+++ b/backend/src/services/mcp/server.ts
@@ -3,9 +3,22 @@ import { listProjectsTool } from './tools/list-projects.ts';
 import { getProjectTool } from './tools/get-project.ts';
 import { getVersionTotalTool } from './tools/get-version-total.ts';
 import { searchItemsTool } from './tools/search-items.ts';
+import { listFloorplansTool } from './tools/list-floorplans.ts';
+import { getFloorplanBomTool } from './tools/get-floorplan-bom.ts';
+import { listAreasTool } from './tools/list-areas.ts';
+import { getInvoiceCalculationTool } from './tools/get-invoice-calculation.ts';
 import { zodToJsonSchema } from './zod-to-json-schema.ts';
 
-const allTools = [listProjectsTool, getProjectTool, getVersionTotalTool, searchItemsTool];
+const allTools = [
+  listProjectsTool,
+  getProjectTool,
+  getVersionTotalTool,
+  searchItemsTool,
+  listFloorplansTool,
+  getFloorplanBomTool,
+  listAreasTool,
+  getInvoiceCalculationTool,
+];
 
 export interface JsonRpcRequest {
   jsonrpc: '2.0';

--- a/backend/src/services/mcp/tools/get-floorplan-bom.ts
+++ b/backend/src/services/mcp/tools/get-floorplan-bom.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { dispatchToBackend } from '../dispatcher.ts';
+import type { ToolContext, ToolResult } from './list-projects.ts';
+
+const inputSchema = z.object({
+  floorplan_id: z.number().int().positive(),
+});
+
+export const getFloorplanBomTool = {
+  name: 'get_floorplan_bom',
+  description:
+    'Get the bill of materials (items placed) for a single floorplan — each entry includes the item name, variant (if any), quantity, and unit price at placement time. Pass a floorplan_id from list_floorplans.',
+  inputSchema,
+  handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
+    const result = await dispatchToBackend(ctx.app, {
+      method: 'GET',
+      path: `/api/floorplans/${args.floorplan_id}/bom`,
+      accessToken: ctx.accessToken,
+    });
+    if (!result.ok) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to get BOM for floorplan ${args.floorplan_id} (HTTP ${result.status}): ${JSON.stringify(result.body)}` }],
+      };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(result.body.data, null, 2) }] };
+  },
+};

--- a/backend/src/services/mcp/tools/get-invoice-calculation.ts
+++ b/backend/src/services/mcp/tools/get-invoice-calculation.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { dispatchToBackend } from '../dispatcher.ts';
+import type { ToolContext, ToolResult } from './list-projects.ts';
+
+const inputSchema = z.object({
+  version_id: z.number().int().positive(),
+});
+
+export const getInvoiceCalculationTool = {
+  name: 'get_invoice_calculation',
+  description:
+    'Get the full itemized invoice calculation for a project version — list price, discount (percentage and absolute), services charge, subtotal, tax, grand total, and currency conversion if applicable. More detailed than get_version_total. Pass a version_id.',
+  inputSchema,
+  handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
+    const result = await dispatchToBackend(ctx.app, {
+      method: 'GET',
+      path: `/api/projects/${args.version_id}/invoice-calculation`,
+      accessToken: ctx.accessToken,
+    });
+    if (!result.ok) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to get invoice calculation for version ${args.version_id} (HTTP ${result.status}): ${JSON.stringify(result.body)}` }],
+      };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(result.body.data, null, 2) }] };
+  },
+};

--- a/backend/src/services/mcp/tools/list-areas.ts
+++ b/backend/src/services/mcp/tools/list-areas.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { dispatchToBackend } from '../dispatcher.ts';
+import type { ToolContext, ToolResult } from './list-projects.ts';
+
+const inputSchema = z.object({
+  floorplan_id: z.number().int().positive(),
+});
+
+export const listAreasTool = {
+  name: 'list_areas',
+  description:
+    'List the named areas/zones (e.g., "Kitchen", "Living Room") defined on a floorplan. Each area has an id, name, and polygon coordinates. Useful for future placement operations where you want to target a specific room.',
+  inputSchema,
+  handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
+    const result = await dispatchToBackend(ctx.app, {
+      method: 'GET',
+      path: '/api/areas',
+      query: { floorplan_id: args.floorplan_id },
+      accessToken: ctx.accessToken,
+    });
+    if (!result.ok) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to list areas for floorplan ${args.floorplan_id} (HTTP ${result.status}): ${JSON.stringify(result.body)}` }],
+      };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(result.body.data, null, 2) }] };
+  },
+};

--- a/backend/src/services/mcp/tools/list-floorplans.ts
+++ b/backend/src/services/mcp/tools/list-floorplans.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { dispatchToBackend } from '../dispatcher.ts';
+import type { ToolContext, ToolResult } from './list-projects.ts';
+
+const inputSchema = z.object({
+  version_id: z.number().int().positive(),
+});
+
+export const listFloorplansTool = {
+  name: 'list_floorplans',
+  description:
+    'List the floorplans (e.g., "Ground Floor", "Upstairs") in a specific project version. Pass a version_id from a project\'s versions array (returned by list_projects or get_project).',
+  inputSchema,
+  handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
+    const result = await dispatchToBackend(ctx.app, {
+      method: 'GET',
+      path: '/api/floorplans',
+      query: { project_id: args.version_id },
+      accessToken: ctx.accessToken,
+    });
+    if (!result.ok) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to list floorplans for version ${args.version_id} (HTTP ${result.status}): ${JSON.stringify(result.body)}` }],
+      };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(result.body.data, null, 2) }] };
+  },
+};

--- a/backend/tests/mcp/tools_test.ts
+++ b/backend/tests/mcp/tools_test.ts
@@ -5,13 +5,19 @@ import { userRepository } from '../../src/repositories/user.ts';
 import { tenantRepository } from '../../src/repositories/tenant.ts';
 import { projectRepository } from '../../src/repositories/project.ts';
 import { itemRepository } from '../../src/repositories/item.ts';
+import { floorplanRepository } from '../../src/repositories/floorplan.ts';
+import { areaRepository } from '../../src/repositories/area.ts';
 import { generateToken } from '../../src/services/jwt.ts';
-import type { CreateTenantDTO, CreateUserDTO, CreateProjectDTO } from '../../src/models/index.ts';
+import type { CreateTenantDTO, CreateUserDTO, CreateProjectDTO, CreateFloorplanDTO, CreateAreaDTO } from '../../src/models/index.ts';
 import type { TenantContext } from '../../src/repositories/user.ts';
 import { listProjectsTool } from '../../src/services/mcp/tools/list-projects.ts';
 import { getProjectTool } from '../../src/services/mcp/tools/get-project.ts';
 import { getVersionTotalTool } from '../../src/services/mcp/tools/get-version-total.ts';
 import { searchItemsTool } from '../../src/services/mcp/tools/search-items.ts';
+import { listFloorplansTool } from '../../src/services/mcp/tools/list-floorplans.ts';
+import { getFloorplanBomTool } from '../../src/services/mcp/tools/get-floorplan-bom.ts';
+import { listAreasTool } from '../../src/services/mcp/tools/list-areas.ts';
+import { getInvoiceCalculationTool } from '../../src/services/mcp/tools/get-invoice-calculation.ts';
 import { projectGroupRepository } from '../../src/repositories/project-group.ts';
 
 async function seedUserWithProjects() {
@@ -152,5 +158,173 @@ Deno.test('search_items tool', async (t) => {
 
     const result = await searchItemsTool.handler({ limit: 5 }, { app, accessToken: token });
     assertEquals(result.isError, undefined);
+  });
+});
+
+Deno.test('list_floorplans tool', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns floorplans for a valid version_id', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
+    const user = await userRepository.create({
+      email: 'listfp@example.com', password_hash: 'x', role: 'user',
+      full_name: 'L', tenant_id: tenant.id,
+    } as CreateUserDTO & { password_hash: string });
+    const project = await projectRepository.create({
+      version_name: 'v1', customer_name: 'FP Customer', tenant_id: tenant.id,
+    } as CreateProjectDTO);
+    await floorplanRepository.create({
+      project_id: project.id, name: 'Ground Floor', image_path: 'test.png',
+    } as CreateFloorplanDTO);
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    const result = await listFloorplansTool.handler({ version_id: project.id }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    assert(result.content[0].text.includes('Ground Floor'));
+  });
+
+  await t.step('returns empty array when version has no floorplans', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
+    const user = await userRepository.create({
+      email: 'listfp2@example.com', password_hash: 'x', role: 'user',
+      full_name: 'L', tenant_id: tenant.id,
+    } as CreateUserDTO & { password_hash: string });
+    const project = await projectRepository.create({
+      version_name: 'v1', customer_name: 'Empty FP Customer', tenant_id: tenant.id,
+    } as CreateProjectDTO);
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    const result = await listFloorplansTool.handler({ version_id: project.id }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    // Should return an empty array (serialized as "[]")
+    assert(result.content[0].text.includes('[]'));
+  });
+
+  await t.step('returns isError on bad auth', async () => {
+    await clearDatabase();
+    const result = await listFloorplansTool.handler({ version_id: 1 }, { app, accessToken: 'bad' });
+    assertEquals(result.isError, true);
+  });
+});
+
+Deno.test('get_floorplan_bom tool', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns BOM for a valid floorplan_id (empty BOM)', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
+    const user = await userRepository.create({
+      email: 'getbom@example.com', password_hash: 'x', role: 'user',
+      full_name: 'B', tenant_id: tenant.id,
+    } as CreateUserDTO & { password_hash: string });
+    const project = await projectRepository.create({
+      version_name: 'v1', customer_name: 'BOM Customer', tenant_id: tenant.id,
+    } as CreateProjectDTO);
+    const floorplan = await floorplanRepository.create({
+      project_id: project.id, name: 'Main Floor', image_path: 'test.png',
+    } as CreateFloorplanDTO);
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    const result = await getFloorplanBomTool.handler({ floorplan_id: floorplan.id }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    // Empty BOM returns an empty array
+    assert(result.content[0].text.length > 0);
+  });
+
+  await t.step('returns isError for unknown floorplan_id', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
+    const user = await userRepository.create({
+      email: 'getbom2@example.com', password_hash: 'x', role: 'user',
+      full_name: 'B', tenant_id: tenant.id,
+    } as CreateUserDTO & { password_hash: string });
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    const result = await getFloorplanBomTool.handler({ floorplan_id: 999999 }, { app, accessToken: token });
+    assertEquals(result.isError, true);
+  });
+});
+
+Deno.test('list_areas tool', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns areas for a valid floorplan_id', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
+    const user = await userRepository.create({
+      email: 'listareas@example.com', password_hash: 'x', role: 'user',
+      full_name: 'A', tenant_id: tenant.id,
+    } as CreateUserDTO & { password_hash: string });
+    const project = await projectRepository.create({
+      version_name: 'v1', customer_name: 'Area Customer', tenant_id: tenant.id,
+    } as CreateProjectDTO);
+    const floorplan = await floorplanRepository.create({
+      project_id: project.id, name: 'Ground Floor', image_path: 'test.png',
+    } as CreateFloorplanDTO);
+    await areaRepository.create({
+      floorplan_id: floorplan.id, x: 10, y: 20, width: 100, height: 80, name: 'Kitchen',
+    } as CreateAreaDTO);
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    const result = await listAreasTool.handler({ floorplan_id: floorplan.id }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    assert(result.content[0].text.includes('Kitchen'));
+  });
+
+  await t.step('returns empty array when floorplan has no areas', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
+    const user = await userRepository.create({
+      email: 'listareas2@example.com', password_hash: 'x', role: 'user',
+      full_name: 'A', tenant_id: tenant.id,
+    } as CreateUserDTO & { password_hash: string });
+    const project = await projectRepository.create({
+      version_name: 'v1', customer_name: 'Area Customer 2', tenant_id: tenant.id,
+    } as CreateProjectDTO);
+    const floorplan = await floorplanRepository.create({
+      project_id: project.id, name: 'Ground Floor', image_path: 'test.png',
+    } as CreateFloorplanDTO);
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    const result = await listAreasTool.handler({ floorplan_id: floorplan.id }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    assert(result.content[0].text.includes('[]'));
+  });
+});
+
+Deno.test('get_invoice_calculation tool', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns invoice calculation for a valid version_id', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
+    const user = await userRepository.create({
+      email: 'getinvoice@example.com', password_hash: 'x', role: 'user',
+      full_name: 'I', tenant_id: tenant.id,
+    } as CreateUserDTO & { password_hash: string });
+    const project = await projectRepository.create({
+      version_name: 'v1', customer_name: 'Invoice Customer', tenant_id: tenant.id,
+    } as CreateProjectDTO);
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    const result = await getInvoiceCalculationTool.handler({ version_id: project.id }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    // Should contain numeric totals even for an empty BOM
+    assert(result.content[0].text.length > 2);
+  });
+
+  await t.step('returns isError for unknown version_id', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
+    const user = await userRepository.create({
+      email: 'getinvoice2@example.com', password_hash: 'x', role: 'user',
+      full_name: 'I', tenant_id: tenant.id,
+    } as CreateUserDTO & { password_hash: string });
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+
+    const result = await getInvoiceCalculationTool.handler({ version_id: 999999 }, { app, accessToken: token });
+    assertEquals(result.isError, true);
   });
 });

--- a/backend/tests/routes/mcp_test.ts
+++ b/backend/tests/routes/mcp_test.ts
@@ -33,7 +33,7 @@ Deno.test('POST /mcp', async (t) => {
     assert(wwwAuth.includes('resource_metadata'));
   });
 
-  await t.step('tools/list returns the 4 tools when authenticated', async () => {
+  await t.step('tools/list returns the 8 tools when authenticated', async () => {
     await clearDatabase();
     const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
     const user = await userRepository.create({
@@ -50,6 +50,15 @@ Deno.test('POST /mcp', async (t) => {
     assertEquals(res.status, 200);
     const body = await res.json();
     const names = body.result.tools.map((t: { name: string }) => t.name).sort();
-    assertEquals(names, ['get_project', 'get_version_total', 'list_projects', 'search_items']);
+    assertEquals(names, [
+      'get_floorplan_bom',
+      'get_invoice_calculation',
+      'get_project',
+      'get_version_total',
+      'list_areas',
+      'list_floorplans',
+      'list_projects',
+      'search_items',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Adds 4 read-only MCP tools that let Claude dig into a specific project version:

- **`list_floorplans(version_id)`** — floorplans defined in a project version (e.g., "Ground Floor", "Upstairs")
- **`get_floorplan_bom(floorplan_id)`** — bill of materials on a single floorplan (items, quantities, snapshotted unit prices)
- **`list_areas(floorplan_id)`** — named zones on a floorplan ("Kitchen", "Living Room"), with polygon coords. Foundation for future area-anchored placement.
- **`get_invoice_calculation(version_id)`** — itemized invoice with discounts, services, currency conversion (more detailed than `get_version_total`)

Total MCP tool surface is now 8.

All four dispatch through Pattern B (`app.fetch` → existing REST routes), so tenant scoping and auth are inherited automatically — the existing `tenant_isolation_test` is still load-bearing.

## Test plan

- [x] 312 backend tests pass (+10 over previous)
- [x] `deno lint` clean
- [x] tools/list test updated to assert all 8 names

🤖 Generated with [Claude Code](https://claude.com/claude-code)