### PR TITLE
fix(versioning): stop deleting BOM picture files shared between versions

### DIFF
--- a/backend/src/repositories/bom-entry.ts
+++ b/backend/src/repositories/bom-entry.ts
@@ -185,9 +185,16 @@ export class BomEntryRepository {
       getDb().query(`DELETE FROM project_bom WHERE id = ?`, [id]);
     });
 
-    // Clean up image files outside transaction
+    // Clean up image files outside transaction. Skip any path still referenced
+    // by another BOM row — legacy data may share files between versions, see
+    // fix-shared-bom-images.ts.
+    const seen = new Set<string>();
     for (const imagePath of imagePaths) {
+      if (seen.has(imagePath)) continue;
+      seen.add(imagePath);
       try {
+        const stillReferenced = await this.findByPicturePath(imagePath);
+        if (stillReferenced.length > 0) continue;
         await fileStorageService.deleteFile(imagePath);
       } catch {
         // Ignore file cleanup errors — DB state is consistent

--- a/backend/src/repositories/project-group.ts
+++ b/backend/src/repositories/project-group.ts
@@ -248,7 +248,10 @@ export class ProjectGroupRepository {
           item_type_name: string | null;
         }>;
 
-        // First pass: insert all with parent_bom_id = null, build bomIdMap
+        // First pass: insert all with parent_bom_id = null and picture_path = null,
+        // then copy the picture file and update the row. Each new BOM entry gets its
+        // own file under the new project's folder so deleting one version cannot
+        // unlink files referenced by another.
         for (const bom of bomEntries) {
           const newFloorplanId = floorplanIdMap.get(bom.floorplan_id);
           if (!newFloorplanId) continue;
@@ -269,13 +272,27 @@ export class ProjectGroupRepository {
             bom.style_name,
             bom.model_number,
             bom.unit_price,
-            bom.picture_path,
+            null,
             bom.area_id,
             bom.item_type_name,
           ]);
 
           const newBomId = (newBomRows[0] as Record<string, unknown>).id as number;
           bomIdMap.set(bom.id, newBomId);
+
+          if (bom.picture_path) {
+            const newPicturePath = await this._copyBomPicture(
+              bom.picture_path,
+              newProject.id,
+              newBomId,
+            );
+            if (newPicturePath) {
+              db.query(
+                `UPDATE project_bom SET picture_path = ? WHERE id = ?`,
+                [newPicturePath, newBomId],
+              );
+            }
+          }
         }
 
         // Second pass: update parent_bom_id using bomIdMap
@@ -433,6 +450,25 @@ export class ProjectGroupRepository {
    */
   private _copyFloorplanImage(sourcePath: string): Promise<string> {
     return fileStorageService.copyFile(sourcePath, 'floorplans');
+  }
+
+  /**
+   * Copy a BOM picture file into the new version's project folder.
+   * Returns the new relative path, or null if the source is missing
+   * (in which case the caller leaves picture_path NULL — the row stays
+   * recoverable from item_variants.image_path later).
+   */
+  private async _copyBomPicture(
+    sourcePath: string,
+    newProjectId: number,
+    newBomId: number,
+  ): Promise<string | null> {
+    const fileName = sourcePath.split('/').pop() || 'image.jpg';
+    const destSubdir = `projects/${newProjectId}/bom-images`;
+    const newFileName = `${newBomId}-${fileName}`;
+    const copied = await fileStorageService.copyFile(sourcePath, destSubdir, newFileName);
+    // copyFile returns the original source path when copy fails; treat that as "no copy"
+    return copied === sourcePath ? null : copied;
   }
 }
 

--- a/backend/src/repositories/project.ts
+++ b/backend/src/repositories/project.ts
@@ -199,42 +199,71 @@ export class ProjectRepository {
 
   /**
    * Internal: cascade delete all data attached to a version (files + DB records).
+   *
+   * BOM picture files are reference-counted: legacy data may share a single file
+   * between versions (see fix-shared-bom-images.ts). We collect the paths first,
+   * delete the DB rows, then unlink files only if no other project_bom row still
+   * references them.
    */
   private _deleteVersionData(projectId: number): Promise<void> {
     const db = getDb();
 
-    // Get floorplans for this project (need image paths before deletion)
     const floorplans = db.queryEntries(
       `SELECT id, image_path FROM floorplans WHERE project_id = ?`,
       [projectId]
     ) as unknown as Array<{ id: number; image_path: string }>;
 
+    const bomPicturePaths: string[] = [];
+    const floorplanImagePaths: string[] = [];
+
     for (const fp of floorplans) {
-      // Delete floorplan image file
-      fileStorageService.deleteFile(fp.image_path).catch(() => {});
+      floorplanImagePaths.push(fp.image_path);
 
-      // placements cascade to area_properties and area_vertices via FK ON DELETE CASCADE
-      db.query(`DELETE FROM placements WHERE floorplan_id = ?`, [fp.id]);
-
-      // Delete BOM entries for this floorplan (get picture paths first)
       const bomEntries = db.queryEntries(
         `SELECT picture_path FROM project_bom WHERE floorplan_id = ? AND picture_path IS NOT NULL`,
         [fp.id]
       ) as unknown as Array<{ picture_path: string }>;
       for (const bom of bomEntries) {
-        fileStorageService.deleteFile(bom.picture_path).catch(() => {});
+        bomPicturePaths.push(bom.picture_path);
       }
-      db.query(`DELETE FROM project_bom WHERE floorplan_id = ?`, [fp.id]);
     }
 
-    // Delete any remaining BOM entries by project_id
+    // Also pick up BOM rows attached to the project without a floorplan
+    const orphanedBom = db.queryEntries(
+      `SELECT picture_path FROM project_bom
+       WHERE project_id = ? AND floorplan_id IS NULL AND picture_path IS NOT NULL`,
+      [projectId]
+    ) as unknown as Array<{ picture_path: string }>;
+    for (const bom of orphanedBom) bomPicturePaths.push(bom.picture_path);
+
+    // Delete DB rows first so the reference check below sees a consistent state
+    for (const fp of floorplans) {
+      db.query(`DELETE FROM placements WHERE floorplan_id = ?`, [fp.id]);
+      db.query(`DELETE FROM project_bom WHERE floorplan_id = ?`, [fp.id]);
+    }
     db.query(`DELETE FROM project_bom WHERE project_id = ?`, [projectId]);
-
-    // Delete floorplans
     db.query(`DELETE FROM floorplans WHERE project_id = ?`, [projectId]);
-
-    // Delete project item types
     db.query(`DELETE FROM project_item_types WHERE project_id = ?`, [projectId]);
+
+    // Floorplan images are always copied per version — safe to delete unconditionally
+    for (const path of floorplanImagePaths) {
+      fileStorageService.deleteFile(path).catch(() => {});
+    }
+
+    // BOM pictures: only unlink if no surviving BOM row still references the path
+    const seen = new Set<string>();
+    for (const path of bomPicturePaths) {
+      if (seen.has(path)) continue;
+      seen.add(path);
+
+      const stillReferenced = db.queryEntries(
+        `SELECT 1 FROM project_bom WHERE picture_path = ? LIMIT 1`,
+        [path]
+      );
+      if (stillReferenced.length === 0) {
+        fileStorageService.deleteFile(path).catch(() => {});
+      }
+    }
 
     return Promise.resolve();
   }
@@ -309,7 +338,7 @@ export class ProjectRepository {
    * Delete all versions in a group.
    * Only called after verifying all versions are empty.
    */
-  deleteAllInGroup(groupId: number, ctx?: TenantContext): Promise<void> {
+  async deleteAllInGroup(groupId: number, ctx?: TenantContext): Promise<void> {
     const db = getDb();
 
     let sql = `SELECT id FROM projects WHERE project_group_id = ?`;
@@ -321,11 +350,9 @@ export class ProjectRepository {
     const projects = db.queryEntries(sql, params) as unknown as Array<{ id: number }>;
 
     for (const project of projects) {
-      this._deleteVersionData(project.id);
+      await this._deleteVersionData(project.id);
       db.query(`DELETE FROM projects WHERE id = ?`, [project.id]);
     }
-
-    return Promise.resolve();
   }
 }
 

--- a/backend/src/scripts/fix-shared-bom-images.ts
+++ b/backend/src/scripts/fix-shared-bom-images.ts
@@ -1,0 +1,232 @@
+#!/usr/bin/env -S deno run --allow-all
+/**
+ * Repair tool: shared & missing BOM picture files
+ *
+ * Background: until the createVersion fix, duplicating a project version
+ * copied floorplan image files but only copied the BOM `picture_path` string.
+ * That left both versions' project_bom rows pointing at the same file on
+ * disk. Deleting one version (or even one placement in one version) then
+ * unlinked the file out from under the surviving version.
+ *
+ * This script scans project_bom and repairs two situations:
+ *
+ *   1. Shared path: a picture_path is referenced by 2+ project_bom rows.
+ *      The earliest-created row keeps the original file; every other row
+ *      gets its own copy at projects/<row.project_id>/bom-images/<id>-<name>.
+ *
+ *   2. Missing file: picture_path is set but the file is gone. We try to
+ *      recover from item_variants.image_path (the catalog source), copying
+ *      it into the row's project folder. If the source is also missing the
+ *      row is reported and skipped.
+ *
+ * Defaults to dry-run. Pass --apply to actually mutate. Run from backend/:
+ *
+ *   deno run --allow-all src/scripts/fix-shared-bom-images.ts            # dry run
+ *   deno run --allow-all src/scripts/fix-shared-bom-images.ts --apply    # mutate
+ */
+
+import { getDb } from '../config/database.ts';
+import { fileStorageService } from '../services/file-storage.ts';
+
+interface BomRow {
+  id: number;
+  project_id: number;
+  variant_id: number | null;
+  picture_path: string;
+  created_at: string;
+}
+
+interface Summary {
+  totalWithPath: number;
+  sharedRows: number;
+  sharedGroups: number;
+  rowsRecopied: number;
+  rowsRecoveredFromCatalog: number;
+  rowsUnrecoverable: number;
+  errors: Array<{ bomId: number; error: string }>;
+}
+
+function deriveDestFilename(bomId: number, sourcePath: string): string {
+  const base = sourcePath.split('/').pop() || 'image.jpg';
+  return `${bomId}-${base}`;
+}
+
+async function repairRow(
+  row: BomRow,
+  source: string,
+  apply: boolean,
+): Promise<string> {
+  const destDir = `projects/${row.project_id}/bom-images`;
+  const newName = deriveDestFilename(row.id, source);
+  const destPath = `${destDir}/${newName}`;
+
+  if (!apply) {
+    return destPath;
+  }
+
+  const copied = await fileStorageService.copyFile(source, destDir, newName);
+  // copyFile returns the original source path if it fails — guard against that
+  if (copied === source) {
+    throw new Error(`copyFile fell back to source path (copy likely failed): ${source}`);
+  }
+
+  getDb().query(`UPDATE project_bom SET picture_path = ? WHERE id = ?`, [copied, row.id]);
+  return copied;
+}
+
+async function main(): Promise<void> {
+  const apply = Deno.args.includes('--apply');
+  const mode = apply ? 'APPLY' : 'DRY-RUN';
+
+  console.log('='.repeat(72));
+  console.log(`Fix shared/missing BOM picture files — ${mode}`);
+  console.log('='.repeat(72));
+
+  const db = getDb();
+
+  const rows = db.queryEntries(`
+    SELECT id, project_id, variant_id, picture_path, created_at
+    FROM project_bom
+    WHERE picture_path IS NOT NULL
+    ORDER BY picture_path, created_at, id
+  `) as unknown as BomRow[];
+
+  const summary: Summary = {
+    totalWithPath: rows.length,
+    sharedRows: 0,
+    sharedGroups: 0,
+    rowsRecopied: 0,
+    rowsRecoveredFromCatalog: 0,
+    rowsUnrecoverable: 0,
+    errors: [],
+  };
+
+  // Group by picture_path
+  const byPath = new Map<string, BomRow[]>();
+  for (const r of rows) {
+    const list = byPath.get(r.picture_path) ?? [];
+    list.push(r);
+    byPath.set(r.picture_path, list);
+  }
+
+  console.log(`Found ${rows.length} BOM rows with picture_path`);
+  console.log(`Found ${byPath.size} distinct paths`);
+
+  // -------- Phase 1: shared paths --------
+  for (const [path, group] of byPath.entries()) {
+    if (group.length < 2) continue;
+
+    summary.sharedGroups++;
+    // Keep the oldest row (already first thanks to ORDER BY created_at, id)
+    const keeper = group[0];
+    const dupes = group.slice(1);
+
+    const sourceExists = await fileStorageService.fileExists(path);
+
+    console.log(
+      `\n[SHARED] ${path}  refs=${group.length}  keeper=bom#${keeper.id} (project ${keeper.project_id})  sourceOnDisk=${sourceExists}`,
+    );
+
+    for (const dup of dupes) {
+      summary.sharedRows++;
+      try {
+        if (!sourceExists) {
+          console.log(`  [SKIP-PHASE-1] bom#${dup.id}: source missing, will try catalog recovery in phase 2`);
+          continue;
+        }
+        const newPath = await repairRow(dup, path, apply);
+        console.log(`  ${apply ? '[COPY]' : '[PLAN]'} bom#${dup.id} → ${newPath}`);
+        if (apply) summary.rowsRecopied++;
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.error(`  [ERR ] bom#${dup.id}: ${msg}`);
+        summary.errors.push({ bomId: dup.id, error: msg });
+      }
+    }
+  }
+
+  // -------- Phase 2: missing files (regenerate from variant catalog) --------
+  // Re-read in case phase 1 already updated some rows
+  const rowsForPhase2 = (apply
+    ? (db.queryEntries(`
+        SELECT id, project_id, variant_id, picture_path, created_at
+        FROM project_bom
+        WHERE picture_path IS NOT NULL
+      `) as unknown as BomRow[])
+    : rows);
+
+  console.log(`\n--- Phase 2: missing files ---`);
+
+  for (const r of rowsForPhase2) {
+    const exists = await fileStorageService.fileExists(r.picture_path);
+    if (exists) continue;
+
+    if (r.variant_id == null) {
+      console.log(`[UNRECOVERABLE] bom#${r.id}: file missing and no variant_id link`);
+      summary.rowsUnrecoverable++;
+      continue;
+    }
+
+    const variant = db.queryEntries(
+      `SELECT image_path FROM item_variants WHERE id = ?`,
+      [r.variant_id],
+    ) as unknown as Array<{ image_path: string | null }>;
+
+    const catalogPath = variant[0]?.image_path ?? null;
+    if (!catalogPath) {
+      console.log(`[UNRECOVERABLE] bom#${r.id}: variant ${r.variant_id} has no image_path`);
+      summary.rowsUnrecoverable++;
+      continue;
+    }
+
+    const catalogExists = await fileStorageService.fileExists(catalogPath);
+    if (!catalogExists) {
+      console.log(`[UNRECOVERABLE] bom#${r.id}: catalog source also missing (${catalogPath})`);
+      summary.rowsUnrecoverable++;
+      continue;
+    }
+
+    try {
+      const newPath = await repairRow(r, catalogPath, apply);
+      console.log(`${apply ? '[RECOVER]' : '[PLAN-RECOVER]'} bom#${r.id} from ${catalogPath} → ${newPath}`);
+      if (apply) summary.rowsRecoveredFromCatalog++;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`[ERR ] bom#${r.id}: ${msg}`);
+      summary.errors.push({ bomId: r.id, error: msg });
+    }
+  }
+
+  console.log('\n' + '='.repeat(72));
+  console.log(`Summary (${mode})`);
+  console.log('='.repeat(72));
+  console.log(`BOM rows with picture_path:     ${summary.totalWithPath}`);
+  console.log(`Distinct picture_paths:         ${byPath.size}`);
+  console.log(`Shared path groups:             ${summary.sharedGroups}`);
+  console.log(`Duplicate rows (need own copy): ${summary.sharedRows}`);
+  if (apply) {
+    console.log(`Rows re-copied from sibling:    ${summary.rowsRecopied}`);
+    console.log(`Rows recovered from catalog:    ${summary.rowsRecoveredFromCatalog}`);
+  }
+  console.log(`Unrecoverable rows:             ${summary.rowsUnrecoverable}`);
+  if (summary.errors.length > 0) {
+    console.log(`\nErrors:`);
+    for (const e of summary.errors) console.log(`  - bom#${e.bomId}: ${e.error}`);
+  }
+
+  if (!apply) {
+    console.log(`\nDry run — re-run with --apply to mutate files and DB.`);
+  } else {
+    console.log(`\nDone.`);
+  }
+}
+
+if (import.meta.main) {
+  try {
+    await main();
+    Deno.exit(0);
+  } catch (e) {
+    console.error('Fatal:', e);
+    Deno.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- `createVersion` only copied floorplan files; BOM `picture_path` was copied as a string, so two versions pointed at the same file on disk. Deleting either version then unlinked pictures the surviving version still needed.
- `createVersion` now copies each BOM picture into the new project's `bom-images` folder (same pattern as floorplan images).
- `_deleteVersionData` and `bomEntryRepository.delete` skip files that other rows still reference — defense in depth for any legacy data still sharing paths.
- New `backend/src/scripts/fix-shared-bom-images.ts` repairs existing databases: splits shared paths into per-row copies and restores missing files from `item_variants.image_path`. Dry-run by default, `--apply` to mutate. Idempotent.

## Test plan
- [x] `deno task test` — 312 passed
- [x] `deno lint` — clean
- [x] Dry-run of repair script on local dev DB: 56 shared paths flagged
- [x] `--apply` on local dev DB: all 56 fixed, idempotent re-run reports zero work, every referenced file present on disk
- [x] Dry-run of repair script on production data snapshot: 56 rows planned for recovery from catalog, 0 unrecoverable
- [x] `--apply` on production data snapshot: 56 rows recovered from `item_variants.image_path`, 0 referenced files missing afterwards
- [ ] After merge & image rebuild: pull on prod, run the script inside the container (dry-run first, then `--apply`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)