### PR TITLE
feat(mcp): area/floorplan/version enrichment + picture tools; empty-folder cleanup

### DIFF
--- a/backend/deno.json
+++ b/backend/deno.json
@@ -20,7 +20,8 @@
     "sqlite": "https://deno.land/x/sqlite@v3.9.1/mod.ts",
     "sharp": "npm:sharp@^0.33.0",
     "@std/assert": "jsr:@std/assert@^0.208.0",
-    "@std/path": "jsr:@std/path@^1.0.0"
+    "@std/path": "jsr:@std/path@^1.0.0",
+    "@std/encoding/base64": "jsr:@std/encoding@^1.0.0/base64"
   },
   "compilerOptions": {
     "strict": true,

--- a/backend/deno.lock
+++ b/backend/deno.lock
@@ -2,6 +2,7 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/assert@0.208": "0.208.0",
+    "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/fmt@0.208": "0.208.0",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/path@1": "1.1.4",
@@ -17,6 +18,9 @@
       "dependencies": [
         "jsr:@std/fmt"
       ]
+    },
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
     "@std/fmt@0.208.0": {
       "integrity": "06584c97a1a7b934e8de185c45a595d8234c5312e51e61cb05650af4cb8eb65f"
@@ -316,6 +320,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@0.208",
+      "jsr:@std/encoding@1",
       "jsr:@std/path@1",
       "npm:@hono/zod-validator@0.2",
       "npm:hono@4",

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -22,6 +22,7 @@ import settingsRoutes from './routes/settings.ts';
 import areaRoutes from './routes/areas.ts';
 import tenantRoutes from './routes/tenants.ts';
 import projectGroupRoutes from './routes/project-groups.ts';
+import bomEntryRoutes from './routes/bom-entries.ts';
 import oauthRoutes from './routes/oauth.ts';
 import oauthConsentRoutes from './routes/oauth-consent.ts';
 import wellKnownRoutes from './routes/well-known.ts';
@@ -119,6 +120,9 @@ api.route('/tenants', tenantRoutes);
 
 // Project group routes at /api/project-groups/*
 api.route('/project-groups', projectGroupRoutes);
+
+// BOM entry read routes at /api/bom-entries/*
+api.route('/bom-entries', bomEntryRoutes);
 
 // Mount API router
 app.route('/api', api);

--- a/backend/src/repositories/project.ts
+++ b/backend/src/repositories/project.ts
@@ -205,7 +205,7 @@ export class ProjectRepository {
    * delete the DB rows, then unlink files only if no other project_bom row still
    * references them.
    */
-  private _deleteVersionData(projectId: number): Promise<void> {
+  private async _deleteVersionData(projectId: number): Promise<void> {
     const db = getDb();
 
     const floorplans = db.queryEntries(
@@ -247,7 +247,7 @@ export class ProjectRepository {
 
     // Floorplan images are always copied per version — safe to delete unconditionally
     for (const path of floorplanImagePaths) {
-      fileStorageService.deleteFile(path).catch(() => {});
+      try { await fileStorageService.deleteFile(path); } catch { /* ignore */ }
     }
 
     // BOM pictures: only unlink if no surviving BOM row still references the path
@@ -261,11 +261,14 @@ export class ProjectRepository {
         [path]
       );
       if (stillReferenced.length === 0) {
-        fileStorageService.deleteFile(path).catch(() => {});
+        try { await fileStorageService.deleteFile(path); } catch { /* ignore */ }
       }
     }
 
-    return Promise.resolve();
+    // Tidy up empty per-version folders. removeDirectoryIfEmpty is a no-op if
+    // anything (e.g. a still-shared BOM picture) is left inside.
+    await fileStorageService.removeDirectoryIfEmpty(`projects/${projectId}/bom-images`);
+    await fileStorageService.removeDirectoryIfEmpty(`projects/${projectId}`);
   }
 
   getItemTypeIds(projectId: number): Promise<number[]> {

--- a/backend/src/routes/bom-entries.ts
+++ b/backend/src/routes/bom-entries.ts
@@ -1,0 +1,42 @@
+import { Hono } from 'hono';
+import { authMiddleware } from '../middleware/auth.ts';
+import { bomEntryRepository } from '../repositories/bom-entry.ts';
+import { getDb } from '../config/database.ts';
+
+const bomEntryRoutes = new Hono();
+
+/**
+ * GET /bom-entries/:id - Fetch a single BOM entry by id, tenant-scoped.
+ *
+ * project_bom rows don't carry tenant_id directly; we join through projects
+ * and reject if the row's project belongs to a different tenant (admins see
+ * everything). This is intentionally read-only — mutations still go through
+ * the floorplan/placement routes.
+ */
+bomEntryRoutes.get('/:id', authMiddleware, async (c) => {
+  const id = parseInt(c.req.param('id'));
+  if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
+
+  try {
+    const entry = await bomEntryRepository.findById(id);
+    if (!entry) return c.json({ error: 'BOM entry not found' }, 404);
+
+    const role = c.get('userRole') as string | undefined;
+    if (role !== 'admin') {
+      const tenantId = c.get('tenantId') as number | undefined;
+      if (tenantId === undefined) return c.json({ error: 'Forbidden' }, 403);
+      const rows = getDb().queryEntries(
+        `SELECT 1 FROM projects WHERE id = ? AND tenant_id = ?`,
+        [entry.project_id, tenantId],
+      );
+      if (rows.length === 0) return c.json({ error: 'BOM entry not found' }, 404);
+    }
+
+    return c.json({ data: entry });
+  } catch (error) {
+    console.error('Get bom entry error:', error);
+    return c.json({ error: 'Internal server error' }, 500);
+  }
+});
+
+export default bomEntryRoutes;

--- a/backend/src/services/file-storage.ts
+++ b/backend/src/services/file-storage.ts
@@ -150,6 +150,24 @@ export class FileStorageService {
   }
 
   /**
+   * Remove a directory only if it is empty. Returns true on success, false if
+   * the directory is missing or still has contents.
+   */
+  async removeDirectoryIfEmpty(relativePath: string): Promise<boolean> {
+    const fullPath = `${this.uploadDir}/${relativePath}`;
+    try {
+      await Deno.remove(fullPath);
+      return true;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return false;
+      // Non-empty directories raise Deno.errors.PermissionDenied on some
+      // platforms and a plain Error elsewhere; either way we treat the
+      // dir as "leave it alone".
+      return false;
+    }
+  }
+
+  /**
    * Check if file exists
    */
   async fileExists(relativePath: string): Promise<boolean> {

--- a/backend/src/services/file-storage.ts
+++ b/backend/src/services/file-storage.ts
@@ -160,9 +160,7 @@ export class FileStorageService {
       return true;
     } catch (error) {
       if (error instanceof Deno.errors.NotFound) return false;
-      // Non-empty directories raise Deno.errors.PermissionDenied on some
-      // platforms and a plain Error elsewhere; either way we treat the
-      // dir as "leave it alone".
+      // Non-empty directories and other errors: leave the dir alone.
       return false;
     }
   }

--- a/backend/src/services/mcp/server.ts
+++ b/backend/src/services/mcp/server.ts
@@ -7,6 +7,8 @@ import { listFloorplansTool } from './tools/list-floorplans.ts';
 import { getFloorplanBomTool } from './tools/get-floorplan-bom.ts';
 import { listAreasTool } from './tools/list-areas.ts';
 import { getInvoiceCalculationTool } from './tools/get-invoice-calculation.ts';
+import { getItemPictureTool } from './tools/get-item-picture.ts';
+import { getFloorplanImageTool } from './tools/get-floorplan-image.ts';
 import { zodToJsonSchema } from './zod-to-json-schema.ts';
 
 const allTools = [
@@ -18,6 +20,8 @@ const allTools = [
   getFloorplanBomTool,
   listAreasTool,
   getInvoiceCalculationTool,
+  getItemPictureTool,
+  getFloorplanImageTool,
 ];
 
 export interface JsonRpcRequest {

--- a/backend/src/services/mcp/tools/get-floorplan-bom.ts
+++ b/backend/src/services/mcp/tools/get-floorplan-bom.ts
@@ -6,23 +6,81 @@ const inputSchema = z.object({
   floorplan_id: z.number().int().positive(),
 });
 
+interface AreaSummary {
+  id: number;
+  name: string;
+}
+
+interface BomEntry {
+  area_id?: number | null;
+  area_name?: string;
+  [key: string]: unknown;
+}
+
+interface BomGroup {
+  mainEntry?: BomEntry;
+  children?: BomEntry[];
+  [key: string]: unknown;
+}
+
+interface FloorplanBomPayload {
+  groups?: BomGroup[];
+  [key: string]: unknown;
+}
+
+function decorateEntry(entry: BomEntry, areasById: Map<number, string>): void {
+  if (entry.area_id != null) {
+    const name = areasById.get(entry.area_id);
+    if (name) entry.area_name = name;
+  }
+}
+
 export const getFloorplanBomTool = {
   name: 'get_floorplan_bom',
   description:
-    'Get the bill of materials (items placed) for a single floorplan — each entry includes the item name, variant (if any), quantity, and unit price at placement time. Pass a floorplan_id from list_floorplans.',
+    'Get the bill of materials (items placed) for a single floorplan — each entry includes the item name, variant (if any), quantity, unit price at placement time, and the human-readable area name when the placement is inside one. Pass a floorplan_id from list_floorplans.',
   inputSchema,
   handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
-    const result = await dispatchToBackend(ctx.app, {
-      method: 'GET',
-      path: `/api/floorplans/${args.floorplan_id}/bom`,
-      accessToken: ctx.accessToken,
-    });
-    if (!result.ok) {
+    const [bomResult, areasResult] = await Promise.all([
+      dispatchToBackend(ctx.app, {
+        method: 'GET',
+        path: `/api/floorplans/${args.floorplan_id}/bom`,
+        accessToken: ctx.accessToken,
+      }),
+      dispatchToBackend(ctx.app, {
+        method: 'GET',
+        path: '/api/areas',
+        query: { floorplan_id: args.floorplan_id },
+        accessToken: ctx.accessToken,
+      }),
+    ]);
+
+    if (!bomResult.ok) {
       return {
         isError: true,
-        content: [{ type: 'text', text: `Failed to get BOM for floorplan ${args.floorplan_id} (HTTP ${result.status}): ${JSON.stringify(result.body)}` }],
+        content: [{ type: 'text', text: `Failed to get BOM for floorplan ${args.floorplan_id} (HTTP ${bomResult.status}): ${JSON.stringify(bomResult.body)}` }],
       };
     }
-    return { content: [{ type: 'text', text: JSON.stringify(result.body.data, null, 2) }] };
+
+    const areasById = new Map<number, string>();
+    if (areasResult.ok && Array.isArray(areasResult.body?.data)) {
+      for (const area of areasResult.body.data as AreaSummary[]) {
+        if (typeof area?.id === 'number' && typeof area?.name === 'string') {
+          areasById.set(area.id, area.name);
+        }
+      }
+    }
+
+    const payload = bomResult.body.data as FloorplanBomPayload;
+    if (areasById.size > 0 && Array.isArray(payload?.groups)) {
+      for (const group of payload.groups) {
+        if (group.mainEntry) decorateEntry(group.mainEntry, areasById);
+        if (Array.isArray(group.children)) {
+          for (const child of group.children) decorateEntry(child, areasById);
+        }
+      }
+    }
+
+    return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
   },
 };

--- a/backend/src/services/mcp/tools/get-floorplan-bom.ts
+++ b/backend/src/services/mcp/tools/get-floorplan-bom.ts
@@ -25,6 +25,8 @@ interface BomGroup {
 
 interface FloorplanBomPayload {
   groups?: BomGroup[];
+  floorplan_name?: string;
+  version_name?: string;
   [key: string]: unknown;
 }
 
@@ -41,7 +43,7 @@ export const getFloorplanBomTool = {
     'Get the bill of materials (items placed) for a single floorplan — each entry includes the item name, variant (if any), quantity, unit price at placement time, and the human-readable area name when the placement is inside one. Pass a floorplan_id from list_floorplans.',
   inputSchema,
   handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
-    const [bomResult, areasResult] = await Promise.all([
+    const [bomResult, areasResult, floorplanResult] = await Promise.all([
       dispatchToBackend(ctx.app, {
         method: 'GET',
         path: `/api/floorplans/${args.floorplan_id}/bom`,
@@ -51,6 +53,11 @@ export const getFloorplanBomTool = {
         method: 'GET',
         path: '/api/areas',
         query: { floorplan_id: args.floorplan_id },
+        accessToken: ctx.accessToken,
+      }),
+      dispatchToBackend(ctx.app, {
+        method: 'GET',
+        path: `/api/floorplans/${args.floorplan_id}`,
         accessToken: ctx.accessToken,
       }),
     ]);
@@ -71,6 +78,20 @@ export const getFloorplanBomTool = {
       }
     }
 
+    const fp = floorplanResult.ok ? (floorplanResult.body?.data as { name?: string; project_id?: number } | undefined) : undefined;
+    let versionName: string | undefined;
+    if (fp?.project_id) {
+      const projectResult = await dispatchToBackend(ctx.app, {
+        method: 'GET',
+        path: `/api/projects/${fp.project_id}`,
+        accessToken: ctx.accessToken,
+      });
+      if (projectResult.ok) {
+        const project = projectResult.body?.data as { version_name?: string } | undefined;
+        versionName = project?.version_name;
+      }
+    }
+
     const payload = bomResult.body.data as FloorplanBomPayload;
     if (areasById.size > 0 && Array.isArray(payload?.groups)) {
       for (const group of payload.groups) {
@@ -80,6 +101,8 @@ export const getFloorplanBomTool = {
         }
       }
     }
+    if (fp?.name) payload.floorplan_name = fp.name;
+    if (versionName) payload.version_name = versionName;
 
     return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
   },

--- a/backend/src/services/mcp/tools/get-floorplan-image.ts
+++ b/backend/src/services/mcp/tools/get-floorplan-image.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+import { dispatchToBackend } from '../dispatcher.ts';
+import { fileStorageService } from '../../file-storage.ts';
+import { encodeBase64 } from '@std/encoding/base64';
+import type { ToolContext, ToolResult } from './list-projects.ts';
+
+const inputSchema = z.object({
+  floorplan_id: z.number().int().positive(),
+});
+
+function mimeTypeForPath(path: string): string {
+  const ext = path.split('.').pop()?.toLowerCase();
+  switch (ext) {
+    case 'jpg':
+    case 'jpeg': return 'image/jpeg';
+    case 'png': return 'image/png';
+    case 'webp': return 'image/webp';
+    case 'gif': return 'image/gif';
+    default: return 'application/octet-stream';
+  }
+}
+
+export const getFloorplanImageTool = {
+  name: 'get_floorplan_image',
+  description:
+    'Fetch the background image of a floorplan as an inline image. Pass a floorplan_id from list_floorplans. Useful when you need to see the room layout or describe placements visually.',
+  inputSchema,
+  handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
+    const meta = await dispatchToBackend(ctx.app, {
+      method: 'GET',
+      path: `/api/floorplans/${args.floorplan_id}`,
+      accessToken: ctx.accessToken,
+    });
+
+    if (!meta.ok) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to load floorplan ${args.floorplan_id} (HTTP ${meta.status}): ${JSON.stringify(meta.body)}` }],
+      };
+    }
+
+    const fp = meta.body?.data as { image_path?: string | null; name?: string } | undefined;
+    const imagePath = fp?.image_path;
+    if (!imagePath) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Floorplan ${args.floorplan_id} has no image_path` }],
+      };
+    }
+
+    try {
+      const bytes = await Deno.readFile(fileStorageService.getFilePath(imagePath));
+      return {
+        content: [
+          { type: 'image', data: encodeBase64(bytes), mimeType: mimeTypeForPath(imagePath) },
+          { type: 'text', text: `Floorplan #${args.floorplan_id} (${fp?.name ?? 'unnamed'}): ${imagePath}` },
+        ],
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to read floorplan image (${imagePath}): ${msg}` }],
+      };
+    }
+  },
+};

--- a/backend/src/services/mcp/tools/get-item-picture.ts
+++ b/backend/src/services/mcp/tools/get-item-picture.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+import { dispatchToBackend } from '../dispatcher.ts';
+import { fileStorageService } from '../../file-storage.ts';
+import { encodeBase64 } from '@std/encoding/base64';
+import type { ToolContext, ToolResult } from './list-projects.ts';
+
+const inputSchema = z.object({
+  bom_id: z.number().int().positive(),
+});
+
+function mimeTypeForPath(path: string): string {
+  const ext = path.split('.').pop()?.toLowerCase();
+  switch (ext) {
+    case 'jpg':
+    case 'jpeg': return 'image/jpeg';
+    case 'png': return 'image/png';
+    case 'webp': return 'image/webp';
+    case 'gif': return 'image/gif';
+    default: return 'application/octet-stream';
+  }
+}
+
+export const getItemPictureTool = {
+  name: 'get_item_picture',
+  description:
+    'Fetch the picture for a single placement (BOM entry) as an inline image. Pass a bom_id from get_floorplan_bom — e.g. mainEntry.id or one of bomEntryIds. Use this only when you need to actually see the item; for normal browsing the text BOM is cheaper.',
+  inputSchema,
+  handler: async (args: z.infer<typeof inputSchema>, ctx: ToolContext): Promise<ToolResult> => {
+    const meta = await dispatchToBackend(ctx.app, {
+      method: 'GET',
+      path: `/api/bom-entries/${args.bom_id}`,
+      accessToken: ctx.accessToken,
+    });
+
+    if (!meta.ok) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to load BOM entry ${args.bom_id} (HTTP ${meta.status}): ${JSON.stringify(meta.body)}` }],
+      };
+    }
+
+    const entry = meta.body?.data as { picture_path?: string | null; item_name?: string } | undefined;
+    const picturePath = entry?.picture_path;
+    if (!picturePath) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `BOM entry ${args.bom_id} has no picture_path` }],
+      };
+    }
+
+    try {
+      const bytes = await Deno.readFile(fileStorageService.getFilePath(picturePath));
+      return {
+        content: [
+          { type: 'image', data: encodeBase64(bytes), mimeType: mimeTypeForPath(picturePath) },
+          { type: 'text', text: `BOM #${args.bom_id} (${entry?.item_name ?? 'unknown'}): ${picturePath}` },
+        ],
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Failed to read picture file for BOM ${args.bom_id} (${picturePath}): ${msg}` }],
+      };
+    }
+  },
+};

--- a/backend/src/services/mcp/tools/list-projects.ts
+++ b/backend/src/services/mcp/tools/list-projects.ts
@@ -7,8 +7,15 @@ export interface ToolContext {
   accessToken: string;
 }
 
+export interface ToolContentBlock {
+  type: 'text' | 'image';
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+
 export interface ToolResult {
-  content: Array<{ type: 'text'; text: string }>;
+  content: ToolContentBlock[];
   isError?: boolean;
 }
 

--- a/backend/tests/mcp/tenant_isolation_test.ts
+++ b/backend/tests/mcp/tenant_isolation_test.ts
@@ -27,7 +27,7 @@ Deno.test('Tenant A cannot see Tenant B projects via MCP', async () => {
   const result = await listProjectsTool.handler({ query: undefined }, { app, accessToken: tokenA });
 
   assertEquals(result.isError, undefined);
-  const text = result.content[0].text;
+  const text = result.content[0]!.text!;
   assert(text.includes('A-customer'), 'must include own-tenant project');
   assert(!text.includes('B-secret'), 'must NOT include other-tenant project (cross-tenant leak!)');
 });

--- a/backend/tests/mcp/tools_test.ts
+++ b/backend/tests/mcp/tools_test.ts
@@ -46,7 +46,7 @@ Deno.test('list_projects tool', async (t) => {
     const result = await listProjectsTool.handler({ query: undefined }, { app, accessToken: token });
     assertEquals(result.isError, undefined);
     assertEquals(result.content.length, 1);
-    const text = result.content[0].text;
+    const text = result.content[0]!.text!;
     assert(text.includes('Alpha Customer'));
     assert(text.includes('Beta Customer'));
   });
@@ -56,8 +56,8 @@ Deno.test('list_projects tool', async (t) => {
     const { token } = await seedUserWithProjects();
     // Search by customer name (project-groups endpoint searches customer_name)
     const result = await listProjectsTool.handler({ query: 'Alpha' }, { app, accessToken: token });
-    assert(result.content[0].text.includes('Alpha Customer'));
-    assert(!result.content[0].text.includes('Beta Customer'));
+    assert(result.content[0]!.text!.includes('Alpha Customer'));
+    assert(!result.content[0]!.text!.includes('Beta Customer'));
   });
 
   await t.step('returns isError on bad auth', async () => {
@@ -88,7 +88,7 @@ Deno.test('get_project tool', async (t) => {
 
     const result = await getProjectTool.handler({ project_id: groupId }, { app, accessToken: token });
     assertEquals(result.isError, undefined);
-    assert(result.content[0].text.includes('Alpha Customer'));
+    assert(result.content[0]!.text!.includes('Alpha Customer'));
   });
 
   await t.step('returns isError for unknown id', async () => {
@@ -123,7 +123,7 @@ Deno.test('get_version_total tool', async (t) => {
 
     const result = await getVersionTotalTool.handler({ version_id: projects[0].id }, { app, accessToken: token });
     assertEquals(result.isError, undefined);
-    assert(result.content[0].text.length > 2);
+    assert(result.content[0]!.text!.length > 2);
   });
 });
 
@@ -144,7 +144,7 @@ Deno.test('search_items tool', async (t) => {
 
     const result = await searchItemsTool.handler({ query: 'Switch' }, { app, accessToken: token });
     assertEquals(result.isError, undefined);
-    assert(result.content[0].text.includes('Smart Switch'));
+    assert(result.content[0]!.text!.includes('Smart Switch'));
   });
 
   await t.step('honors limit', async () => {
@@ -181,7 +181,7 @@ Deno.test('list_floorplans tool', async (t) => {
 
     const result = await listFloorplansTool.handler({ version_id: project.id }, { app, accessToken: token });
     assertEquals(result.isError, undefined);
-    assert(result.content[0].text.includes('Ground Floor'));
+    assert(result.content[0]!.text!.includes('Ground Floor'));
   });
 
   await t.step('returns empty array when version has no floorplans', async () => {
@@ -199,7 +199,7 @@ Deno.test('list_floorplans tool', async (t) => {
     const result = await listFloorplansTool.handler({ version_id: project.id }, { app, accessToken: token });
     assertEquals(result.isError, undefined);
     // Should return an empty array (serialized as "[]")
-    assert(result.content[0].text.includes('[]'));
+    assert(result.content[0]!.text!.includes('[]'));
   });
 
   await t.step('returns isError on bad auth', async () => {
@@ -230,7 +230,7 @@ Deno.test('get_floorplan_bom tool', async (t) => {
     const result = await getFloorplanBomTool.handler({ floorplan_id: floorplan.id }, { app, accessToken: token });
     assertEquals(result.isError, undefined);
     // Empty BOM returns an empty array
-    assert(result.content[0].text.length > 0);
+    assert(result.content[0]!.text!.length > 0);
   });
 
   await t.step('returns isError for unknown floorplan_id', async () => {
@@ -270,7 +270,7 @@ Deno.test('list_areas tool', async (t) => {
 
     const result = await listAreasTool.handler({ floorplan_id: floorplan.id }, { app, accessToken: token });
     assertEquals(result.isError, undefined);
-    assert(result.content[0].text.includes('Kitchen'));
+    assert(result.content[0]!.text!.includes('Kitchen'));
   });
 
   await t.step('returns empty array when floorplan has no areas', async () => {
@@ -290,7 +290,7 @@ Deno.test('list_areas tool', async (t) => {
 
     const result = await listAreasTool.handler({ floorplan_id: floorplan.id }, { app, accessToken: token });
     assertEquals(result.isError, undefined);
-    assert(result.content[0].text.includes('[]'));
+    assert(result.content[0]!.text!.includes('[]'));
   });
 });
 
@@ -312,7 +312,7 @@ Deno.test('get_invoice_calculation tool', async (t) => {
     const result = await getInvoiceCalculationTool.handler({ version_id: project.id }, { app, accessToken: token });
     assertEquals(result.isError, undefined);
     // Should contain numeric totals even for an empty BOM
-    assert(result.content[0].text.length > 2);
+    assert(result.content[0]!.text!.length > 2);
   });
 
   await t.step('returns isError for unknown version_id', async () => {

--- a/backend/tests/mcp/tools_test.ts
+++ b/backend/tests/mcp/tools_test.ts
@@ -18,7 +18,10 @@ import { listFloorplansTool } from '../../src/services/mcp/tools/list-floorplans
 import { getFloorplanBomTool } from '../../src/services/mcp/tools/get-floorplan-bom.ts';
 import { listAreasTool } from '../../src/services/mcp/tools/list-areas.ts';
 import { getInvoiceCalculationTool } from '../../src/services/mcp/tools/get-invoice-calculation.ts';
+import { getItemPictureTool } from '../../src/services/mcp/tools/get-item-picture.ts';
 import { projectGroupRepository } from '../../src/repositories/project-group.ts';
+import { getDb } from '../../src/config/database.ts';
+import { fileStorageService } from '../../src/services/file-storage.ts';
 
 async function seedUserWithProjects() {
   const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
@@ -325,6 +328,131 @@ Deno.test('get_invoice_calculation tool', async (t) => {
     const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
 
     const result = await getInvoiceCalculationTool.handler({ version_id: 999999 }, { app, accessToken: token });
+    assertEquals(result.isError, true);
+  });
+});
+
+Deno.test('get_floorplan_bom enrichment', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('includes floorplan_name, version_name and area_name', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
+    const user = await userRepository.create({
+      email: 'enrich@example.com', password_hash: 'x', role: 'user',
+      full_name: 'E', tenant_id: tenant.id,
+    } as CreateUserDTO & { password_hash: string });
+    const project = await projectRepository.create({
+      version_name: 'v1', customer_name: 'Enrich Customer', tenant_id: tenant.id,
+    } as CreateProjectDTO);
+    const floorplan = await floorplanRepository.create({
+      project_id: project.id, name: 'Main Floor', image_path: 'test.png',
+    } as CreateFloorplanDTO);
+    const area = await areaRepository.create({
+      floorplan_id: floorplan.id, x: 0, y: 0, width: 50, height: 50, name: 'Wohnzimmer',
+    } as CreateAreaDTO);
+
+    // Insert a BOM row + a matching item placement so the row appears in the
+    // aggregated BOM output. item_id/variant_id stay null — that's fine for
+    // the aggregation path (the row just gets isAvailable=false).
+    const db = getDb();
+    const bomRows = db.queryEntries<{ id: number }>(`
+      INSERT INTO project_bom (
+        project_id, floorplan_id, item_id, variant_id, parent_bom_id,
+        item_name, style_name, model_number, unit_price, picture_path, area_id
+      ) VALUES (?, ?, NULL, NULL, NULL, ?, NULL, NULL, ?, NULL, ?)
+      RETURNING id
+    `, [project.id, floorplan.id, 'Test Lamp', 0, area.id]);
+    const bomId = bomRows[0]!.id;
+    db.query(`
+      INSERT INTO placements (bom_id, floorplan_id, type, area_id, x, y, width, height, rotation)
+      VALUES (?, ?, 'item', ?, 10, 10, 1, 1, 0)
+    `, [bomId, floorplan.id, area.id]);
+
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+    const result = await getFloorplanBomTool.handler({ floorplan_id: floorplan.id }, { app, accessToken: token });
+    assertEquals(result.isError, undefined);
+    const text = result.content[0]!.text!;
+    assert(text.includes('"floorplan_name": "Main Floor"'));
+    assert(text.includes('"version_name": "v1"'));
+    assert(text.includes('"area_name": "Wohnzimmer"'));
+  });
+});
+
+Deno.test('get_item_picture tool', async (t) => {
+  await setupTestDatabase();
+
+  await t.step('returns an image content block for a BOM entry with picture_path', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
+    const user = await userRepository.create({
+      email: 'pic@example.com', password_hash: 'x', role: 'user',
+      full_name: 'P', tenant_id: tenant.id,
+    } as CreateUserDTO & { password_hash: string });
+    const project = await projectRepository.create({
+      version_name: 'v1', customer_name: 'Pic Customer', tenant_id: tenant.id,
+    } as CreateProjectDTO);
+    const floorplan = await floorplanRepository.create({
+      project_id: project.id, name: 'Main', image_path: 'test.png',
+    } as CreateFloorplanDTO);
+
+    // Write a tiny fixture file inside the test uploads dir
+    const subdir = `projects/${project.id}/bom-images`;
+    await fileStorageService.ensureDirectory(subdir);
+    const relPath = `${subdir}/test-pic.png`;
+    const fakeBytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3, 4]);
+    await Deno.writeFile(fileStorageService.getFilePath(relPath), fakeBytes);
+
+    const db = getDb();
+    const bomRows = db.queryEntries<{ id: number }>(`
+      INSERT INTO project_bom (
+        project_id, floorplan_id, item_id, variant_id, parent_bom_id,
+        item_name, style_name, model_number, unit_price, picture_path
+      ) VALUES (?, ?, NULL, NULL, NULL, ?, NULL, NULL, ?, ?)
+      RETURNING id
+    `, [project.id, floorplan.id, 'Pic Lamp', 0, relPath]);
+    const bomId = bomRows[0]!.id;
+
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+    const result = await getItemPictureTool.handler({ bom_id: bomId }, { app, accessToken: token });
+
+    try {
+      assertEquals(result.isError, undefined);
+      const img = result.content.find(b => b.type === 'image');
+      assertEquals(img?.type, 'image');
+      assertEquals(img?.mimeType, 'image/png');
+      assert((img?.data?.length ?? 0) > 0);
+    } finally {
+      await fileStorageService.deleteFile(relPath).catch(() => {});
+    }
+  });
+
+  await t.step('returns isError for BOM entry with no picture_path', async () => {
+    await clearDatabase();
+    const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
+    const user = await userRepository.create({
+      email: 'pic2@example.com', password_hash: 'x', role: 'user',
+      full_name: 'P', tenant_id: tenant.id,
+    } as CreateUserDTO & { password_hash: string });
+    const project = await projectRepository.create({
+      version_name: 'v1', customer_name: 'Pic Customer 2', tenant_id: tenant.id,
+    } as CreateProjectDTO);
+    const floorplan = await floorplanRepository.create({
+      project_id: project.id, name: 'Main', image_path: 'test.png',
+    } as CreateFloorplanDTO);
+
+    const db = getDb();
+    const bomRows = db.queryEntries<{ id: number }>(`
+      INSERT INTO project_bom (
+        project_id, floorplan_id, item_id, variant_id, parent_bom_id,
+        item_name, style_name, model_number, unit_price, picture_path
+      ) VALUES (?, ?, NULL, NULL, NULL, ?, NULL, NULL, ?, NULL)
+      RETURNING id
+    `, [project.id, floorplan.id, 'No-pic Lamp', 0]);
+    const bomId = bomRows[0]!.id;
+
+    const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+    const result = await getItemPictureTool.handler({ bom_id: bomId }, { app, accessToken: token });
     assertEquals(result.isError, true);
   });
 });

--- a/backend/tests/routes/bom_entries_test.ts
+++ b/backend/tests/routes/bom_entries_test.ts
@@ -1,0 +1,91 @@
+import { assertEquals } from '@std/assert';
+import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
+import { testRequest, parseJSON } from '../test-client.ts';
+import { generateToken } from '../../src/services/jwt.ts';
+import { getDb } from '../../src/config/database.ts';
+
+await setupTestDatabase();
+
+const { tenantRepository } = await import('../../src/repositories/tenant.ts');
+const { userRepository } = await import('../../src/repositories/user.ts');
+const { projectRepository } = await import('../../src/repositories/project.ts');
+const { floorplanRepository } = await import('../../src/repositories/floorplan.ts');
+
+async function seedBomEntry(tenantName: string, userEmail: string) {
+  const tenant = await tenantRepository.create({ name: tenantName });
+  const user = await userRepository.create({
+    email: userEmail,
+    password_hash: 'x',
+    role: 'user',
+    full_name: 'U',
+    tenant_id: tenant.id,
+  });
+  const project = await projectRepository.create({
+    version_name: 'v1',
+    customer_name: 'Customer',
+    tenant_id: tenant.id,
+  });
+  const floorplan = await floorplanRepository.create({
+    project_id: project.id,
+    name: 'Main',
+    image_path: 'test.png',
+  });
+  const rows = getDb().queryEntries<{ id: number }>(`
+    INSERT INTO project_bom (
+      project_id, floorplan_id, item_id, variant_id, parent_bom_id,
+      item_name, style_name, model_number, unit_price, picture_path
+    ) VALUES (?, ?, NULL, NULL, NULL, ?, NULL, NULL, ?, NULL)
+    RETURNING id
+  `, [project.id, floorplan.id, 'Some Lamp', 0]);
+  const token = await generateToken(user.id, user.email, user.role, user.tenant_id);
+  return { tenant, user, bomId: rows[0]!.id, token };
+}
+
+Deno.test('GET /api/bom-entries/:id', async (t) => {
+  await t.step('owner can read their BOM entry', async () => {
+    await clearDatabase();
+    const { bomId, token } = await seedBomEntry('A', 'a@example.com');
+    const res = await testRequest(`/api/bom-entries/${bomId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assertEquals(res.status, 200);
+    const body = await parseJSON(res);
+    assertEquals(body.data.id, bomId);
+    assertEquals(body.data.item_name, 'Some Lamp');
+  });
+
+  await t.step('user from another tenant gets 404', async () => {
+    await clearDatabase();
+    const { bomId } = await seedBomEntry('A', 'a2@example.com');
+    const { token: tokenB } = await seedBomEntry('B', 'b@example.com');
+    const res = await testRequest(`/api/bom-entries/${bomId}`, {
+      headers: { Authorization: `Bearer ${tokenB}` },
+    });
+    assertEquals(res.status, 404);
+  });
+
+  await t.step('returns 400 for non-numeric id', async () => {
+    await clearDatabase();
+    const { token } = await seedBomEntry('A', 'a3@example.com');
+    const res = await testRequest('/api/bom-entries/not-a-number', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assertEquals(res.status, 400);
+  });
+
+  await t.step('returns 404 for unknown id', async () => {
+    await clearDatabase();
+    const { token } = await seedBomEntry('A', 'a4@example.com');
+    const res = await testRequest('/api/bom-entries/999999', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assertEquals(res.status, 404);
+  });
+
+  await t.step('returns 401 without auth', async () => {
+    await clearDatabase();
+    const { bomId } = await seedBomEntry('A', 'a5@example.com');
+    const res = await testRequest(`/api/bom-entries/${bomId}`);
+    assertEquals(res.status, 401);
+  });
+});

--- a/backend/tests/routes/mcp_test.ts
+++ b/backend/tests/routes/mcp_test.ts
@@ -33,7 +33,7 @@ Deno.test('POST /mcp', async (t) => {
     assert(wwwAuth.includes('resource_metadata'));
   });
 
-  await t.step('tools/list returns the 8 tools when authenticated', async () => {
+  await t.step('tools/list returns the 10 tools when authenticated', async () => {
     await clearDatabase();
     const tenant = await tenantRepository.create({ name: 'T' } as CreateTenantDTO);
     const user = await userRepository.create({
@@ -52,7 +52,9 @@ Deno.test('POST /mcp', async (t) => {
     const names = body.result.tools.map((t: { name: string }) => t.name).sort();
     assertEquals(names, [
       'get_floorplan_bom',
+      'get_floorplan_image',
       'get_invoice_calculation',
+      'get_item_picture',
       'get_project',
       'get_version_total',
       'list_areas',

--- a/backend/tests/routes/projects_test.ts
+++ b/backend/tests/routes/projects_test.ts
@@ -1,8 +1,9 @@
-import { assertEquals, assertExists } from '@std/assert';
+import { assertEquals, assert, assertExists } from '@std/assert';
 import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
 import { testRequest, parseJSON } from '../test-client.ts';
 import { hashPassword } from '../../src/services/password.ts';
 import { getDb } from '../../src/config/database.ts';
+import { fileStorageService } from '../../src/services/file-storage.ts';
 
 // Setup test database before all tests
 await setupTestDatabase();
@@ -380,6 +381,59 @@ Deno.test('Project - cannot access without auth', async () => {
 });
 
 // ── Delete Tests ─────────────────────────────────────────────────
+
+Deno.test('Project - deleting a version unlinks its BOM picture files', async () => {
+  const token = await getAuthToken();
+
+  const createResponse = await testRequest('/api/projects', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ customer_name: 'Folder Cleanup Test' }),
+  });
+  assertEquals(createResponse.status, 201);
+  const v1 = (await parseJSON(createResponse)).data;
+  const groupId = v1.project_group_id;
+
+  const v2Response = await testRequest(`/api/project-groups/${groupId}/versions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ version_name: 'v2', source_project_id: v1.id }),
+  });
+  assertEquals(v2Response.status, 201);
+
+  const db = getDb();
+  const fpRows = db.queryEntries<{ id: number }>(`
+    INSERT INTO floorplans (project_id, name, image_path, sort_order)
+    VALUES (?, ?, ?, 0)
+    RETURNING id
+  `, [v1.id, 'Cleanup Floor', `floorplans/dummy-${v1.id}.png`]);
+  const floorplanId = fpRows[0]!.id;
+
+  const v1Dir = `projects/${v1.id}/bom-images`;
+  await fileStorageService.ensureDirectory(v1Dir);
+  // Unique fixture name so this test doesn't collide with leftover dev data
+  const v1Path = `${v1Dir}/test-cleanup-${Date.now()}.png`;
+  await Deno.writeFile(fileStorageService.getFilePath(v1Path), new Uint8Array([0, 1, 2]));
+  db.query(`
+    INSERT INTO project_bom (
+      project_id, floorplan_id, item_id, variant_id, parent_bom_id,
+      item_name, style_name, model_number, unit_price, picture_path
+    ) VALUES (?, ?, NULL, NULL, NULL, ?, NULL, NULL, ?, ?)
+  `, [v1.id, floorplanId, 'Cleanup Lamp', 0, v1Path]);
+
+  assert(await fileStorageService.fileExists(v1Path));
+
+  const deleteResponse = await testRequest(`/api/projects/${v1.id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assertEquals(deleteResponse.status, 200);
+
+  // File for the deleted version must be gone. (The empty-folder cleanup runs
+  // afterwards; we don't assert on the folder here because dev/test runs leave
+  // unrelated leftover files in projects/<id>/ that the test doesn't own.)
+  assertEquals(await fileStorageService.fileExists(v1Path), false);
+});
 
 Deno.test('Project - can delete a non-last version', async () => {
   const token = await getAuthToken();


### PR DESCRIPTION
## Summary
- **Empty-folder cleanup on version delete.** `_deleteVersionData` now removes the now-empty `projects/{id}/bom-images` and `projects/{id}` folders after files are unlinked. No-op if anything remains.
- **`area_name` in `get_floorplan_bom`.** Each entry with an `area_id` is decorated with the human-readable area name so cross-version comparisons match by display name.
- **`floorplan_name` and `version_name` in `get_floorplan_bom`.** Same reason: surrogate ids differ across versions, names don't.
- **New `get_item_picture(bom_id)` MCP tool.** Returns a single placement's picture as an inline image. Backed by a new `GET /api/bom-entries/:id` route that's tenant-scoped.
- **New `get_floorplan_image(floorplan_id)` MCP tool.** Returns the floorplan background as an inline image.
- `ToolContentBlock` widened to optional `text`/`data`/`mimeType` so image blocks coexist with text blocks.

## Test plan
- [x] `deno lint`
- [x] `deno task test` — 312 passed
- [x] `tools/list` now returns 10 tools, including the two new image tools
- [ ] After merge: pull image on prod, verify `get_item_picture` returns a usable image content block and `get_floorplan_bom` exposes `floorplan_name` / `version_name` / `area_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)