### PR TITLE
Fix product-type catalog import isolation

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -29,6 +29,28 @@ export async function authMiddleware(c: Context, next: Next): Promise<Response |
 }
 
 /**
+ * Optional auth middleware - populates identity for valid bearer tokens
+ * while preserving access to public routes when no valid token is supplied.
+ */
+export async function optionalAuthMiddleware(c: Context, next: Next): Promise<Response | void> {
+  const authHeader = c.req.header('Authorization');
+
+  if (authHeader?.startsWith('Bearer ')) {
+    try {
+      const payload = await verifyToken(authHeader.substring(7));
+      c.set('userId', parseInt(payload.sub));
+      c.set('userEmail', payload.email);
+      c.set('userRole', payload.role);
+      c.set('tenantId', payload.tenantId);
+    } catch {
+      // Optional authentication keeps public catalog reads available.
+    }
+  }
+
+  await next();
+}
+
+/**
  * Tenant admin middleware - checks if user has tenant_admin or admin role
  * Must be used after authMiddleware
  */

--- a/backend/src/repositories/category.ts
+++ b/backend/src/repositories/category.ts
@@ -41,6 +41,14 @@ export class CategoryRepository {
     return Promise.resolve(result.length > 0 ? (result[0] as unknown as Category) : null);
   }
 
+  hasActiveItems(categoryId: number): Promise<boolean> {
+    const result = getDb().queryEntries<{ count: number }>(
+      'SELECT COUNT(*) AS count FROM items WHERE category_id = ? AND is_active = true',
+      [categoryId],
+    );
+    return Promise.resolve(result[0].count > 0);
+  }
+
   deactivate(id: number): Promise<Category | null> {
     // Deactivate the category
     const result = getDb().queryEntries(`

--- a/backend/src/repositories/item.ts
+++ b/backend/src/repositories/item.ts
@@ -67,6 +67,10 @@ export class ItemRepository {
     const countResult = getDb().query(`SELECT COUNT(*) as total FROM items i LEFT JOIN item_types it ON i.type_id = it.id ${whereClause}`, values);
     const total = countResult[0][0] as number;
 
+    // Active-only catalog requests must not expose inactive variant images.
+    // Admin inactive-inclusive requests may use an inactive variant as preview.
+    const previewVariantFilter = filter?.include_inactive ? '' : 'AND iv.is_active = true';
+
     // Build query with first variant image
     let query = `
       SELECT
@@ -83,7 +87,7 @@ export class ItemRepository {
         it.abbreviation as type_abbreviation,
         it.color as type_color,
         (SELECT iv.image_path FROM item_variants iv
-         WHERE iv.item_id = i.id AND iv.is_active = true
+         WHERE iv.item_id = i.id ${previewVariantFilter}
          ORDER BY iv.sort_order ASC, iv.id ASC
          LIMIT 1) as preview_image
       FROM items i

--- a/backend/src/routes/items.ts
+++ b/backend/src/routes/items.ts
@@ -6,7 +6,7 @@ import { itemVariantRepository } from '../repositories/item-variant.ts';
 import { variantAddonRepository } from '../repositories/variant-addon.ts';
 import { categoryRepository } from '../repositories/category.ts';
 import { bomEntryRepository } from '../repositories/bom-entry.ts';
-import { authMiddleware, adminMiddleware } from '../middleware/auth.ts';
+import { authMiddleware, adminMiddleware, optionalAuthMiddleware } from '../middleware/auth.ts';
 import { uploadMiddleware } from '../middleware/upload.ts';
 import { fileStorageService } from '../services/file-storage.ts';
 import type { CreateItemDTO, UpdateItemDTO, CreateItemVariantDTO, CreateVariantAddonDTO } from '../models/index.ts';
@@ -28,15 +28,15 @@ const itemRoutes = new Hono();
 
 // GET /items - List all items
 // Query params: category_id, search, page, limit, include_inactive (admin only)
-itemRoutes.get('/', async (c) => {
+itemRoutes.get('/', optionalAuthMiddleware, async (c) => {
   try {
     const categoryId = c.req.query('category_id');
     const typeId = c.req.query('type_id');
     const search = c.req.query('search');
     const page = parseInt(c.req.query('page') || '1', 10);
     const limit = Math.min(parseInt(c.req.query('limit') || '20', 10), 100);
-    // Only allow include_inactive for authenticated users
-    const includeInactive = c.req.query('include_inactive') === 'true' && !!c.get('userId');
+    // Only allow include_inactive for administrators
+    const includeInactive = c.req.query('include_inactive') === 'true' && c.get('userRole') === 'admin';
 
     const filter: { category_id?: number | null; type_id?: number; search?: string; include_inactive?: boolean } = {};
     
@@ -424,13 +424,13 @@ itemRoutes.delete('/:id', authMiddleware, adminMiddleware, async (c) => {
 
 // GET /items/:id/variants - Get all variants for an item
 // Query param: include_inactive=true (admin only) to include inactive variants
-itemRoutes.get('/:id/variants', async (c) => {
+itemRoutes.get('/:id/variants', optionalAuthMiddleware, async (c) => {
   try {
     const itemId = parseInt(c.req.param('id'));
     if (isNaN(itemId)) {
       return c.json({ error: 'Invalid ID' }, 400);
     }
-    const includeInactive = c.req.query('include_inactive') === 'true' && !!c.get('userId');
+    const includeInactive = c.req.query('include_inactive') === 'true' && c.get('userRole') === 'admin';
     
     const item = await itemRepository.findById(itemId);
     if (!item) {

--- a/backend/src/services/excel-sync.ts
+++ b/backend/src/services/excel-sync.ts
@@ -146,6 +146,9 @@ export class ExcelSyncService {
         // Phase 4: Sync Variant Addons
         await this.syncVariantAddons(groupedItems, itemIdMap, result);
 
+        // Phase 5: Deactivate categories only when no active products remain
+        await this.deactivateEmptyCategories(groupedItems, result);
+
         // Set last sync timestamp
         await settingsRepository.setLastSyncTimestamp(Date.now());
 
@@ -428,7 +431,7 @@ export class ExcelSyncService {
    * Phase 1: Sync Categories
    * - Create new categories from Excel
    * - Activate categories that exist in Excel
-   * - Deactivate categories not in Excel
+   * - Defer deactivation until product synchronization is complete
    */
   private async syncCategories(
     groupedItems: Record<string, GroupedItem>,
@@ -467,17 +470,45 @@ export class ExcelSyncService {
       }
     }
 
-    // Deactivate categories not in Excel
-    for (const dbCat of dbCategories) {
-      if (!excelCategories.has(dbCat.name) && dbCat.is_active) {
-        await categoryRepository.deactivate(dbCat.id);
-        result.phases.categories.deactivated++;
-        this.log(result, `  ✗ Deactivated category: ${dbCat.name}`, 'categories');
+    result.phases.categories.total = excelCategories.size;
+    this.log(
+      result,
+      `✓ Categories prepared: ${result.phases.categories.added} added, ${result.phases.categories.activated} activated`,
+      'categories',
+    );
+  }
+
+  private async deactivateEmptyCategories(
+    groupedItems: Record<string, GroupedItem>,
+    result: SyncResult,
+  ): Promise<void> {
+    const excelCategoryNames = new Set(
+      Object.values(groupedItems)
+        .map((item) => item.category.trim().toLowerCase())
+        .filter(Boolean),
+    );
+    const dbCategories = await categoryRepository.findAll(true);
+
+    for (const category of dbCategories) {
+      const isPresentInExcel = excelCategoryNames.has(category.name.trim().toLowerCase());
+      if (isPresentInExcel || !category.is_active) {
+        continue;
       }
+
+      if (await categoryRepository.hasActiveItems(category.id)) {
+        continue;
+      }
+
+      await categoryRepository.deactivate(category.id);
+      result.phases.categories.deactivated++;
+      this.log(result, `  ✗ Deactivated empty category: ${category.name}`, 'categories');
     }
 
-    result.phases.categories.total = excelCategories.size;
-    this.log(result, `✓ Categories synced: ${result.phases.categories.added} added, ${result.phases.categories.activated} activated, ${result.phases.categories.deactivated} deactivated`, 'categories');
+    this.log(
+      result,
+      `✓ Category cleanup complete: ${result.phases.categories.deactivated} empty categories deactivated`,
+      'categories',
+    );
   }
 
   /**

--- a/backend/tests/routes/items_test.ts
+++ b/backend/tests/routes/items_test.ts
@@ -36,6 +36,25 @@ async function getAdminToken(): Promise<string> {
   return loginData.data.accessToken;
 }
 
+async function createNonAdminToken(email: string): Promise<string> {
+  const passwordHash = hashPassword('user123');
+  await userRepository.create({
+    email,
+    password_hash: passwordHash,
+    role: 'user',
+    tenant_id: 1,
+  });
+
+  const loginResponse = await testRequest('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: 'user123' }),
+  });
+
+  const loginData = await parseJSON(loginResponse);
+  return loginData.data.accessToken;
+}
+
 Deno.test('GET /items - should list all items (public)', async () => {
   clearDatabase();
   
@@ -114,6 +133,71 @@ Deno.test('GET /items - should search items', async () => {
   assertEquals(response.status, 200);
   assertEquals(data.data.length, 1);
   assertEquals(data.data[0].name, 'Smart Bulb Pro');
+});
+
+Deno.test('GET /items - admin include_inactive returns inactive items', async () => {
+  const token = await getAdminToken();
+  const nonAdminToken = await createNonAdminToken('user-items@example.com');
+  const category = await categoryRepository.create({ name: 'Lighting' });
+  await itemRepository.create({
+    category_id: category.id,
+    name: 'Active Product',
+    base_model_number: 'ACTIVE-1',
+    type_id: 1,
+  });
+  const inactiveItem = await itemRepository.create({
+    category_id: category.id,
+    name: 'Inactive Product',
+    base_model_number: 'INACTIVE-1',
+    type_id: 1,
+  });
+  const inactivePreviewVariant = await itemVariantRepository.create({
+    item_id: inactiveItem.id,
+    style_name: 'Inactive Style',
+    price: 20,
+    image_path: 'items/inactive-preview.png',
+  });
+  await itemRepository.deactivate(inactiveItem.id);
+
+  const inactivePreviewVariantAfterDeactivation = await itemVariantRepository.findById(inactivePreviewVariant.id);
+  assertExists(inactivePreviewVariantAfterDeactivation);
+  assertEquals(Boolean(inactivePreviewVariantAfterDeactivation.is_active), false);
+
+  const publicResponse = await testRequest('/api/items?include_inactive=true');
+  const publicData = await parseJSON(publicResponse);
+  assertEquals(publicResponse.status, 200);
+  assertEquals(publicData.data.map((item: { name: string }) => item.name), ['Active Product']);
+
+  const nonAdminResponse = await testRequest('/api/items?include_inactive=true', {
+    headers: { Authorization: `Bearer ${nonAdminToken}` },
+  });
+  const nonAdminData = await parseJSON(nonAdminResponse);
+  assertEquals(nonAdminResponse.status, 200);
+  assertEquals(nonAdminData.data.map((item: { name: string }) => item.name), ['Active Product']);
+
+  const invalidTokenResponse = await testRequest('/api/items?include_inactive=true', {
+    headers: { Authorization: 'Bearer invalid-token' },
+  });
+  const invalidTokenData = await parseJSON(invalidTokenResponse);
+  assertEquals(invalidTokenResponse.status, 200);
+  assertEquals(invalidTokenData.data.map((item: { name: string }) => item.name), ['Active Product']);
+
+  const adminResponse = await testRequest('/api/items?include_inactive=true', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const adminData = await parseJSON(adminResponse);
+  assertEquals(adminResponse.status, 200);
+  assertEquals(adminData.data.length, 2);
+  assertEquals(adminData.data.some((item: { id: number }) => item.id === inactiveItem.id), true);
+  const returnedInactiveItem = adminData.data.find((item: { id: number }) => item.id === inactiveItem.id);
+  assertEquals(returnedInactiveItem.preview_image, 'items/inactive-preview.png');
+
+  const inactiveItemAfter = await itemRepository.findById(inactiveItem.id);
+  const inactivePreviewVariantAfter = await itemVariantRepository.findById(inactivePreviewVariant.id);
+  assertExists(inactiveItemAfter);
+  assertExists(inactivePreviewVariantAfter);
+  assertEquals(Boolean(inactiveItemAfter.is_active), false);
+  assertEquals(Boolean(inactivePreviewVariantAfter.is_active), false);
 });
 
 Deno.test('GET /items/:id - should get single item with variants', async () => {
@@ -373,6 +457,56 @@ Deno.test('GET /items/:id/variants - should list variants', async () => {
   assertEquals(data.data.length, 2);
   assertEquals(data.data[0].style_name, 'White');
   assertEquals(data.data[1].style_name, 'Black');
+});
+
+Deno.test('GET /items/:id/variants - admin include_inactive returns inactive variants', async () => {
+  const token = await getAdminToken();
+  const nonAdminToken = await createNonAdminToken('user-variants@example.com');
+  const category = await categoryRepository.create({ name: 'Lighting' });
+  const item = await itemRepository.create({
+    category_id: category.id,
+    name: 'Product',
+    base_model_number: 'PRODUCT-1',
+    type_id: 1,
+  });
+  await itemVariantRepository.create({ item_id: item.id, style_name: 'Active Style', price: 10 });
+  const inactiveVariant = await itemVariantRepository.create({
+    item_id: item.id,
+    style_name: 'Inactive Style',
+    price: 20,
+  });
+  await itemVariantRepository.deactivate(inactiveVariant.id);
+
+  const publicResponse = await testRequest(`/api/items/${item.id}/variants?include_inactive=true`);
+  const publicData = await parseJSON(publicResponse);
+  assertEquals(publicResponse.status, 200);
+  assertEquals(publicData.data.map((variant: { style_name: string }) => variant.style_name), ['Active Style']);
+
+  const nonAdminResponse = await testRequest(`/api/items/${item.id}/variants?include_inactive=true`, {
+    headers: { Authorization: `Bearer ${nonAdminToken}` },
+  });
+  const nonAdminData = await parseJSON(nonAdminResponse);
+  assertEquals(nonAdminResponse.status, 200);
+  assertEquals(nonAdminData.data.map((variant: { style_name: string }) => variant.style_name), ['Active Style']);
+
+  const invalidTokenResponse = await testRequest(`/api/items/${item.id}/variants?include_inactive=true`, {
+    headers: { Authorization: 'Bearer invalid-token' },
+  });
+  const invalidTokenData = await parseJSON(invalidTokenResponse);
+  assertEquals(invalidTokenResponse.status, 200);
+  assertEquals(invalidTokenData.data.map((variant: { style_name: string }) => variant.style_name), ['Active Style']);
+
+  const adminResponse = await testRequest(`/api/items/${item.id}/variants?include_inactive=true`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const adminData = await parseJSON(adminResponse);
+  assertEquals(adminResponse.status, 200);
+  assertEquals(adminData.data.length, 2);
+  assertEquals(adminData.data.some((variant: { id: number }) => variant.id === inactiveVariant.id), true);
+
+  const inactiveVariantAfter = await itemVariantRepository.findById(inactiveVariant.id);
+  assertExists(inactiveVariantAfter);
+  assertEquals(Boolean(inactiveVariantAfter.is_active), false);
 });
 
 Deno.test('POST /items/:id/variants - should create variant (admin)', async () => {

--- a/backend/tests/services/excel-sync_test.ts
+++ b/backend/tests/services/excel-sync_test.ts
@@ -1,9 +1,11 @@
 import { assertEquals, assertExists } from '@std/assert';
+import * as xlsx from 'xlsx';
 import { setupTestDatabase, clearDatabase } from '../test-utils.ts';
 import { excelSyncService } from '../../src/services/excel-sync.ts';
 import { categoryRepository } from '../../src/repositories/category.ts';
 import { itemRepository } from '../../src/repositories/item.ts';
 import { itemVariantRepository } from '../../src/repositories/item-variant.ts';
+import { itemTypeRepository } from '../../src/repositories/item-type.ts';
 
 // Setup test database before all tests
 await setupTestDatabase();
@@ -154,6 +156,73 @@ Deno.test("ExcelSyncService - variant can have image path", async () => {
   
   const updated = await itemVariantRepository.findById(variant.id);
   assertEquals(updated?.image_path, 'items/excel-import/image2.png');
+});
+
+Deno.test('ExcelSyncService - import only deactivates missing items from the selected product type', async () => {
+  clearDatabase();
+
+  const importedType = await itemTypeRepository.create({
+    name: 'Imported Type',
+    abbreviation: 'IMP',
+  });
+  const protectedType = await itemTypeRepository.create({
+    name: 'Protected Type',
+    abbreviation: 'PRO',
+  });
+
+  const sharedCategory = await categoryRepository.create({ name: 'Shared Category' });
+  const emptyAfterImportCategory = await categoryRepository.create({ name: 'Obsolete Category' });
+
+  const missingImportedItem = await itemRepository.create({
+    category_id: emptyAfterImportCategory.id,
+    type_id: importedType.id,
+    name: 'Missing Imported Product',
+    base_model_number: 'IMP-OLD',
+  });
+  const protectedItem = await itemRepository.create({
+    category_id: sharedCategory.id,
+    type_id: protectedType.id,
+    name: 'Protected Product',
+    base_model_number: 'PRO-KEEP',
+  });
+
+  const worksheet = xlsx.utils.aoa_to_sheet([
+    [],
+    [],
+    [],
+    ['Imported Category', '', '', 'Current Imported Product', '', 'IMP-NEW', '', 'Default', 'IMP-NEW-DEFAULT', 100],
+  ]);
+  const workbook = xlsx.utils.book_new();
+  xlsx.utils.book_append_sheet(workbook, worksheet, 'Catalog');
+  const workbookBytes = xlsx.write(workbook, { type: 'array', bookType: 'xlsx' });
+  const relativePath = 'imports/product-type-scope-test.xlsx';
+  const fullPath = `./uploads/${relativePath}`;
+
+  await Deno.mkdir('./uploads/imports', { recursive: true });
+  await Deno.writeFile(fullPath, new Uint8Array(workbookBytes));
+
+  try {
+    const result = await excelSyncService.syncCatalog(relativePath, importedType.id);
+
+    assertEquals(result.success, true);
+    assertEquals(result.phases.items.deactivated, 1);
+
+    const missingImportedAfter = await itemRepository.findById(missingImportedItem.id);
+    const protectedAfter = await itemRepository.findById(protectedItem.id);
+    const sharedCategoryAfter = await categoryRepository.findById(sharedCategory.id);
+    const emptyCategoryAfter = await categoryRepository.findById(emptyAfterImportCategory.id);
+
+    assertExists(missingImportedAfter);
+    assertExists(protectedAfter);
+    assertExists(sharedCategoryAfter);
+    assertExists(emptyCategoryAfter);
+    assertEquals(Boolean(missingImportedAfter.is_active), false);
+    assertEquals(Boolean(protectedAfter.is_active), true);
+    assertEquals(Boolean(sharedCategoryAfter.is_active), true);
+    assertEquals(Boolean(emptyCategoryAfter.is_active), false);
+  } finally {
+    await Deno.remove(fullPath).catch(() => {});
+  }
 });
 
 Deno.test("ExcelSyncService - variant addons can be linked", async () => {

--- a/docs/superpowers/plans/2026-07-12-product-type-catalog-import-scope.md
+++ b/docs/superpowers/plans/2026-07-12-product-type-catalog-import-scope.md
@@ -1,0 +1,250 @@
+# Product-Type-Scoped Catalog Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent a catalog import for one product type from deactivating products belonging to another product type while still deactivating genuinely empty categories.
+
+**Architecture:** Keep product synchronization scoped by the selected `typeId`. Split category synchronization into an early create/reactivate pass and a late cleanup pass; the cleanup deactivates a category only when no active product of any type remains in it. Preserve the existing transaction and soft-deletion behavior.
+
+**Tech Stack:** Deno 2.8, TypeScript strict mode, SQLite, npm `xlsx`, Deno.test, `@std/assert`
+
+## Global Constraints
+
+- Catalog import uses soft deletion only: products and categories remain in the database with `is_active = false`.
+- An import may deactivate products only for its selected product type.
+- A category shared with any active product remains active.
+- A category absent from the Excel file may be deactivated only after synchronization leaves it with zero active products across all product types.
+- Keep every database mutation inside the existing `syncCatalog` transaction.
+- Do not change frontend behavior, API request/response formats, migrations, or database schema.
+
+---
+
+## File Structure
+
+- Modify `backend/tests/services/excel-sync_test.ts`: add a public-API regression test that builds a minimal workbook and verifies cross-type isolation, empty-category cleanup, and retained database records.
+- Modify `backend/src/repositories/category.ts`: add the focused `hasActiveItems(categoryId)` query used to guard category deactivation.
+- Modify `backend/src/services/excel-sync.ts`: stop deactivating categories during the initial pass and add guarded cleanup after item/variant/add-on synchronization.
+
+### Task 1: Scope Catalog Deactivation by Product Type
+
+**Files:**
+- Modify: `backend/tests/services/excel-sync_test.ts`
+- Modify: `backend/src/repositories/category.ts`
+- Modify: `backend/src/services/excel-sync.ts`
+
+**Interfaces:**
+- Consumes: `ExcelSyncService.syncCatalog(excelPath: string, typeId: number): Promise<SyncResult>` and the existing category/item repository APIs.
+- Produces: `CategoryRepository.hasActiveItems(categoryId: number): Promise<boolean>`.
+- Preserves: the `SyncResult` structure, the `/api/items/sync-catalog?type_id=...` contract, and transaction rollback behavior.
+
+- [ ] **Step 1: Write the failing cross-type regression test**
+
+Add the `xlsx` and item-type imports at the top of `backend/tests/services/excel-sync_test.ts`:
+
+```typescript
+import * as xlsx from 'xlsx';
+import { itemTypeRepository } from '../../src/repositories/item-type.ts';
+```
+
+Then add this test after the existing repository tests:
+
+```typescript
+Deno.test('ExcelSyncService - import only deactivates missing items from the selected product type', async () => {
+  clearDatabase();
+
+  const importedType = await itemTypeRepository.create({
+    name: 'Imported Type',
+    abbreviation: 'IMP',
+  });
+  const protectedType = await itemTypeRepository.create({
+    name: 'Protected Type',
+    abbreviation: 'PRO',
+  });
+
+  const sharedCategory = await categoryRepository.create({ name: 'Shared Category' });
+  const emptyAfterImportCategory = await categoryRepository.create({ name: 'Obsolete Category' });
+
+  const missingImportedItem = await itemRepository.create({
+    category_id: emptyAfterImportCategory.id,
+    type_id: importedType.id,
+    name: 'Missing Imported Product',
+    base_model_number: 'IMP-OLD',
+  });
+  const protectedItem = await itemRepository.create({
+    category_id: sharedCategory.id,
+    type_id: protectedType.id,
+    name: 'Protected Product',
+    base_model_number: 'PRO-KEEP',
+  });
+
+  const worksheet = xlsx.utils.aoa_to_sheet([
+    [],
+    [],
+    [],
+    ['Imported Category', '', '', 'Current Imported Product', '', 'IMP-NEW', '', 'Default', 'IMP-NEW-DEFAULT', 100],
+  ]);
+  const workbook = xlsx.utils.book_new();
+  xlsx.utils.book_append_sheet(workbook, worksheet, 'Catalog');
+  const workbookBytes = xlsx.write(workbook, { type: 'array', bookType: 'xlsx' });
+  const relativePath = 'imports/product-type-scope-test.xlsx';
+  const fullPath = `./uploads/${relativePath}`;
+
+  await Deno.mkdir('./uploads/imports', { recursive: true });
+  await Deno.writeFile(fullPath, new Uint8Array(workbookBytes));
+
+  try {
+    const result = await excelSyncService.syncCatalog(relativePath, importedType.id);
+
+    assertEquals(result.success, true);
+    assertEquals(result.phases.items.deactivated, 1);
+
+    const missingImportedAfter = await itemRepository.findById(missingImportedItem.id);
+    const protectedAfter = await itemRepository.findById(protectedItem.id);
+    const sharedCategoryAfter = await categoryRepository.findById(sharedCategory.id);
+    const emptyCategoryAfter = await categoryRepository.findById(emptyAfterImportCategory.id);
+
+    assertExists(missingImportedAfter);
+    assertExists(protectedAfter);
+    assertEquals(Boolean(missingImportedAfter.is_active), false);
+    assertEquals(Boolean(protectedAfter.is_active), true);
+    assertEquals(Boolean(sharedCategoryAfter?.is_active), true);
+    assertEquals(Boolean(emptyCategoryAfter?.is_active), false);
+  } finally {
+    await Deno.remove(fullPath).catch(() => {});
+  }
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify the current bug**
+
+Run:
+
+```bash
+cd backend && deno test --allow-all tests/services/excel-sync_test.ts --filter "import only deactivates"
+```
+
+Expected: FAIL because `protectedAfter.is_active` is `false`. The existing early category cleanup deactivates `Shared Category`, whose repository cascade deactivates `Protected Product` despite its different `type_id`.
+
+- [ ] **Step 3: Add the category active-item guard**
+
+Add this method to `CategoryRepository` in `backend/src/repositories/category.ts`, adjacent to `findByName`:
+
+```typescript
+  hasActiveItems(categoryId: number): Promise<boolean> {
+    const result = getDb().queryEntries<{ count: number }>(
+      'SELECT COUNT(*) AS count FROM items WHERE category_id = ? AND is_active = true',
+      [categoryId],
+    );
+    return Promise.resolve(result[0].count > 0);
+  }
+```
+
+This query deliberately has no `type_id` filter: category activity is shared globally, so any active product protects the category.
+
+- [ ] **Step 4: Make initial category synchronization non-destructive**
+
+Update the Phase 1 comment in `backend/src/services/excel-sync.ts` to state that it creates/reactivates categories and defers cleanup. In `syncCategories`, remove the existing `// Deactivate categories not in Excel` loop entirely. Retain category creation/reactivation and finish the method with:
+
+```typescript
+    result.phases.categories.total = excelCategories.size;
+    this.log(
+      result,
+      `✓ Categories prepared: ${result.phases.categories.added} added, ${result.phases.categories.activated} activated`,
+      'categories',
+    );
+```
+
+- [ ] **Step 5: Add guarded late category cleanup**
+
+Add this private method immediately after `syncCategories` in `backend/src/services/excel-sync.ts`:
+
+```typescript
+  private async deactivateEmptyCategories(
+    groupedItems: Record<string, GroupedItem>,
+    result: SyncResult,
+  ): Promise<void> {
+    const excelCategoryNames = new Set(
+      Object.values(groupedItems)
+        .map((item) => item.category.trim().toLowerCase())
+        .filter(Boolean),
+    );
+    const dbCategories = await categoryRepository.findAll(true);
+
+    for (const category of dbCategories) {
+      const isPresentInExcel = excelCategoryNames.has(category.name.trim().toLowerCase());
+      if (isPresentInExcel || !category.is_active) {
+        continue;
+      }
+
+      if (await categoryRepository.hasActiveItems(category.id)) {
+        continue;
+      }
+
+      await categoryRepository.deactivate(category.id);
+      result.phases.categories.deactivated++;
+      this.log(result, `  ✗ Deactivated empty category: ${category.name}`, 'categories');
+    }
+
+    this.log(
+      result,
+      `✓ Category cleanup complete: ${result.phases.categories.deactivated} empty categories deactivated`,
+      'categories',
+    );
+  }
+```
+
+In `syncCatalog`, call it after `syncVariantAddons` and before `setLastSyncTimestamp`:
+
+```typescript
+        // Phase 5: Deactivate categories only when no active products remain
+        await this.deactivateEmptyCategories(groupedItems, result);
+```
+
+- [ ] **Step 6: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+cd backend && deno test --allow-all tests/services/excel-sync_test.ts --filter "import only deactivates"
+```
+
+Expected: PASS. The selected-type product becomes inactive, the other-type product remains active, the shared category remains active, and the now-empty category becomes inactive while all records still exist.
+
+- [ ] **Step 7: Run the entire Excel sync test file**
+
+Run:
+
+```bash
+cd backend && deno test --allow-all tests/services/excel-sync_test.ts
+```
+
+Expected: all tests pass with zero failures.
+
+- [ ] **Step 8: Run backend lint and the complete backend suite**
+
+Run:
+
+```bash
+cd backend && deno lint
+cd backend && deno task test
+```
+
+Expected: lint reports no diagnostics and the full backend suite finishes with zero failed tests.
+
+- [ ] **Step 9: Review the diff for scope and whitespace errors**
+
+Run:
+
+```bash
+git diff --check
+git diff -- backend/src/repositories/category.ts backend/src/services/excel-sync.ts backend/tests/services/excel-sync_test.ts
+```
+
+Expected: `git diff --check` exits successfully. The diff contains only the regression test, category active-item query, deferred category cleanup, and orchestration call.
+
+- [ ] **Step 10: Commit the fix**
+
+```bash
+git add backend/src/repositories/category.ts backend/src/services/excel-sync.ts backend/tests/services/excel-sync_test.ts
+git commit -m "fix: scope catalog imports by product type"
+```

--- a/docs/superpowers/plans/2026-07-12-show-inactive-catalog.md
+++ b/docs/superpowers/plans/2026-07-12-show-inactive-catalog.md
@@ -23,9 +23,11 @@
 - Modify: `backend/tests/routes/items_test.ts`
 - Modify: `backend/src/middleware/auth.ts`
 - Modify: `backend/src/routes/items.ts`
+- Modify: `backend/src/repositories/item.ts`
 
 **Interfaces:**
 - Produces: `optionalAuthMiddleware(c: Context, next: Next): Promise<Response | void>`.
+- Produces: inactive-aware preview selection in `ItemRepository.findAll`.
 - Preserves: public `GET /api/items` and `GET /api/items/:id/variants` behavior.
 
 - [ ] **Step 1: Add failing route regression tests**
@@ -48,6 +50,12 @@ Deno.test('GET /items - admin include_inactive returns inactive items', async ()
     base_model_number: 'INACTIVE-1',
     type_id: 1,
   });
+  await itemVariantRepository.create({
+    item_id: inactiveItem.id,
+    style_name: 'Inactive Style',
+    price: 20,
+    image_path: 'items/inactive-preview.png',
+  });
   await itemRepository.deactivate(inactiveItem.id);
 
   const publicResponse = await testRequest('/api/items?include_inactive=true');
@@ -62,6 +70,8 @@ Deno.test('GET /items - admin include_inactive returns inactive items', async ()
   assertEquals(adminResponse.status, 200);
   assertEquals(adminData.data.length, 2);
   assertEquals(adminData.data.some((item: { id: number }) => item.id === inactiveItem.id), true);
+  const returnedInactiveItem = adminData.data.find((item: { id: number }) => item.id === inactiveItem.id);
+  assertEquals(returnedInactiveItem.preview_image, 'items/inactive-preview.png');
 });
 
 Deno.test('GET /items/:id/variants - admin include_inactive returns inactive variants', async () => {
@@ -139,6 +149,14 @@ const includeInactive = c.req.query('include_inactive') === 'true' && c.get('use
 ```
 
 - [ ] **Step 5: Verify GREEN and route regressions**
+
+Before verifying GREEN, update `ItemRepository.findAll` in `backend/src/repositories/item.ts` so its preview subquery filters active styles only for active-only requests:
+
+```typescript
+    const previewVariantFilter = filter?.include_inactive ? '' : 'AND iv.is_active = true';
+```
+
+Use `${previewVariantFilter}` after `WHERE iv.item_id = i.id` in the preview-image subquery. This retains inactive preview paths only for the administrator’s inactive-inclusive request.
 
 Run:
 

--- a/docs/superpowers/plans/2026-07-12-show-inactive-catalog.md
+++ b/docs/superpowers/plans/2026-07-12-show-inactive-catalog.md
@@ -1,0 +1,170 @@
+# Show Inactive Catalog Records Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the existing “Show inactive” control return inactive products and styles for administrators without removing public active-only catalog access.
+
+**Architecture:** Add optional JWT identity parsing that populates Hono context only when a valid bearer token is supplied. Apply it to the two public list routes and gate `include_inactive=true` on `userRole === 'admin'`.
+
+**Tech Stack:** Deno 2.8, Hono, TypeScript, JWT, SQLite, Deno.test
+
+## Global Constraints
+
+- Public unauthenticated catalog reads remain available and active-only.
+- Only administrators may retrieve inactive products or styles.
+- API response formats, frontend controls, schema, and migrations remain unchanged.
+- Use test-first development and preserve all existing tests.
+
+---
+
+### Task 1: Honor Show Inactive for Administrators
+
+**Files:**
+- Modify: `backend/tests/routes/items_test.ts`
+- Modify: `backend/src/middleware/auth.ts`
+- Modify: `backend/src/routes/items.ts`
+
+**Interfaces:**
+- Produces: `optionalAuthMiddleware(c: Context, next: Next): Promise<Response | void>`.
+- Preserves: public `GET /api/items` and `GET /api/items/:id/variants` behavior.
+
+- [ ] **Step 1: Add failing route regression tests**
+
+Add two tests to `backend/tests/routes/items_test.ts`. Each calls `getAdminToken()` first, creates one active and one inactive record, proves the public request omits the inactive record, then proves an administrator request with `include_inactive=true` includes both.
+
+```typescript
+Deno.test('GET /items - admin include_inactive returns inactive items', async () => {
+  const token = await getAdminToken();
+  const category = await categoryRepository.create({ name: 'Lighting' });
+  await itemRepository.create({
+    category_id: category.id,
+    name: 'Active Product',
+    base_model_number: 'ACTIVE-1',
+    type_id: 1,
+  });
+  const inactiveItem = await itemRepository.create({
+    category_id: category.id,
+    name: 'Inactive Product',
+    base_model_number: 'INACTIVE-1',
+    type_id: 1,
+  });
+  await itemRepository.deactivate(inactiveItem.id);
+
+  const publicResponse = await testRequest('/api/items?include_inactive=true');
+  const publicData = await parseJSON(publicResponse);
+  assertEquals(publicResponse.status, 200);
+  assertEquals(publicData.data.map((item: { name: string }) => item.name), ['Active Product']);
+
+  const adminResponse = await testRequest('/api/items?include_inactive=true', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const adminData = await parseJSON(adminResponse);
+  assertEquals(adminResponse.status, 200);
+  assertEquals(adminData.data.length, 2);
+  assertEquals(adminData.data.some((item: { id: number }) => item.id === inactiveItem.id), true);
+});
+
+Deno.test('GET /items/:id/variants - admin include_inactive returns inactive variants', async () => {
+  const token = await getAdminToken();
+  const category = await categoryRepository.create({ name: 'Lighting' });
+  const item = await itemRepository.create({
+    category_id: category.id,
+    name: 'Product',
+    base_model_number: 'PRODUCT-1',
+    type_id: 1,
+  });
+  await itemVariantRepository.create({ item_id: item.id, style_name: 'Active Style', price: 10 });
+  const inactiveVariant = await itemVariantRepository.create({
+    item_id: item.id,
+    style_name: 'Inactive Style',
+    price: 20,
+  });
+  await itemVariantRepository.deactivate(inactiveVariant.id);
+
+  const publicResponse = await testRequest(`/api/items/${item.id}/variants?include_inactive=true`);
+  const publicData = await parseJSON(publicResponse);
+  assertEquals(publicResponse.status, 200);
+  assertEquals(publicData.data.map((variant: { style_name: string }) => variant.style_name), ['Active Style']);
+
+  const adminResponse = await testRequest(`/api/items/${item.id}/variants?include_inactive=true`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const adminData = await parseJSON(adminResponse);
+  assertEquals(adminResponse.status, 200);
+  assertEquals(adminData.data.length, 2);
+  assertEquals(adminData.data.some((variant: { id: number }) => variant.id === inactiveVariant.id), true);
+});
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+cd backend && deno test --allow-all tests/routes/items_test.ts --filter "admin include_inactive"
+```
+
+Expected: both tests fail because authenticated requests still omit inactive records.
+
+- [ ] **Step 3: Add optional authentication**
+
+Add to `backend/src/middleware/auth.ts`:
+
+```typescript
+export async function optionalAuthMiddleware(c: Context, next: Next): Promise<Response | void> {
+  const authHeader = c.req.header('Authorization');
+
+  if (authHeader?.startsWith('Bearer ')) {
+    try {
+      const payload = await verifyToken(authHeader.substring(7));
+      c.set('userId', parseInt(payload.sub));
+      c.set('userEmail', payload.email);
+      c.set('userRole', payload.role);
+      c.set('tenantId', payload.tenantId);
+    } catch {
+      // Optional authentication keeps public catalog reads available.
+    }
+  }
+
+  await next();
+}
+```
+
+- [ ] **Step 4: Apply optional authentication and admin gating**
+
+Import `optionalAuthMiddleware` in `backend/src/routes/items.ts`. Add it before the handlers for `GET /` and `GET /:id/variants`, then replace both identity checks with:
+
+```typescript
+const includeInactive = c.req.query('include_inactive') === 'true' && c.get('userRole') === 'admin';
+```
+
+- [ ] **Step 5: Verify GREEN and route regressions**
+
+Run:
+
+```bash
+cd backend && deno test --allow-all tests/routes/items_test.ts --filter "admin include_inactive"
+cd backend && deno test --allow-all tests/routes/items_test.ts
+```
+
+Expected: focused tests pass, followed by all item-route tests passing.
+
+- [ ] **Step 6: Verify the backend**
+
+Run:
+
+```bash
+cd backend && deno lint
+cd backend && deno task test
+```
+
+Expected: lint has no diagnostics and all backend tests pass.
+
+- [ ] **Step 7: Review and commit**
+
+```bash
+git diff --check
+git diff -- backend/src/middleware/auth.ts backend/src/routes/items.ts backend/tests/routes/items_test.ts
+git add backend/src/middleware/auth.ts backend/src/routes/items.ts backend/tests/routes/items_test.ts
+git commit -m "fix: show inactive catalog records to admins"
+```

--- a/docs/superpowers/specs/2026-07-12-product-type-catalog-import-scope-design.md
+++ b/docs/superpowers/specs/2026-07-12-product-type-catalog-import-scope-design.md
@@ -1,0 +1,43 @@
+# Product-Type-Scoped Catalog Import
+
+## Problem
+
+Catalog import accepts a selected product type and correctly intends to deactivate products of that type when they are absent from the imported Excel file. Category synchronization currently deactivates every database category absent from the file before product synchronization. Deactivating a category cascades to all products in that category without filtering by product type. Products from unrelated product types therefore become inactive and disappear from the catalog.
+
+Catalog import uses soft deletion: records remain in the database with `is_active = false` so existing references remain intact and later imports can reactivate them.
+
+## Required Behavior
+
+- An import for product type A may create, update, reactivate, or deactivate only products belonging to product type A.
+- Products belonging to every other product type must retain their active state.
+- Categories present in the imported file are created or reactivated as needed.
+- Category cleanup runs only after products for the selected type have been synchronized.
+- A category absent from the imported file is deactivated only when it has no active products remaining across any product type.
+- A category shared with an active product from another product type remains active.
+- No products or categories are physically deleted by catalog import.
+
+## Design
+
+Split category synchronization into two responsibilities:
+
+1. Before product synchronization, create or reactivate categories present in the Excel file. Do not deactivate missing categories at this stage.
+2. Synchronize products for the selected product type. Deactivate only products of that type whose base model numbers are absent from the file.
+3. After product and variant synchronization, evaluate categories absent from the Excel file. Deactivate only categories with zero active products. Because no active products remain, the existing category-deactivation cascade cannot affect an active product from another type.
+
+The category repository will expose a focused active-product check, or the synchronization service will use an equivalent repository query. The synchronization service remains responsible for deciding when category cleanup is appropriate.
+
+## Error Handling and Transactions
+
+All synchronization phases remain inside the existing database transaction. Any failure rolls back product and category state together. Existing structured import errors and result counters remain unchanged, except category deactivation counts now reflect only categories that became empty.
+
+## Tests
+
+Add a service-level regression test that creates two product types and categories, then imports a catalog for the first type. It must prove:
+
+- a missing product of the imported type becomes inactive;
+- an active product of the other type remains active;
+- a category used by that other product remains active;
+- a missing category containing no active products becomes inactive;
+- no database records are physically deleted.
+
+Run the focused backend test first, then the complete backend test and lint commands.

--- a/docs/superpowers/specs/2026-07-12-show-inactive-catalog-design.md
+++ b/docs/superpowers/specs/2026-07-12-show-inactive-catalog-design.md
@@ -1,0 +1,28 @@
+# Show Inactive Catalog Records
+
+## Problem
+
+The frontend correctly sends `include_inactive=true` with an authorization token. The public product and variant GET routes do not run authentication middleware, so their Hono context never receives `userId` or `userRole`. Both routes therefore ignore the flag and return active records only.
+
+## Required Behavior
+
+- Public catalog requests without authentication continue to return active products and styles.
+- A valid administrator token allows `include_inactive=true` to return active and inactive products and styles.
+- Non-administrator and unauthenticated requests cannot expose inactive catalog records.
+- Existing API response formats and frontend controls remain unchanged.
+
+## Design
+
+Add an optional authentication middleware that reads a bearer token when supplied, verifies it, and populates the same context fields as the required authentication middleware. A missing or invalid token continues without identity, preserving public catalog access.
+
+Apply optional authentication to the product-list and item-variant-list routes. Honor `include_inactive=true` only when `userRole === 'admin'`, rather than merely checking for any authenticated user.
+
+## Tests
+
+Add route-level regression coverage proving:
+
+- public requests with `include_inactive=true` still omit inactive products and styles;
+- administrator requests with the flag include inactive products and styles;
+- database records remain unchanged by reads.
+
+Run the focused route tests, backend lint, and the complete backend test suite.

--- a/docs/superpowers/specs/2026-07-12-show-inactive-catalog-design.md
+++ b/docs/superpowers/specs/2026-07-12-show-inactive-catalog-design.md
@@ -9,6 +9,7 @@ The frontend correctly sends `include_inactive=true` with an authorization token
 - Public catalog requests without authentication continue to return active products and styles.
 - A valid administrator token allows `include_inactive=true` to return active and inactive products and styles.
 - Non-administrator and unauthenticated requests cannot expose inactive catalog records.
+- Inactive products shown to administrators retain a preview from their first style, even when every style is inactive.
 - Existing API response formats and frontend controls remain unchanged.
 
 ## Design
@@ -17,12 +18,15 @@ Add an optional authentication middleware that reads a bearer token when supplie
 
 Apply optional authentication to the product-list and item-variant-list routes. Honor `include_inactive=true` only when `userRole === 'admin'`, rather than merely checking for any authenticated user.
 
+When the item repository includes inactive records, its preview-image subquery may select the first inactive style image as a fallback. Active-only requests continue to select images from active styles only.
+
 ## Tests
 
 Add route-level regression coverage proving:
 
 - public requests with `include_inactive=true` still omit inactive products and styles;
 - administrator requests with the flag include inactive products and styles;
+- inactive products returned to administrators retain their stored preview image;
 - database records remain unchanged by reads.
 
 Run the focused route tests, backend lint, and the complete backend test suite.


### PR DESCRIPTION
## Summary
- scope catalog import deactivation to the selected product type
- only deactivate categories after they have no active products
- make Show inactive work for administrators while preserving public active-only reads
- retain preview images for inactive products
- add regression coverage for cross-type imports, authorization boundaries, and inactive previews

## Verification
- backend lint passes
- backend suite: 328 passed, 0 failed
- focused route and catalog-sync regression tests pass